### PR TITLE
Configure bintray publishing for sbt plugin.

### DIFF
--- a/naptime-sbt-plugin/build.sbt
+++ b/naptime-sbt-plugin/build.sbt
@@ -21,3 +21,13 @@ buildInfoPackage := "sbtbuildinfo"
 
 // Use the Play sbt plugin for Play projects
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.4.4")
+
+licenses += ("Apache-2", url("https://opensource.org/licenses/Apache-2.0"))
+
+description := "API Framework for developer productivity. http://coursera.github.io/naptime/"
+
+publishMavenStyle := false
+
+bintrayRepository := "sbt-plugins"
+
+bintrayOrganization := Some("coursera")

--- a/project/NaptimeBuild.scala
+++ b/project/NaptimeBuild.scala
@@ -25,7 +25,9 @@ object NaptimeBuild extends Build with NamedDependencies with PluginVersionProvi
 
   lazy val root = project
     .in(file("."))
+    .settings(org.coursera.naptime.sbt.Sonatype.settings)
     .aggregate(naptime, models, testing, pegasus)
+    .disablePlugins(bintray.BintrayPlugin)
 
   lazy val naptime = configure(project)
     .in(file("naptime"))
@@ -48,7 +50,7 @@ object NaptimeBuild extends Build with NamedDependencies with PluginVersionProvi
 
   lazy val plugin = project
     .in(file("naptime-sbt-plugin"))
-    .settings(org.coursera.naptime.sbt.Sonatype.settings)
+    .disablePlugins(xerial.sbt.Sonatype)
 
   lazy val testSettings = Seq(
     Keys.testFrameworks := Seq(sbt.TestFrameworks.JUnit),
@@ -60,6 +62,7 @@ object NaptimeBuild extends Build with NamedDependencies with PluginVersionProvi
       .disablePlugins(play.sbt.PlayLayoutPlugin)
       .settings(testSettings)
       .settings(org.coursera.naptime.sbt.Sonatype.settings)
+      .disablePlugins(bintray.BintrayPlugin)
   }
 
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,6 +10,8 @@ addSbtPlugin("org.coursera.courier" % "courier-sbt-plugin" % "2.0.2")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
 
+addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
+
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 
 // Add build information for the Scaladoc plugin.


### PR DESCRIPTION
This commit adds all the configuration & publishes the sbt-naptime plugin
to bintray. It has been marked for inclusion in the standard sbt plugins
bintray distribution, but is not available yet. If you would like to depend
on it presently, add the following to `project/plugins.sbt`:

```
resolvers += Resolver.bintrayIvyRepo("coursera", "sbt-plugins")
```

This commit also fixes a publishing problem in the maven central publishing workflow.
