### PR TITLE
Fix `test` in `root` project.

### DIFF
--- a/project/NaptimeBuild.scala
+++ b/project/NaptimeBuild.scala
@@ -23,7 +23,7 @@ object NaptimeBuild extends Build with NamedDependencies with PluginVersionProvi
   def akkaVersion = "2.3.13" // Akka version must match the one Play is built with.
   def courierVersion = "2.0.2"
 
-  lazy val root = configure(project)
+  lazy val root = project
     .in(file("."))
     .aggregate(naptime, models, testing, pegasus)
 


### PR DESCRIPTION
Whenever running the `test` command in the `root` sbt project, it would run all
the tests, but then hang forever in the interactive console. This commit removes
the unnecessary configuration call. Now, you can run `test` in the root project,
and you won't have to kill your sbt shell afterwards. :-)