### PR TITLE
Add attributes to Resources.

### DIFF
--- a/naptime/src/main/pegasus/org/coursera/naptime/schema/JsValue.courier
+++ b/naptime/src/main/pegasus/org/coursera/naptime/schema/JsValue.courier
@@ -5,6 +5,7 @@ namespace org.coursera.naptime.schema
  *
  * Note: this is entirely an escape hatch from the Schema type system. Use judiciously!
  */
+@passthroughExempt
 record JsValue {
   // Intentionally empty!
 }

--- a/naptime/src/main/pegasus/org/coursera/naptime/schema/Resource.courier
+++ b/naptime/src/main/pegasus/org/coursera/naptime/schema/Resource.courier
@@ -44,4 +44,9 @@ record Resource {
    * The fully qualified name of the class that implements this resource.
    */
   className: string
+
+  /**
+   * A list of attributes related to this resource.
+   */
+  attributes: array[Attribute]
 }

--- a/naptime/src/main/scala/org/coursera/naptime/router2/MacroImpls.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/router2/MacroImpls.scala
@@ -187,7 +187,8 @@ class MacroImpls(val c: blackbox.Context) {
             bodyType = ${bodyType(resourceType)},
             parentClass = $parentResourceName,
             handlers = List(..${trees.flatMap(_._2)}),
-            className = ${resourceType.toString})
+            className = ${resourceType.toString},
+            attributes = List.empty)
         }
         override def types = ${computeTypes(resourceType)}
       }


### PR DESCRIPTION
Documentation is represented as an attribute. This commit adds in the forgotten
field to the courier models.