### PR TITLE
Add withFallbackReads to KeyFormat

### DIFF
--- a/naptime-models/src/main/scala/org/coursera/naptime/model/KeyFormat.scala
+++ b/naptime-models/src/main/scala/org/coursera/naptime/model/KeyFormat.scala
@@ -145,6 +145,28 @@ object KeyFormat extends PrimitiveFormats {
 
   }
 
+  /**
+   * Augment [[K]]'s format with an additional fallback JsReads implementation.
+   *
+   * @param altReads An alternate JsValue to [[K]] Reads implementation.
+   * @param keyFormat The standard KeyFormat to augment.
+   * @tparam K The key type.
+   * @return The augmented KeyFormat.
+   */
+  def withFallbackReads[K](altReads: Reads[K])(keyFormat: KeyFormat[K]): KeyFormat[K] = {
+    new KeyFormat[K] {
+
+      override implicit def stringKeyFormat: StringKeyFormat[K] = keyFormat.stringKeyFormat
+
+      override implicit def format: OFormat[K] = keyFormat.format
+
+      override def reads(json: JsValue): JsResult[K] = {
+        keyFormat.reads(json).orElse(altReads.reads(json))
+      }
+
+      override def writes(o: K): JsValue = keyFormat.writes(o)
+    }
+  }
 }
 
 /**

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.0.4"
+version in ThisBuild := "0.0.5"


### PR DESCRIPTION
When migrating KeyFormats it's very helpful to be able to maintain the ability
to read the old key format, while simultaneously reading & writing the new
format.