### PR TITLE
Remove unused bintray repository.

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,10 +1,6 @@
 // Use the Play sbt plugin for Play projects
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.4.4")
 
-// Add the coursera sbt plugin bintray repository for the courier-sbt-plugin until it gets mirrored
-// into the community sbt plugin repository.
-resolvers += Resolver.bintrayRepo("coursera", "sbt-plugins")
-
 // Courier binding generator plugin
 addSbtPlugin("org.coursera.courier" % "courier-sbt-plugin" % "2.0.2")
 


### PR DESCRIPTION
The courier sbt plugin is now mirrored in the standard sbt plugin bintray
distribution, so we can remove our own resolver.

Note: in this commit, we comment out the travis-ci caching, in order to
properly test that this change is safe.