### PR TITLE
Add sbt-header plugin to check for licenses

### DIFF
--- a/project/NaptimeBuild.scala
+++ b/project/NaptimeBuild.scala
@@ -16,6 +16,9 @@
 
 import sbt._
 import sbt.Keys
+import de.heikoseeberger.sbtheader.HeaderKey.headers
+import de.heikoseeberger.sbtheader.license.Apache2_0
+
 
 object NaptimeBuild extends Build with NamedDependencies with PluginVersionProvider {
 
@@ -54,11 +57,21 @@ object NaptimeBuild extends Build with NamedDependencies with PluginVersionProvi
     Keys.testFrameworks := Seq(sbt.TestFrameworks.JUnit),
     Keys.testOptions += Tests.Argument(TestFrameworks.JUnit, "-v", "-q", "-a"))
 
+  lazy val headerSettings = Seq(
+    headers := Map(
+      "scala" -> Apache2_0("2016", "Coursera Inc."),
+      "conf" -> Apache2_0("2016", "Coursera Inc.", "#"),
+      "courier" -> Apache2_0("2016", "Coursera Inc.")
+    )
+  )
+
+
   private[this] def configure(project: Project): Project = {
     project
       .enablePlugins(play.sbt.PlayScala)
       .disablePlugins(play.sbt.PlayLayoutPlugin)
       .settings(testSettings)
+      .settings(headerSettings)
       .settings(org.coursera.naptime.sbt.Sonatype.settings)
   }
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -16,3 +16,6 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.3.1")
 
 libraryDependencies += { "org.scala-sbt" % "scripted-plugin" % sbtVersion.value }
+
+// addSbtPlugin("de.heikoseeberger" % "sbt-header" % "1.5.1")
+addSbtPlugin("de.heikoseeberger" % "sbt-header" % "1.5.1-2-g8b57b53")


### PR DESCRIPTION
I've added the sbt-header plugin to ensure licenses are atop all files. Note,
however, that it doesn't correctly add headers to *.sbt files, *.courier files,
or files inside sbt-test directories. There are open tickets on sbt-header for
this, so we will wait and see.