### PR TITLE
Use courier version 2.0.2 + add coursera bintray repository.

### DIFF
--- a/project/NaptimeBuild.scala
+++ b/project/NaptimeBuild.scala
@@ -21,7 +21,7 @@ object NaptimeBuild extends Build with NamedDependencies with PluginVersionProvi
 
   def playVersion = "2.4.4" // Play version is defined here, and in project/plugins.sbt
   def akkaVersion = "2.3.13" // Akka version must match the one Play is built with.
-  def courierVersion = "2.0.1"
+  def courierVersion = "2.0.2"
 
   lazy val root = configure(project)
     .in(file("."))

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,9 @@
 // Use the Play sbt plugin for Play projects
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.4.4")
 
+// Add the coursera sbt plugin bintray repository for the courier-sbt-plugin until it gets mirrored
+// into the community sbt plugin repository.
+resolvers += Resolver.bintrayRepo("coursera", "sbt-plugins")
+
 // Courier binding generator plugin
-addSbtPlugin("org.coursera.courier" % "courier-sbt-plugin" % "2.0.1")
+addSbtPlugin("org.coursera.courier" % "courier-sbt-plugin" % "2.0.2")


### PR DESCRIPTION
The courier-sbt-plugin has not been published for 2.0.1. Instead, add the
courier sbt plugin via the coursera bintray repository.