### PR TITLE
Migrate over internal model tests to OSS

### DIFF
--- a/naptime/src/test/scala/org/coursera/naptime/FieldsTest.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/FieldsTest.scala
@@ -1,0 +1,106 @@
+package org.coursera.naptime
+
+import org.junit.Test
+import org.scalatest.junit.AssertionsForJUnit
+import play.api.libs.json.Json
+import play.api.test.FakeRequest
+
+import scala.util.Success
+
+case class FieldsTestModel(a: String, b: Int, c: String)
+object FieldsTestModel {
+  implicit val format = Json.format[FieldsTestModel]
+}
+
+class FieldsTest extends AssertionsForJUnit {
+
+  val sampleFields = Fields[FieldsTestModel].withDefaultFields("a").withRelated(
+    "author" -> ResourceName("user", 6))
+
+  @Test
+  def simpleComputeFields(): Unit = {
+    testSuccess("/foo/bar?fields=c", QueryFields(Set("a", "c"), Map.empty))
+  }
+
+  @Test
+  def testMissing(): Unit = {
+    testSuccess("/foo/bar", QueryFields(Set("a"), Map.empty))
+  }
+
+  @Test
+  def testNestedResources(): Unit = {
+    testSuccess("/foo/bar?fields=foo.v1(z)", QueryFields(Set("a"), Map(ResourceName("foo", 1) -> Set("z"))))
+  }
+
+  @Test
+  def testNegatedResources(): Unit = {
+    testSuccess("/foo/bar?fields=-a,b,c", QueryFields(Set("b", "c"), Map.empty))
+  }
+
+  @Test
+  def testEmpty(): Unit = {
+    testSuccess("/foo/bar?fields=", QueryFields(Set("a"), Map.empty))
+  }
+
+  @Test
+  def handleImproperlyFormedRequest(): Unit = {
+    testFailure("/foo/bar?fields=,a")
+  }
+
+  @Test
+  def handleImproperlyFormedRequest2(): Unit = {
+    testFailure("/foo/bar?fields=a.vb(a,b)")
+  }
+
+  @Test
+  def headerFieldsOverride(): Unit = {
+    val request = FakeRequest("GET", "/foo/bar").withHeaders(Fields.FIELDS_HEADER -> "ALL")
+    val parsed = sampleFields.computeFields(request)
+
+    assert(parsed === Success(AllFields))
+  }
+
+  private[this] def testSuccess(path: String, fields: QueryFields): Unit = {
+    val request = FakeRequest("GET", path)
+    val parsed = sampleFields.computeFields(request)
+    assert(parsed === Success(fields))
+  }
+
+  private[this] def testFailure(path: String): Unit = {
+    val request = FakeRequest("GET", path)
+    val parsed = sampleFields.computeFields(request)
+    assert(parsed.isFailure)
+  }
+
+  @Test
+  def testSimpleRelated(): Unit = {
+    assert(sampleFields.makeMetaRelationsMap(Set("author")) === Json.obj("author" -> "user.v6"))
+  }
+
+  @Test
+  def multiRelated(): Unit = {
+    val related = sampleFields
+      .withRelated("comments" -> ResourceName("qaComments", 1, List("history")))
+      .withRelated("relatedItem" -> ResourceName("relations", 203))
+    assert(related.makeMetaRelationsMap(Set("author", "comments")) ===
+      Json.obj("author" -> "user.v6", "comments" -> "qaComments.v1/history"))
+  }
+
+  @Test
+  def repeatedFieldsInvalid(): Unit = {
+    intercept[IllegalArgumentException] {
+      Fields[FieldsTestModel]
+        .withDefaultFields("a")
+        .withDefaultFields("a")
+    }
+  }
+
+  @Test
+  def repeatedRelationsInvalid(): Unit = {
+    intercept[IllegalArgumentException] {
+      Fields[FieldsTestModel]
+        .withRelated("author" -> ResourceName("user", 6))
+        .withRelated("author" -> ResourceName("user", 1))
+    }
+  }
+}

--- a/naptime/src/test/scala/org/coursera/naptime/JsonUtilitiesTest.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/JsonUtilitiesTest.scala
@@ -1,0 +1,141 @@
+package org.coursera.naptime
+
+import org.coursera.naptime.model.KeyFormat
+import org.coursera.naptime.model.Keyed
+import org.junit._
+import org.scalatest.junit.AssertionsForJUnit
+import play.api.libs.json.Json
+
+case class TestResource(name: String, description: String, author: Int)
+
+object TestResource {
+  implicit val format = Json.format[TestResource]
+
+  def mk(id: Int): Keyed[Int, TestResource] = {
+    Keyed(id, apply(s"TestResource$id", s"A test resource $id", id + 10))
+  }
+}
+
+case class FakeUser(name: String, profile: String, almaMater: Int)
+
+object FakeUser {
+  implicit val format = Json.format[FakeUser]
+}
+
+case class University(name: String)
+
+object University {
+  implicit val format = Json.format[University]
+}
+
+class JsonUtilitiesTest extends AssertionsForJUnit {
+  val obj = Json.obj("id" -> 123, "name" -> "hogwarts", "location" -> "platform 9 3/4")
+  val fields = QueryFields(Set("id", "name"), Map.empty)
+
+  @Test
+  def simpleFilter() {
+    val filtered = JsonUtilities.filterJsonFields(obj, fields)
+    assert(filtered.fields.size === 2)
+    assert(filtered.fields.map(_._1) === Seq("id", "name"))
+  }
+
+  @Test
+  def ignoreUnknownNames() {
+    val filtered = JsonUtilities.filterJsonFields(obj, QueryFields(Set("id", "foo"), Map.empty))
+    assert(filtered.fields.size === 1)
+    assert(filtered.fields.map(_._1) === Seq("id"))
+  }
+
+  @Test
+  def outputsObjects() {
+    val objs = (0 to 2).map(TestResource.mk).toSeq
+    val jsonified = JsonUtilities.outputSeq(objs, QueryFields(Set("id"), Map.empty))
+    assert("""[{"id":0},{"id":1},{"id":2}]""" === Json.stringify(Json.toJson(jsonified)))
+  }
+
+  @Test
+  def metaLinksSimple(): Unit = {
+    val fields = Fields[TestResource].withRelated("author" -> ResourceName("user", 1))
+    val meta = JsonUtilities.formatLinksMeta(QueryIncludes(Set("author"), Map.empty),
+      QueryFields.empty, fields, Ok(()))
+    assert(meta === Json.obj("elements" -> Json.obj("author" -> "user.v1")))
+  }
+
+  @Test
+  def metaLinksRecursed(): Unit = {
+    val fields = Fields[TestResource].withRelated("author" -> ResourceName("user", 1))
+    val userFields = Fields[FakeUser].withRelated("almaMater" -> ResourceName("university", 3))
+    val result = Ok(()).withRelated(ResourceName("user", 1), Seq.empty[Keyed[Int, FakeUser]])(
+      FakeUser.format, KeyFormat.intKeyFormat, userFields)
+    val meta = JsonUtilities.formatLinksMeta(
+      QueryIncludes(Set("author"), Map(ResourceName("user", 1) -> Set("almaMater"))),
+      QueryFields(Set("author"), Map(ResourceName("user", 1) -> Set("almaMater"))),
+      fields, result)
+    val expected = Json.obj(
+      "elements" -> Json.obj("author" -> "user.v1"),
+      "user.v1" -> Json.obj("almaMater" -> "university.v3")
+    )
+    assert(meta === expected)
+  }
+
+  @Test
+  def formatIncludes(): Unit = {
+    val fields = Fields[TestResource].withRelated("author" -> ResourceName("user", 1))
+    val userFields = Fields[FakeUser].withDefaultFields("name")
+    val queryIncludes = QueryIncludes(Set("author"), Map.empty)
+
+    val fakeUser = FakeUser("bob", "good", 1)
+    val ok = Ok(()).withRelated(ResourceName("user", 1), List(Keyed(1, fakeUser)))(
+      FakeUser.format, KeyFormat.intKeyFormat, userFields)
+
+    val includesResult = JsonUtilities.formatIncludes(ok, QueryFields.empty, queryIncludes, fields)
+
+    val expected = Some(Json.obj(
+      "user.v1" -> Json.arr(
+        Json.obj("id" -> 1, "name" -> "bob")
+      )))
+    assert(expected === includesResult)
+  }
+
+  @Test
+  def formatTransitiveIncludes(): Unit = {
+    val userResource = ResourceName("user", 1)
+    val universityResource = ResourceName("universities", 1)
+    implicit val fields = Fields[TestResource].withRelated("author" -> userResource)
+    implicit val userFields = Fields[FakeUser].withDefaultFields("name").withRelated(
+      "almaMater" -> universityResource)
+    implicit val uniFields = Fields[University].withDefaultFields("name")
+    val queryIncludes = QueryIncludes(Set("author"), Map(userResource -> Set("almaMater")))
+
+    val ok = Ok(())
+      .withRelated(userResource, List(Keyed(1, FakeUser("bob", "good", 5))))
+      .withRelated(universityResource, List(Keyed(5, University("ecole polytechnique"))))
+
+    val includesResult = JsonUtilities.formatIncludes(ok, QueryFields.empty, queryIncludes, fields)
+
+    val expected = Some(Json.obj(
+      "user.v1" -> Json.arr(
+        Json.obj("id" -> 1, "name" -> "bob")),
+      "universities.v1" -> Json.arr(
+        Json.obj("name" -> "ecole polytechnique", "id" -> 5))))
+    assert(expected === includesResult)
+  }
+
+  @Test
+  def formatIncludesNotRequested(): Unit = {
+    val fields = Fields[TestResource].withRelated("author" -> ResourceName("user", 1))
+    val userFields = Fields[FakeUser].withDefaultFields("name")
+    val queryIncludes = QueryIncludes(Set("nonexistent"), Map.empty)
+
+    val fakeUser = FakeUser("bob", "good", 1)
+    val ok = Ok(()).withRelated(ResourceName("user", 1), List(Keyed(1, fakeUser)))(
+      FakeUser.format, KeyFormat.intKeyFormat, userFields)
+
+    val includesResult = JsonUtilities.formatIncludes(ok, QueryFields.empty, queryIncludes, fields)
+
+    val expected = Some(Json.obj())
+
+    assert(expected === includesResult)
+  }
+
+}

--- a/naptime/src/test/scala/org/coursera/naptime/ResourceNameTest.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/ResourceNameTest.scala
@@ -1,0 +1,39 @@
+package org.coursera.naptime
+
+import org.junit.Test
+import org.scalatest.junit.AssertionsForJUnit
+
+class ResourceNameTest extends AssertionsForJUnit {
+
+  @Test
+  def simpleResourceNameIdentifier(): Unit = {
+    assert(ResourceName("foo", 1).identifier === "foo.v1")
+  }
+
+  @Test
+  def nestedResourceNameIdentifier(): Unit = {
+    assert(ResourceName("fooBar", 1, List("history")).identifier === "fooBar.v1/history")
+  }
+
+  @Test
+  def deeplyNestedResourceNameIdenfier(): Unit = {
+    assert(ResourceName("fooBarBaz", 103, List("history", "author")).identifier ===
+      "fooBarBaz.v103/history/author")
+  }
+
+  @Test
+  def parseSimple(): Unit = {
+    assert(ResourceName("foo", 1) === ResourceName.parse("foo.v1").get)
+  }
+
+  @Test
+  def parseNested(): Unit = {
+    assert(ResourceName("fooBar", 2, List("sub")) === ResourceName.parse("fooBar.v2/sub").get)
+  }
+
+  @Test
+  def parseDeeplyNested(): Unit = {
+    assert(ResourceName("fooBar", 3, List("sub", "superSub")) ===
+      ResourceName.parse("fooBar.v3/sub/superSub").get)
+  }
+}

--- a/naptime/src/test/scala/org/coursera/naptime/RestContextTest.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/RestContextTest.scala
@@ -1,0 +1,54 @@
+package org.coursera.naptime
+
+import org.junit.Test
+import play.api.i18n.Lang
+import play.api.mvc.Request
+import org.mockito.Mockito.when
+import org.scalatest.junit.AssertionsForJUnit
+import org.scalatest.mock.MockitoSugar
+
+class RestContextTest extends AssertionsForJUnit with MockitoSugar {
+
+  private[this] def makeContext(languagePreferences: Seq[Lang]): RestContext[Unit, Unit] = {
+    val mockRequest = mock[Request[Unit]]
+    val restContext = new RestContext((), (), mockRequest, null, null, null)
+    when(mockRequest.acceptLanguages).thenReturn(languagePreferences)
+    restContext
+  }
+
+  def test(
+      requestLanguages: Seq[Lang],
+      availableLanguages: Set[Lang],
+      defaultLanguage: Lang,
+      expected: Lang): Unit = {
+    val restContext = makeContext(requestLanguages)
+    assert(restContext.selectLanguage(availableLanguages, defaultLanguage) === expected)
+  }
+
+  @Test
+  def basicLanguage(): Unit = {
+    test(
+      requestLanguages = Seq(Lang("en")),
+      availableLanguages = Set(Lang("fr"), Lang("en")),
+      defaultLanguage = Lang("en"),
+      expected = Lang("en"))
+  }
+
+  @Test
+  def defaultFallback(): Unit = {
+    test(
+      requestLanguages = Seq(Lang("zh")),
+      availableLanguages = Set(Lang("fr"), Lang("en")),
+      defaultLanguage = Lang("en"),
+      expected = Lang("en"))
+  }
+
+  @Test
+  def choosePreferred(): Unit = {
+    test(
+      requestLanguages = Seq(Lang("zh"), Lang("fr"), Lang("en")),
+      availableLanguages = Set(Lang("fr"), Lang("en")),
+      defaultLanguage = Lang("en"),
+      expected = Lang("fr"))
+  }
+}


### PR DESCRIPTION
As part of removing the internal copy of naptime from Coursera's source tree,
I discovered these tests had gotten forgotten.