### PR TITLE
Add testing capabilities to HeaderAccessControl

### DIFF
--- a/naptime/src/main/scala/org/coursera/naptime/access/HeaderAccessControl.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/access/HeaderAccessControl.scala
@@ -49,6 +49,10 @@ trait HeaderAccessControl[A] {
       requestHeader: RequestHeader)
       (implicit executionContext: ExecutionContext): Future[Either[NaptimeActionException, A]]
 
+  /**
+   * Used for testing access control configurations in Naptime tests.
+   */
+  private[naptime] def check(authInfo: A): Either[NaptimeActionException, A]
 }
 
 object HeaderAccessControl extends AnyOf with And with EitherOf {

--- a/naptime/src/main/scala/org/coursera/naptime/access/StructuredAccessControl.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/access/StructuredAccessControl.scala
@@ -18,6 +18,7 @@ package org.coursera.naptime.access
 
 import org.coursera.naptime.NaptimeActionException
 import org.coursera.naptime.access.authenticator.Authenticator
+import org.coursera.naptime.access.authorizer.AuthorizeResult
 import org.coursera.naptime.access.authorizer.Authorizer
 import play.api.http.Status
 import play.api.mvc.RequestHeader
@@ -47,6 +48,10 @@ case class StructuredAccessControl[A](
         StructuredAccessControl.missingResponse
       }
     }
+  }
+
+  override private[naptime] def check(authInfo: A): Either[NaptimeActionException, A] = {
+    Authorizer.toResponse(authorizer.authorize(authInfo), authInfo)
   }
 }
 

--- a/naptime/src/main/scala/org/coursera/naptime/access/combiner/And.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/access/combiner/And.scala
@@ -56,6 +56,13 @@ private[access] trait And {
           }
         }
       }
+      override private[naptime] def check(authInfo: (A, B)): Either[NaptimeActionException, (A, B)] = {
+        (controlA.check(authInfo._1), controlB.check(authInfo._2)) match {
+          case (Right(resultA), Right(resultB)) => Right((resultA, resultB))
+          case (Left(err), _) => Left(err)
+          case (_, Left(err)) => Left(err)
+        }
+      }
     }
   }
 
@@ -89,7 +96,15 @@ private[access] trait And {
           }
         }
       }
+
+      override private[naptime] def check(authInfo: (A, B, C)): Either[NaptimeActionException, (A, B, C)] = {
+        (controlA.check(authInfo._1), controlB.check(authInfo._2), controlC.check(authInfo._3)) match {
+          case (Right(a), Right(b), Right(c)) => Right((a, b, c))
+          case (Left(err), _, _) => Left(err)
+          case (_, Left(err), _) => Left(err)
+          case (_, _, Left(err)) => Left(err)
+        }
+      }
     }
   }
-
 }

--- a/naptime/src/main/scala/org/coursera/naptime/access/combiner/EitherOf.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/access/combiner/EitherOf.scala
@@ -59,6 +59,16 @@ private[access] trait EitherOf {
           }
         }
       }
+
+      override private[naptime] def check(
+          authInfo: Either[A, B]): Either[NaptimeActionException, Either[A, B]] = {
+        authInfo match {
+          case Left(authA) =>
+            controlA.check(authA).right.map(Left.apply)
+          case Right(authB) =>
+            controlB.check(authB).right.map(Right.apply)
+        }
+      }
     }
   }
 

--- a/naptime/src/main/scala/org/coursera/naptime/models.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/models.scala
@@ -74,6 +74,10 @@ class RestContext[+AuthType, +BodyType] private[naptime] (
 
     findPreferredLanguage(acceptLanguages)
   }
+
+  private[naptime] def copyWithAuth[NewAuth](newAuth: NewAuth): RestContext[NewAuth, BodyType] = {
+    new RestContext(body, newAuth, _request, paging, includes, fields)
+  }
 }
 
 /**

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.0.7"
+version in ThisBuild := "0.0.8"


### PR DESCRIPTION
When testing Naptime endpoints, it's often a good idea to test the access
control mechanisms as well. Because Naptime tests operate at a higher level,
it doesn't make sense to include the parsing & decorating. It does, however,
make sense to run the Authorizors.

In order to do this while simultaneously supporting the combinators, we add a
new method to `HeaderAccessControl` called `check` that will run the Authorizer.
The type signature of `check` is a little funny in order to support the behavior
of some of the more sophisticated combinators (i.e. `anyOf`) which must support
filtering of the parsed values.