### PR TITLE
Change asymmetric type computation log message from error to warning

### DIFF
--- a/naptime/src/main/scala/org/coursera/naptime/Types.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/Types.scala
@@ -84,7 +84,7 @@ object Types extends StrictLogging {
     val fields = idField :: fieldsMinusId
     recordDataSchema.setFields(fields.asJava, errorMessageBuilder)
     if (errorMessageBuilder.length() > 0) {
-      logger.warning(s"Error while computing asymmetric type $typeName: $errorMessageBuilder")
+      logger.warn(s"Error while computing asymmetric type $typeName: $errorMessageBuilder")
     }
     recordDataSchema
   }
@@ -112,7 +112,7 @@ object Types extends StrictLogging {
     val fields = idField :: valueType.getFields().asScala.toList
     recordDataSchema.setFields(fields.asJava, errorMessageBuilder)
     if (errorMessageBuilder.length() > 0) {
-      logger.warning(s"Error while computing asymmetric type $typeName: $errorMessageBuilder")
+      logger.warn(s"Error while computing asymmetric type $typeName: $errorMessageBuilder")
     }
     recordDataSchema
   }

--- a/naptime/src/main/scala/org/coursera/naptime/Types.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/Types.scala
@@ -84,7 +84,7 @@ object Types extends StrictLogging {
     val fields = idField :: fieldsMinusId
     recordDataSchema.setFields(fields.asJava, errorMessageBuilder)
     if (errorMessageBuilder.length() > 0) {
-      logger.error(s"Error while computing asymmetric type $typeName: $errorMessageBuilder")
+      logger.warning(s"Error while computing asymmetric type $typeName: $errorMessageBuilder")
     }
     recordDataSchema
   }
@@ -112,7 +112,7 @@ object Types extends StrictLogging {
     val fields = idField :: valueType.getFields().asScala.toList
     recordDataSchema.setFields(fields.asJava, errorMessageBuilder)
     if (errorMessageBuilder.length() > 0) {
-      logger.error(s"Error while computing asymmetric type $typeName: $errorMessageBuilder")
+      logger.warning(s"Error while computing asymmetric type $typeName: $errorMessageBuilder")
     }
     recordDataSchema
   }


### PR DESCRIPTION
Since the these methods still return valid values even if errors occurred, errors should be logged as warnings rather than errors.