### PR TITLE
Treat None.type specially

### DIFF
--- a/naptime-models/src/main/scala/org/coursera/naptime/courier/SchemaInference.scala
+++ b/naptime-models/src/main/scala/org/coursera/naptime/courier/SchemaInference.scala
@@ -115,9 +115,15 @@ private[courier] class ScalaClassTraverser(rootType: ru.Type) {
     } else if (typ <:< ru.typeOf[scala.Enumeration#Value]) {
       inferEnum(typ)
     } else if (typ <:< ru.typeOf[Option[_]]) {
-      val optionalType = typ.asInstanceOf[ru.TypeRefApi].args.head
-      val inferred = inferSchema(optionalType)
-      InferredSchema(inferred.schema, isOptional = true)
+      if (typ <:< ru.typeOf[None.type]) {
+        InferredSchema(Json.obj(
+          "name" -> typeName,
+          "type" -> "null"))
+      } else {
+        val optionalType = typ.asInstanceOf[ru.TypeRefApi].args.head
+        val inferred = inferSchema(optionalType)
+        InferredSchema(inferred.schema, isOptional = true)
+      }
     } else if (typ <:< ru.typeOf[Map[_, _]]) {
       inferMap(typ)
     } else if (typ <:< ru.typeOf[Traversable[_]] || typ <:< ru.typeOf[Array[_]]) {

--- a/naptime-models/src/main/scala/org/coursera/naptime/courier/SchemaInference.scala
+++ b/naptime-models/src/main/scala/org/coursera/naptime/courier/SchemaInference.scala
@@ -116,13 +116,11 @@ private[courier] class ScalaClassTraverser(rootType: ru.Type) {
       inferEnum(typ)
     } else if (typ <:< ru.typeOf[Option[_]]) {
       if (typ <:< ru.typeOf[None.type]) {
-        InferredSchema(Json.obj(
-          "name" -> typeName,
-          "type" -> "null"))
+        InferredSchema(JsString("null"))
       } else {
         val optionalType = typ.asInstanceOf[ru.TypeRefApi].args.head
         val inferred = inferSchema(optionalType)
-        InferredSchema(inferred.schema, isOptional = true)
+        InferredSchema(inferred.schema, isOptional = !(typ <:< ru.typeOf[Some[_]]))
       }
     } else if (typ <:< ru.typeOf[Map[_, _]]) {
       inferMap(typ)

--- a/naptime-models/src/test/scala/org/coursera/naptime/courier/SchemaInferenceTest.scala
+++ b/naptime-models/src/test/scala/org/coursera/naptime/courier/SchemaInferenceTest.scala
@@ -56,6 +56,36 @@ class SchemaInferenceTest extends AssertionsForJUnit {
   }
 
   @Test
+  def testWithNone(): Unit = {
+    assert(inferSchema[WithNone] ===
+      Json.parse(
+        """{
+          |  "name": "WithNone",
+          |  "namespace": "org.coursera.naptime.courier",
+          |  "type": "record",
+          |  "fields": [
+          |    {"name": "none", "type": "null"}
+          |  ]
+          |}
+          |""".stripMargin))
+  }
+
+  @Test
+  def testWithSome(): Unit = {
+    assert(inferSchema[WithSome] ===
+      Json.parse(
+        """{
+          |  "name": "WithSome",
+          |  "namespace": "org.coursera.naptime.courier",
+          |  "type": "record",
+          |  "fields": [
+          |    {"name": "int", "type": "int"}
+          |  ]
+          |}
+          |""".stripMargin))
+  }
+
+  @Test
   def testWithRecord(): Unit = {
     assert(inferSchema[WithRecord] ===
       Json.parse(
@@ -192,6 +222,8 @@ class SchemaInferenceTest extends AssertionsForJUnit {
 
 case class WithPrimitives(int: Int)
 case class WithOptional(int: Option[Int])
+case class WithSome(int: Some[Int])
+case class WithNone(none: None.type)
 
 case class Simple(message: String)
 case class WithRecord(record: Simple)


### PR DESCRIPTION
Previously, `SchemaInference.inferSchema` would break on schemas that included `None.type`. This change handles `None.type` correctly. 

When evaluating the following code:
```
import org.coursera.naptime.courier.SchemaInference
import scala.reflect.runtime.universe

case class WithNone(nothing: None.type)
SchemaInference.inferSchema(universe.typeOf[WithNone])
```
Before:
```
java.lang.ClassCastException: scala.reflect.internal.Types$UniqueSingleType cannot be cast to scala.reflect.api.Types$TypeRefApi
  at org.coursera.naptime.courier.ScalaClassTraverser.org$coursera$naptime$courier$ScalaClassTraverser$$inferSchema(SchemaInference.scala:118)
```

After:
```
res0: play.api.libs.json.JsObject = {"name":"WithNone","type":"record","fields":[{"name":"nothing","type":"null"}],"namespace":"$line5"}
```

Additionally, we change the schema for `Some[A]` to be identical to the schema of `A`.