### PR TITLE
Streamline helpers & migrate more test

### DIFF
--- a/naptime-testing/src/test/scala/org/coursera/naptime/NestedMacroTests.scala
+++ b/naptime-testing/src/test/scala/org/coursera/naptime/NestedMacroTests.scala
@@ -51,33 +51,9 @@ import scala.collection.JavaConversions._
  * The top level resource in our fledgling social network.
  */
 class PersonResource
-  extends TopLevelCollectionResource[String, Person]
-  with FieldsBuilder[Person] {
+  extends TopLevelCollectionResource[String, Person] {
 
   val PATH_KEY: PathKey = ("myPathKeyId" ::: RootParsedPathKey).asInstanceOf[PathKey]
-
-  /**
-   * Helper to easily construct Rest actions.
-   *
-   * Typically, all actions in a naptime resource will all use the same auth parser and policy, or
-   * will want to use the same error handling function for all requests. These resources should do
-   * something similar to the following:
-   *
-   * {{{
-   *   class MyResource extends RestActionHelpers[Foo, Bar] {
-   *     def RRest[RACType, ResponseType] =
-   *       Rest[RACType, ResponseType].auth(myAuthPolicy).catching(errorFn)
-   *
-   *   ...
-   *   }
-   *
-   * }}}
-   */
-  def Rest[RACType, ResponseType]()
-    (implicit keyFormat: KeyFormat[String],
-      resourceFormat: OFormat[Person]) =
-    new RestActionBuilder[RACType, Unit, AnyContent, String, Person, ResponseType](
-      HeaderAccessControl.allowAll, BodyParsers.parse.anyContent, PartialFunction.empty)
 
   override def keyFormat: KeyFormat[String] = KeyFormat.stringKeyFormat
 
@@ -93,40 +69,40 @@ class PersonResource
     Keyed("3", Person("fred")),
     Keyed("4", Person("bill")))
 
-  def getAll = Rest.getAll { implicit ctx =>
+  def getAll = Nap.getAll { implicit ctx =>
     Ok(allItems)
   }
 
-  def get(id: PathKey) = Rest.get { ctx =>
+  def get(id: PathKey) = Nap.get { ctx =>
     Ok(allItems.head)
   }
 
-  def multiGet(ids: Set[String]) = Rest.multiGet { ctx =>
+  def multiGet(ids: Set[String]) = Nap.multiGet { ctx =>
     Ok(allItems.filter(item => ids.contains(item.key)))
   }
 
-  def update(id: String, message: Option[String]) = Rest.update(ctx => ???)
+  def update(id: String, message: Option[String]) = Nap.update(ctx => ???)
 
   // Required argument with default allowed.
-  def delete(id: KeyType, message: String = "Something?") = Rest.delete(ctx => ???)
+  def delete(id: KeyType, message: String = "Something?") = Nap.delete(ctx => ???)
 
-  def create = Rest.create(ctx => ???)
+  def create = Nap.create(ctx => ???)
 
-  def byEmail(email: String) = Rest.finder(ctx => ???)
+  def byEmail(email: String) = Nap.finder(ctx => ???)
 
-  def byUsernameAndDomain(userName: String, domain: String) = Rest.finder(ctx => ???)
+  def byUsernameAndDomain(userName: String, domain: String) = Nap.finder(ctx => ???)
 
-  def byUsernameSorted(userName: String, sort: SortOrder) = Rest.finder(ctx => ???)
+  def byUsernameSorted(userName: String, sort: SortOrder) = Nap.finder(ctx => ???)
 
   def complex(complex: ComplexEmailType, extra: Option[String], skipCache: Boolean) =
-    Rest.finder(ctx => ???)
+    Nap.finder(ctx => ???)
 
   def complexWithDefault(complex: ComplexEmailType = ComplexEmailType("daphne", "coursera.org")) =
-    Rest.finder(ctx => ???)
+    Nap.finder(ctx => ???)
 
-  def batchModify(someParam: Option[ComplexEmailType]) = Rest.action(ctx => ???)
+  def batchModify(someParam: Option[ComplexEmailType]) = Nap.action(ctx => ???)
 
-  def parameterless() = Rest.action(ctx => ???)
+  def parameterless() = Nap.action(ctx => ???)
 }
 
 object PersonResource {
@@ -142,8 +118,7 @@ object FriendshipInfo {
 }
 
 class FriendsResource(val parentResource: PersonResource)
-  extends CollectionResource[PersonResource, String, FriendshipInfo]
-  with FieldsBuilder[FriendshipInfo] {
+  extends CollectionResource[PersonResource, String, FriendshipInfo] {
   override def keyFormat: KeyFormat[KeyType] = KeyFormat.stringKeyFormat
 
   override implicit def resourceFormat: OFormat[FriendshipInfo] = FriendshipInfo.jsonFormat
@@ -157,61 +132,37 @@ class FriendsResource(val parentResource: PersonResource)
   val PATH_KEY: PathKey = ("friendId" ::: ANCESTOR_KEY).asInstanceOf[PathKey]
   val OPT_PATH_KEY: OptPathKey = (None ::: ANCESTOR_KEY).asInstanceOf[OptPathKey]
 
-  /**
-   * Helper to easily construct Rest actions.
-   *
-   * Typically, all actions in a naptime resource will all use the same auth parser and policy, or
-   * will want to use the same error handling function for all requests. These resources should do
-   * something similar to the following:
-   *
-   * {{{
-   *   class MyResource extends RestActionHelpers[Foo, Bar] {
-   *     def RRest[RACType, ResponseType] =
-   *       Rest[RACType, ResponseType].auth(myAuthPolicy).catching(errorFn)
-   *
-   *   ...
-   *   }
-   *
-   * }}}
-   */
-  def Rest[RACType, ResponseType]()
-    (implicit keyFormat: KeyFormat[String],
-      resourceFormat: OFormat[FriendshipInfo]) =
-    new RestActionBuilder[RACType, Unit, AnyContent, String, FriendshipInfo, ResponseType](
-      HeaderAccessControl.allowAll, BodyParsers.parse.anyContent, PartialFunction.empty)
-
-
-  def getAll(ancestorKeys: AncestorKeys) = Rest.getAll { implicit ctx =>
+  def getAll(ancestorKeys: AncestorKeys) = Nap.getAll { implicit ctx =>
     ???
   }
 
-  def get(id: PathKey) = Rest.get(ctx => ???)
+  def get(id: PathKey) = Nap.get(ctx => ???)
 
-  def multiGet(ids: Set[String], parentIds: AncestorKeys) = Rest.multiGet(ctx => ???)
+  def multiGet(ids: Set[String], parentIds: AncestorKeys) = Nap.multiGet(ctx => ???)
 
-  def update(id: String, parentIds: AncestorKeys) = Rest.update(ctx => ???)
+  def update(id: String, parentIds: AncestorKeys) = Nap.update(ctx => ???)
 
-  def delete(id: KeyType, fullId: PathKey) = Rest.delete(ctx => ???)
+  def delete(id: KeyType, fullId: PathKey) = Nap.delete(ctx => ???)
 
-  def create(ancestorKeys: AncestorKeys) = Rest.create(ctx => ???)
+  def create(ancestorKeys: AncestorKeys) = Nap.create(ctx => ???)
 
-  def byEmail(optPathKey: OptPathKey, email: String) = Rest.finder(ctx => ???)
+  def byEmail(optPathKey: OptPathKey, email: String) = Nap.finder(ctx => ???)
 
   def byUsernameAndDomain(
       ancestorKeys: AncestorKeys,
       userName: String,
-      domain: String) = Rest.finder(ctx => ???)
+      domain: String) = Nap.finder(ctx => ???)
 
   def withDefaults(
     ancestorKeys: AncestorKeys,
     userName: String,
-    domain: String = "defaultDomain") = Rest.finder(ctx => ???)
+    domain: String = "defaultDomain") = Nap.finder(ctx => ???)
 
-  def complex(complex: ComplexEmailType, extra: Option[String]) = Rest.finder(ctx => ???)
+  def complex(complex: ComplexEmailType, extra: Option[String]) = Nap.finder(ctx => ???)
 
   def batchModify(
       ancestorKeys: AncestorKeys,
-      someParam: Option[ComplexEmailType]) = Rest.action(ctx => ???)
+      someParam: Option[ComplexEmailType]) = Nap.action(ctx => ???)
 }
 
 object FriendsResource {
@@ -732,19 +683,14 @@ class NestedMacroTests extends AssertionsForJUnit with MockitoSugar {
 
   def shouldNotCompileTests(): Unit = {
     shapeless.test.illTyped("""
-      class MyResource extends TopLevelCollectionResource[String, FriendshipInfo]
-        with FieldsBuilder[FriendshipInfo] {
+      class MyResource extends TopLevelCollectionResource[String, FriendshipInfo] {
 
         override def keyFormat: KeyFormat[KeyType] = KeyFormat.stringKeyFormat
         override implicit def resourceFormat: OFormat[FriendshipInfo] = FriendshipInfo.jsonFormat
         override def resourceName: String = "friends"
         implicit val fields = Fields.withDefaultFields("friendshipQuality")
-        def Rest[RACType, ResponseType]()(implicit keyFormat: KeyFormat[String],
-            resourceFormat: OFormat[FriendshipInfo]) =
-          new RestActionBuilder[RACType, Unit, AnyContent, String, FriendshipInfo, ResponseType](
-            HeaderAccessControl.allowAll, BodyParsers.parse.anyContent, PartialFunction.empty)
 
-        def get(id: PathKey, optPath: OptPathKey) = Rest.get { ctx => ??? }
+        def get(id: PathKey, optPath: OptPathKey) = Nap.get { ctx => ??? }
       }
       object MyResource {
         val router = Router.build[MyResource]
@@ -753,19 +699,14 @@ class NestedMacroTests extends AssertionsForJUnit with MockitoSugar {
     )
 
     shapeless.test.illTyped("""
-      class MyResource extends TopLevelCollectionResource[String, FriendshipInfo]
-        with FieldsBuilder[FriendshipInfo] {
+      class MyResource extends TopLevelCollectionResource[String, FriendshipInfo] {
 
         override def keyFormat: KeyFormat[KeyType] = KeyFormat.stringKeyFormat
         override implicit def resourceFormat: OFormat[FriendshipInfo] = FriendshipInfo.jsonFormat
         override def resourceName: String = "friends"
         implicit val fields = Fields.withDefaultFields("friendshipQuality")
-        def Rest[RACType, ResponseType]()(implicit keyFormat: KeyFormat[String],
-            resourceFormat: OFormat[FriendshipInfo]) =
-          new RestActionBuilder[RACType, Unit, AnyContent, String, FriendshipInfo, ResponseType](
-            HeaderAccessControl.allowAll, BodyParsers.parse.anyContent, PartialFunction.empty)
 
-        def getAll(pathKey: PathKey) = Rest.getAll { ctx => ??? }
+        def getAll(pathKey: PathKey) = Nap.getAll { ctx => ??? }
       }
       object MyResource {
         val router = Router.build[MyResource]
@@ -774,19 +715,14 @@ class NestedMacroTests extends AssertionsForJUnit with MockitoSugar {
     )
 
     shapeless.test.illTyped("""
-      class MyResource extends TopLevelCollectionResource[String, FriendshipInfo]
-        with FieldsBuilder[FriendshipInfo] {
+      class MyResource extends TopLevelCollectionResource[String, FriendshipInfo] {
 
         override def keyFormat: KeyFormat[KeyType] = KeyFormat.stringKeyFormat
         override implicit def resourceFormat: OFormat[FriendshipInfo] = FriendshipInfo.jsonFormat
         override def resourceName: String = "friends"
         implicit val fields = Fields.withDefaultFields("friendshipQuality")
-        def Rest[RACType, ResponseType]()(implicit keyFormat: KeyFormat[String],
-            resourceFormat: OFormat[FriendshipInfo]) =
-          new RestActionBuilder[RACType, Unit, AnyContent, String, FriendshipInfo, ResponseType](
-            HeaderAccessControl.allowAll, BodyParsers.parse.anyContent, PartialFunction.empty)
 
-        def myFinder(pathKey: PathKey) = Rest.finder { ctx => ??? }
+        def myFinder(pathKey: PathKey) = Nap.finder { ctx => ??? }
       }
       object MyResource {
         val router = Router.build[MyResource]
@@ -795,19 +731,14 @@ class NestedMacroTests extends AssertionsForJUnit with MockitoSugar {
     )
 
     shapeless.test.illTyped("""
-      class MyResource extends TopLevelCollectionResource[String, FriendshipInfo]
-        with FieldsBuilder[FriendshipInfo] {
+      class MyResource extends TopLevelCollectionResource[String, FriendshipInfo] {
 
         override def keyFormat: KeyFormat[KeyType] = KeyFormat.stringKeyFormat
         override implicit def resourceFormat: OFormat[FriendshipInfo] = FriendshipInfo.jsonFormat
         override def resourceName: String = "friends"
         implicit val fields = Fields.withDefaultFields("friendshipQuality")
-        def Rest[RACType, ResponseType]()(implicit keyFormat: KeyFormat[String],
-            resourceFormat: OFormat[FriendshipInfo]) =
-          new RestActionBuilder[RACType, Unit, AnyContent, String, FriendshipInfo, ResponseType](
-            HeaderAccessControl.allowAll, BodyParsers.parse.anyContent, PartialFunction.empty)
 
-        def getall(randomParameter: String) = Rest.getAll { ctx => ??? }
+        def getall(randomParameter: String) = Nap.getAll { ctx => ??? }
       }
       object MyResource {
         val router = Router.build[MyResource]

--- a/naptime-testing/src/test/scala/org/coursera/naptime/NonNestedMacroTests.scala
+++ b/naptime-testing/src/test/scala/org/coursera/naptime/NonNestedMacroTests.scala
@@ -51,30 +51,7 @@ object ComplexEmailType {
     ComplexEmailType.unapply)
 }
 
-class Resource extends TopLevelCollectionResource[String, Item] with FieldsBuilder[Item] {
-
-  /**
-   * Helper to easily construct Rest actions.
-   *
-   * Typically, all actions in a naptime resource will all use the same auth parser and policy, or
-   * will want to use the same error handling function for all requests. These resources should do
-   * something similar to the following:
-   *
-   * {{{
-   *   class MyResource extends RestActionHelpers[Foo, Bar] {
-   *     def RRest[RACType, ResponseType] =
-   *       Rest[RACType, ResponseType].auth(myAuthPolicy).catching(errorFn)
-   *
-   *   ...
-   *   }
-   *
-   * }}}
-   */
-  def Rest[RACType, ResponseType]()
-    (implicit keyFormat: KeyFormat[String],
-      resourceFormat: OFormat[Item]) =
-    new RestActionBuilder[RACType, Unit, AnyContent, String, Item, ResponseType](
-      HeaderAccessControl.allowAll, BodyParsers.parse.anyContent, PartialFunction.empty)
+class Resource extends TopLevelCollectionResource[String, Item] {
 
   override def keyFormat: KeyFormat[String] = KeyFormat.stringKeyFormat
 
@@ -90,47 +67,47 @@ class Resource extends TopLevelCollectionResource[String, Item] with FieldsBuild
     Keyed("3", Item("tree", "with branches and leaves")),
     Keyed("4", Item("flour", "make bread with me")))
 
-  def getAll = Rest.getAll { implicit ctx =>
+  def getAll = Nap.getAll { implicit ctx =>
     Ok(allItems)
   }
 
-  def get(id: String) = Rest.get { ctx =>
+  def get(id: String) = Nap.get { ctx =>
     Ok(allItems.head)
   }
 
-  def multiGet(ids: Set[String]) = Rest.multiGet { ctx =>
+  def multiGet(ids: Set[String]) = Nap.multiGet { ctx =>
     Ok(allItems.filter(item => ids.contains(item.key)))
   }
 
-  def update(id: String) = Rest.update { ctx =>
+  def update(id: String) = Nap.update { ctx =>
     ???
   }
 
-  def delete(id: String) = Rest.delete { ctx =>
+  def delete(id: String) = Nap.delete { ctx =>
     ???
   }
 
-  def create = Rest.create { ctx =>
+  def create = Nap.create { ctx =>
     ???
   }
 
-  def byEmail(email: String) = Rest.finder { ctx =>
+  def byEmail(email: String) = Nap.finder { ctx =>
     ???
   }
 
-  def byUsernameAndDomain(userName: String, domain: String) = Rest.finder { ctx =>
+  def byUsernameAndDomain(userName: String, domain: String) = Nap.finder { ctx =>
     ???
   }
 
-  def complex(complex: ComplexEmailType, extra: Option[String]) = Rest.finder { ctx =>
+  def complex(complex: ComplexEmailType, extra: Option[String]) = Nap.finder { ctx =>
     ???
   }
 
-  def batchModify(someParam: Option[ComplexEmailType]) = Rest.action { ctx =>
+  def batchModify(someParam: Option[ComplexEmailType]) = Nap.action { ctx =>
     ???
   }
 
-  def parameterless() = Rest.action { ctx =>
+  def parameterless() = Nap.action { ctx =>
     ???
   }
 

--- a/naptime-testing/src/test/scala/org/coursera/naptime/router2/PlayNaptimeRouterIntegrationTest.scala
+++ b/naptime-testing/src/test/scala/org/coursera/naptime/router2/PlayNaptimeRouterIntegrationTest.scala
@@ -20,11 +20,8 @@ import com.google.inject.Guice
 import org.coursera.naptime.model.KeyFormat
 import org.coursera.naptime.model.Keyed
 import org.coursera.naptime.ComplexEmailType
-import org.coursera.naptime.FieldsBuilder
 import org.coursera.naptime.NaptimeModule
 import org.coursera.naptime.Ok
-import org.coursera.naptime.actions.RestActionBuilder
-import org.coursera.naptime.access.HeaderAccessControl
 import org.coursera.naptime.path.ParseFailure
 import org.coursera.naptime.path.ParseSuccess
 import org.coursera.naptime.path.RootParsedPathKey
@@ -38,9 +35,7 @@ import org.scalatest.junit.AssertionsForJUnit
 import org.scalatest.mock.MockitoSugar
 import play.api.libs.json.Json
 import play.api.libs.json.OFormat
-import play.api.mvc.AnyContent
 import play.api.mvc.AnyContentAsEmpty
-import play.api.mvc.BodyParsers
 import play.api.mvc.RequestHeader
 import play.api.test.FakeRequest
 
@@ -58,33 +53,10 @@ object PlayNaptimeRouterIntegrationTest {
    * The top level resource in our fledgling social network.
    */
   class PersonResource
-    extends TopLevelCollectionResource[String, Person]
-    with FieldsBuilder[Person] {
+    extends TopLevelCollectionResource[String, Person] {
 
     val PATH_KEY: PathKey = ("myPathKeyId" ::: RootParsedPathKey).asInstanceOf[PathKey]
 
-    /**
-     * Helper to easily construct Rest actions.
-     *
-     * Typically, all actions in a naptime resource will all use the same auth parser and policy, or
-     * will want to use the same error handling function for all requests. These resources should do
-     * something similar to the following:
-     *
-     * {{{
-     *   class MyResource extends RestActionHelpers[Foo, Bar] {
-     *     def RRest[RACType, ResponseType] =
-     *       Rest[RACType, ResponseType].auth(myAuthPolicy).catching(errorFn)
-     *
-     *   ...
-     *   }
-     *
-     * }}}
-     */
-    def Rest[RACType, ResponseType]()
-      (implicit keyFormat: KeyFormat[String],
-        resourceFormat: OFormat[Person]) =
-      new RestActionBuilder[RACType, Unit, AnyContent, String, Person, ResponseType](
-        HeaderAccessControl.allowAll, BodyParsers.parse.anyContent, PartialFunction.empty)
 
     override def keyFormat: KeyFormat[String] = KeyFormat.stringKeyFormat
 
@@ -100,29 +72,29 @@ object PlayNaptimeRouterIntegrationTest {
       Keyed("3", Person("fred")),
       Keyed("4", Person("bill")))
 
-    def getAll = Rest.getAll(implicit ctx => Ok(allItems))
+    def getAll = Nap.getAll(implicit ctx => Ok(allItems))
 
-    def get(id: PathKey) = Rest.get(ctx => Ok(allItems.head))
+    def get(id: PathKey) = Nap.get(ctx => Ok(allItems.head))
 
-    def multiGet(ids: Set[String]) = Rest.multiGet { ctx =>
+    def multiGet(ids: Set[String]) = Nap.multiGet { ctx =>
       Ok(allItems.filter(item => ids.contains(item.key)))
     }
 
-    def update(id: String) = Rest.update(ctx => ???)
+    def update(id: String) = Nap.update(ctx => ???)
 
-    def delete(id: KeyType) = Rest.delete(ctx => ???)
+    def delete(id: KeyType) = Nap.delete(ctx => ???)
 
-    def create = Rest.create(ctx => ???)
+    def create = Nap.create(ctx => ???)
 
-    def byEmail(email: String) = Rest.finder(ctx => ???)
+    def byEmail(email: String) = Nap.finder(ctx => ???)
 
-    def byUsernameAndDomain(userName: String, domain: String) = Rest.finder(ctx => ???)
+    def byUsernameAndDomain(userName: String, domain: String) = Nap.finder(ctx => ???)
 
-    def complex(complex: ComplexEmailType, extra: Option[String]) = Rest.finder(ctx => ???)
+    def complex(complex: ComplexEmailType, extra: Option[String]) = Nap.finder(ctx => ???)
 
-    def batchModify(someParam: Option[ComplexEmailType]) = Rest.action(ctx => ???)
+    def batchModify(someParam: Option[ComplexEmailType]) = Nap.action(ctx => ???)
 
-    def parameterless() = Rest.action(ctx => ???)
+    def parameterless() = Nap.action(ctx => ???)
   }
 
   case class FriendshipInfo(
@@ -134,8 +106,7 @@ object PlayNaptimeRouterIntegrationTest {
   }
 
   class FriendsResource(val parentResource: PersonResource)
-    extends CollectionResource[PersonResource, String, FriendshipInfo]
-    with FieldsBuilder[FriendshipInfo] {
+    extends CollectionResource[PersonResource, String, FriendshipInfo] {
     override def keyFormat: KeyFormat[KeyType] = KeyFormat.stringKeyFormat
 
     override implicit def resourceFormat: OFormat[FriendshipInfo] = FriendshipInfo.jsonFormat
@@ -149,59 +120,35 @@ object PlayNaptimeRouterIntegrationTest {
     val PATH_KEY: PathKey = ("friendId" ::: ANCESTOR_KEY).asInstanceOf[PathKey]
     val OPT_PATH_KEY: OptPathKey = (None ::: ANCESTOR_KEY).asInstanceOf[OptPathKey]
 
-    /**
-     * Helper to easily construct Rest actions.
-     *
-     * Typically, all actions in a naptime resource will all use the same auth parser and policy, or
-     * will want to use the same error handling function for all requests. These resources should do
-     * something similar to the following:
-     *
-     * {{{
-     *   class MyResource extends RestActionHelpers[Foo, Bar] {
-     *     def RRest[RACType, ResponseType] =
-     *       Rest[RACType, ResponseType].auth(myAuthPolicy).catching(errorFn)
-     *
-     *   ...
-     *   }
-     *
-     * }}}
-     */
-    def Rest[RACType, ResponseType]()
-      (implicit keyFormat: KeyFormat[String],
-        resourceFormat: OFormat[FriendshipInfo]) =
-      new RestActionBuilder[RACType, Unit, AnyContent, String, FriendshipInfo, ResponseType](
-        HeaderAccessControl.allowAll, BodyParsers.parse.anyContent, PartialFunction.empty)
+    def getAll(ancestorKeys: AncestorKeys) = Nap.getAll(ctx => ???)
 
+    def get(id: PathKey) = Nap.get(ctx => ???)
 
-    def getAll(ancestorKeys: AncestorKeys) = Rest.getAll(ctx => ???)
+    def multiGet(ids: Set[String], parentIds: AncestorKeys) = Nap.multiGet(ctx => ???)
 
-    def get(id: PathKey) = Rest.get(ctx => ???)
+    def update(id: String, parentIds: AncestorKeys) = Nap.update(ctx => ???)
 
-    def multiGet(ids: Set[String], parentIds: AncestorKeys) = Rest.multiGet(ctx => ???)
+    def delete(id: KeyType, fullId: PathKey) = Nap.delete(ctx => ???)
 
-    def update(id: String, parentIds: AncestorKeys) = Rest.update(ctx => ???)
+    def create(ancestorKeys: AncestorKeys) = Nap.create(ctx => ???)
 
-    def delete(id: KeyType, fullId: PathKey) = Rest.delete(ctx => ???)
-
-    def create(ancestorKeys: AncestorKeys) = Rest.create(ctx => ???)
-
-    def byEmail(optPathKey: OptPathKey, email: String) = Rest.finder(ctx => ???)
+    def byEmail(optPathKey: OptPathKey, email: String) = Nap.finder(ctx => ???)
 
     def byUsernameAndDomain(
       ancestorKeys: AncestorKeys,
       userName: String,
-      domain: String) = Rest.finder(ctx => ???)
+      domain: String) = Nap.finder(ctx => ???)
 
     def withDefaults(
       ancestorKeys: AncestorKeys,
       userName: String,
-      domain: String = "defaultDomain") = Rest.finder(ctx => ???)
+      domain: String = "defaultDomain") = Nap.finder(ctx => ???)
 
-    def complex(complex: ComplexEmailType, extra: Option[String]) = Rest.finder(ctx => ???)
+    def complex(complex: ComplexEmailType, extra: Option[String]) = Nap.finder(ctx => ???)
 
     def batchModify(
       ancestorKeys: AncestorKeys,
-      someParam: Option[ComplexEmailType]) = Rest.action(ctx => ???)
+      someParam: Option[ComplexEmailType]) = Nap.action(ctx => ???)
   }
 }
 

--- a/naptime/src/main/scala/org/coursera/naptime/models.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/models.scala
@@ -330,15 +330,6 @@ object Fields {
   val FIELDS_HEADER = "X-Coursera-Naptime-Fields"
 }
 
-/**
- * Mix this trait in to make it easy to generate an appropriate Fields object.
- *
- * @tparam T The type of the field.
- */
-trait FieldsBuilder[T] {
-  def Fields(implicit format: OFormat[T]): Fields[T] = org.coursera.naptime.Fields[T](format)
-}
-
 // TODO(saeta): FieldFn should also take advantage of the authentication applied. This will require
 // adding additional type information to many models.
 sealed trait FieldsFunction extends ((RequestHeader, QueryFields) => QueryFields) {

--- a/naptime/src/test/scala/org/coursera/naptime/actionCategoriesTests.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/actionCategoriesTests.scala
@@ -1,0 +1,269 @@
+package org.coursera.naptime
+
+import org.coursera.naptime.model.KeyFormat
+import org.coursera.naptime.model.Keyed
+import org.coursera.common.stringkey.StringKeyFormat
+import org.coursera.naptime.actions.RestAction
+import org.coursera.naptime.actions.RestActionCategoryEngine
+import org.coursera.naptime.resources.CollectionResource
+import org.coursera.naptime.resources.TopLevelCollectionResource
+import org.coursera.naptime.util.Validators
+import org.junit.Test
+import org.scalatest.concurrent.IntegrationPatience
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.junit.AssertionsForJUnit
+import play.api.http.HeaderNames
+import play.api.http.Status
+import play.api.http.Writeable
+import play.api.libs.iteratee.Enumerator
+import play.api.libs.json.Json
+import play.api.mvc.AnyContentAsEmpty
+import play.api.mvc.RequestHeader
+import play.api.test.FakeRequest
+import play.api.mvc.Result
+import play.api.mvc.AnyContent
+
+import scala.concurrent.duration._
+import play.api.libs.json.OFormat
+import play.api.libs.json.OWrites
+import play.api.test.Helpers.contentAsBytes
+import play.api.test.Helpers.defaultAwaitTimeout
+
+import scala.concurrent.Future
+
+case class EngineTestResource(name: String, desc: String)
+
+object EngineTestResource {
+  implicit val format = Json.format[EngineTestResource]
+
+  def mk(id: Int): EngineTestResource = apply(s"$id", s"EngineTestResource($id)")
+}
+
+object RestActionCategoryEngineTest {
+
+  /**
+   * A test resource to be used for testing the rest engines.
+   *
+   * Note: because we're not using routing, we can get away with having multiple get's / etc.
+   * In general, it is a very bad idea to have multiple gets / etc. in a single resource.
+   */
+  object SampleResource
+    extends TopLevelCollectionResource[Int, EngineTestResource] {
+    override val keyFormat: KeyFormat[Int] = KeyFormat.intKeyFormat
+    override val resourceName: String = "tests"
+    override val resourceFormat = Json.format[EngineTestResource]
+    implicit val fields = Fields.withDefaultFields("name", "desc")
+
+    def get1(id: Int) = Nap.get { ctx =>
+      Ok(Keyed(1, EngineTestResource.mk(1)))
+    }
+
+    def get2(id: Int) = Nap.get { ctx =>
+      Errors.BadRequest("bad", "You lose!")
+    }
+
+    def create1 = Nap.create { ctx =>
+      Ok(Keyed(1, Some(EngineTestResource.mk(1))))
+    }
+
+    def create2 = Nap.create { ctx =>
+      Ok(Keyed(1, None))
+    }
+
+    def create3 = Nap.catching {
+      case e: RuntimeException => RestError(NaptimeActionException(Status.BAD_REQUEST, Some("boom"), None))
+    }.create { ctx =>
+      throw new RuntimeException("Boom")
+    }
+
+    def delete1(id: Int) = Nap.delete {
+      Ok(())
+    }
+
+    def testFinder1(q1: K1) = Nap.finder.async { ctx =>
+      Future.successful(Ok(List(Keyed(1, EngineTestResource("finder", s"q1=$q1")))))
+    }
+
+    def testFinder2(q1: K1, q2: K2) = Nap.finder.async { ctx =>
+      Future.successful(Ok(List(Keyed(1, EngineTestResource("finder", s"q1=$q1, q2=$q2")))))
+    }
+
+  }
+
+  case class K1(key: Int)
+
+  object K1 {
+    implicit val stringKeyFormat: StringKeyFormat[K1] = StringKeyFormat.delegateFormat[K1, Int](k => Some(K1(k)), k => k.key)
+  }
+
+  case class K2(key: Int)
+
+  object K2 {
+    implicit val stringKeyFormat: StringKeyFormat[K2] = StringKeyFormat.delegateFormat[K2, Int](k => Some(K2(k)), k => k.key)
+  }
+
+}
+
+class RestActionCategoryEngineTest extends AssertionsForJUnit with ScalaFutures {
+  import RestActionCategoryEngineTest._
+
+  @Test
+  def get1(): Unit = {
+    testEmptyBody(SampleResource.get1(1))
+  }
+
+  @Test
+  def get2(): Unit = {
+    testEmptyBody(SampleResource.get2(2))
+  }
+
+  @Test
+  def create1(): Unit = {
+    testEmptyBody(SampleResource.create1)
+  }
+
+  @Test
+  def create2(): Unit = {
+    testEmptyBody(SampleResource.create2)
+  }
+
+  @Test
+  def create3(): Unit = {
+    testEmptyBody(SampleResource.create3)
+  }
+
+  @Test
+  def delete1(): Unit = {
+    testEmptyBody(SampleResource.delete1(1))
+  }
+
+  @Test
+  def testFinder1(): Unit = {
+    val request = FakeRequest("GET", "/?q1=1")
+    testEmptyBody(SampleResource.testFinder1(K1(1)), request = request)
+  }
+
+  @Test
+  def testFinder2(): Unit = {
+    val request = FakeRequest("GET", "/?q1=1&q2=2")
+    testEmptyBody(SampleResource.testFinder2(K1(1), K2(2)), request = request)
+  }
+
+  // Helpers below.
+
+  private[this] def test[BodyType](actionToTest: RestAction[_, _, BodyType, _, _, _],
+      request: FakeRequest[BodyType],
+      strictMode: Boolean = false)(
+      implicit writeable: Writeable[BodyType]): Result = {
+    val result = runTestRequest(actionToTest, request)
+    Validators.assertValidResponse(result, strictMode = strictMode)
+    result
+  }
+
+  private[this] def testEmptyBody(actionToTest: RestAction[_, _, AnyContent, _, _, _],
+      request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest(),
+      strictMode: Boolean = false): Result = {
+    val result = runTestRequest(actionToTest, request)
+    Validators.assertValidResponse(result, strictMode = strictMode)
+    result
+  }
+
+  private[this] def runTestRequestInternal[BodyType](
+      restAction: RestAction[_, _, BodyType, _, _, _],
+      request: RequestHeader,
+      body: Enumerator[Array[Byte]] = Enumerator.empty): Result = {
+    val iteratee = restAction.apply(request)
+    val resultFut = body.run(iteratee)
+    resultFut.futureValue
+  }
+
+  private[this] def runTestRequest[BodyType](restAction: RestAction[_, _, BodyType, _, _, _],
+      fakeRequest: FakeRequest[BodyType])(
+      implicit writeable: Writeable[BodyType]): Result = {
+    val requestWithHeader = writeable.contentType.map { ct =>
+      fakeRequest.withHeaders(HeaderNames.CONTENT_TYPE -> ct)
+    }.getOrElse(fakeRequest)
+    val b = Enumerator(fakeRequest.body).through(writeable.toEnumeratee)
+    runTestRequestInternal(restAction, requestWithHeader, b)
+  }
+
+  private[this] def runTestRequest(restAction: RestAction[_, _, AnyContent, _, _, _],
+      fakeRequest: FakeRequest[AnyContentAsEmpty.type]): Result = {
+    runTestRequestInternal(restAction, fakeRequest)
+  }
+}
+
+class ETagRestActionCategoryEngineTest extends AssertionsForJUnit with ScalaFutures {
+
+  import ETagRestActionCategoryEngineTest._
+
+  val testPagination = RequestPagination(limit = 20, start = None, isDefault = true)
+
+  @Test
+  def mkETagHeader(): Unit = {
+    val result = "test result"
+    val eTag = "1"
+    val okResponse = Ok(result).withETag(eTag)
+    val expectedHeader = "ETag" -> "\"1\""
+
+    val header = RestActionCategoryEngine.mkETagHeaderOpt(testPagination, okResponse, None)
+    assert(Some(expectedHeader) === header)
+    assertETagHeaderValueFormat(header.get._2)
+  }
+
+  @Test
+  def mkETagHeaderNone(): Unit = {
+    val result = "test result"
+    val okResponse = Ok(result)
+
+    assert(None === RestActionCategoryEngine.mkETagHeaderOpt(testPagination, okResponse, None))
+  }
+
+  @Test
+  def fallbackETagHeader(): Unit = {
+    val jsObject = Json.obj("hello" -> "world", "foo" -> Json.obj("bar" -> "baz"))
+    val result = "test result"
+    val okResponse = Ok(result)
+
+    val etag = RestActionCategoryEngine.mkETagHeader(testPagination, okResponse, jsObject)
+    assert(etag._1 === HeaderNames.ETAG)
+    assertETagHeaderValueFormat(etag._2)
+  }
+
+  @Test
+  def etagShouldShortCircuitResponse(): Unit = {
+    implicit val intKeyFormat = KeyFormat.intKeyFormat
+    val req = FakeRequest().withHeaders(HeaderNames.IF_NONE_MATCH -> "\"asdf\"")
+    val fields = Fields[TestResponse](TestResponse.fmt)
+    val pagination = RequestPagination(20, None, isDefault = true)
+    val naptimeResponse = Ok(Keyed(1, TestResponse(foo = "bar"))).withETag("asdf")
+
+    val engine = RestActionCategoryEngine.getActionCategoryEngine[Int, TestResponse](
+      TestResponse.writes, intKeyFormat)
+
+    val response = engine.mkResponse(req, fields, QueryFields.empty, QueryIncludes.empty,
+      pagination, naptimeResponse)
+    assert(response.header.status === Status.NOT_MODIFIED)
+    val bodyContent = contentAsBytes(Future.successful(response))
+    assert(bodyContent.length === 0)
+  }
+
+  private[this] def assertETagHeaderValueFormat(etagHeaderValue: String) = {
+    assert(etagHeaderValue.startsWith("\""), "ETag header values must start with a quote character")
+    assert(etagHeaderValue.endsWith("\""), "ETag header values must end with a quote character.")
+
+    assert(etagHeaderValueRegex.pattern.matcher(etagHeaderValue).matches)
+  }
+}
+
+object ETagRestActionCategoryEngineTest {
+  val etagHeaderValueRegex = "^\"[A-z0-9-]+\"".r
+}
+
+case class TestResponse(foo: String)
+
+object TestResponse {
+  implicit val writes = OWrites[TestResponse](tr => Json.obj("foo" -> tr.foo))
+  val reads = Json.reads[TestResponse]
+  implicit val fmt = OFormat(reads, writes)
+}

--- a/naptime/src/test/scala/org/coursera/naptime/actions/RestActionCategoryEngine2Test.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/actions/RestActionCategoryEngine2Test.scala
@@ -22,7 +22,6 @@ import org.coursera.naptime.model.Keyed
 import org.coursera.naptime.RestError
 import org.coursera.naptime.NaptimeActionException
 import org.coursera.naptime.Errors
-import org.coursera.naptime.FieldsBuilder
 import org.coursera.naptime.Ok
 import org.coursera.naptime.access.HeaderAccessControl
 import org.coursera.naptime.resources.TopLevelCollectionResource
@@ -58,40 +57,35 @@ object RestActionCategoryEngine2Test {
    * In general, it is a very bad idea to have multiple gets, creates, etc, in a single resource.
    */
   object PlayJsonTestResource
-    extends TopLevelCollectionResource[String, Person]
-    with FieldsBuilder[Person] {
+    extends TopLevelCollectionResource[String, Person] {
     override def keyFormat: KeyFormat[String] = KeyFormat.stringKeyFormat
     override def resourceName: String = "testResource"
     override implicit val resourceFormat: OFormat[Person] = Json.format[Person]
     implicit val fields = Fields.withDefaultFields("name")
 
-    def Rest[RACType, ResponseType] =
-      new RestActionBuilder[RACType, Unit, AnyContent, String, Person, ResponseType](
-        HeaderAccessControl.allowAll, BodyParsers.parse.anyContent, PartialFunction.empty)
-
-    def get1(id: String) = Rest.get { ctx =>
+    def get1(id: String) = Nap.get { ctx =>
       Ok(Keyed(id, Person(id, s"$id@coursera.org")))
     }
 
-    def get2(id: String) = Rest.get { ctx =>
+    def get2(id: String) = Nap.get { ctx =>
       Errors.NotFound(errorCode = "id", msg = s"Bad id $id")
     }
 
-    def create1 = Rest.create { ctx =>
+    def create1 = Nap.create { ctx =>
       Ok(Keyed("newId", Some(Person("newId", "newId@coursera.org"))))
     }
 
-    def create2 = Rest.create { ctx =>
+    def create2 = Nap.create { ctx =>
       Ok(Keyed("newId2", None))
     }
 
-    def create3 = Rest.catching {
+    def create3 = Nap.catching {
       case e: RuntimeException => RestError(NaptimeActionException(Status.BAD_REQUEST, Some("boom"), None))
     }.create { ctx =>
       throw new RuntimeException("boooooooom")
     }
 
-    def delete1(id: String) = Rest.delete {
+    def delete1(id: String) = Nap.delete {
       Ok(())
     }
   }
@@ -105,8 +99,7 @@ object RestActionCategoryEngine2Test {
    * In general, it is a very bad idea to have multiple gets, creates, etc, in a single resource.
    */
   object CourierTestResource
-    extends TopLevelCollectionResource[String, Course]
-    with FieldsBuilder[Course] {
+    extends TopLevelCollectionResource[String, Course] {
     override def keyFormat: KeyFormat[String] = KeyFormat.stringKeyFormat
     override def resourceName: String = "testResource"
     override implicit val resourceFormat: OFormat[Course] =
@@ -115,33 +108,29 @@ object RestActionCategoryEngine2Test {
 
     def mk(id: String): Course = Course(s"$id name", s"$id description")
 
-    def Rest[RACType, ResponseType] =
-      new RestActionBuilder[RACType, Unit, AnyContent, String, Course, ResponseType](
-        HeaderAccessControl.allowAll, BodyParsers.parse.anyContent, PartialFunction.empty)
-
-    def get1(id: String) = Rest.get { ctx =>
+    def get1(id: String) = Nap.get { ctx =>
       Ok(Keyed(id, mk(id)))
     }
 
-    def get2(id: String) = Rest.get { ctx =>
+    def get2(id: String) = Nap.get { ctx =>
       Errors.NotFound(errorCode = "id", msg = s"Bad id: $id")
     }
 
-    def create1 = Rest.create { ctx =>
+    def create1 = Nap.create { ctx =>
       Ok(Keyed("1", Some(mk("1"))))
     }
 
-    def create2 = Rest.create { ctx =>
+    def create2 = Nap.create { ctx =>
       Ok(Keyed("1", None))
     }
 
-    def create3 = Rest.catching {
+    def create3 = Nap.catching {
       case e: RuntimeException => RestError(NaptimeActionException(Status.BAD_REQUEST, Some("boom"), None))
     }.create { ctx =>
       throw new RuntimeException("boooooooom")
     }
 
-    def delete1(id: String) = Rest.delete {
+    def delete1(id: String) = Nap.delete {
       Ok(())
     }
   }

--- a/naptime/src/test/scala/org/coursera/naptime/router2/NestingCollectionResourceRouterTest.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/router2/NestingCollectionResourceRouterTest.scala
@@ -18,7 +18,6 @@ package org.coursera.naptime.router2
 
 import org.coursera.common.stringkey.StringKeyFormat
 import org.coursera.naptime.model.KeyFormat
-import org.coursera.naptime.Fields
 import org.coursera.naptime.actions.RestActionBuilder
 import org.coursera.naptime.access.HeaderAccessControl
 import org.coursera.naptime.path.:::
@@ -53,45 +52,41 @@ object NestingCollectionResourceRouterTest {
     override def keyFormat: KeyFormat[KeyType] = KeyFormat.stringKeyFormat
     override implicit def resourceFormat: OFormat[Person] = Person.jsonFormat
     override def resourceName: String = "myResource"
-    implicit val fields = Fields.apply[Person]
+    implicit val fields = Fields
 
-    def Rest[RACType, ResponseType] =
-      new RestActionBuilder[RACType, Unit, AnyContent, String, Person, ResponseType](
-        HeaderAccessControl.allowAll, BodyParsers.parse.anyContent, PartialFunction.empty)
-
-    def get(id: String) = Rest.get { ctx =>
+    def get(id: String) = Nap.get { ctx =>
       ???
     }
 
-    def multiGet(ids: Set[String]) = Rest.multiGet { ctx =>
+    def multiGet(ids: Set[String]) = Nap.multiGet { ctx =>
       ???
     }
 
-    def getAll = Rest.getAll { ctx =>
+    def getAll = Nap.getAll { ctx =>
       ???
     }
 
-    def me = Rest.finder { ctx =>
+    def me = Nap.finder { ctx =>
       ???
     }
 
-    def create = Rest.create { ctx =>
+    def create = Nap.create { ctx =>
       ???
     }
 
-    def delete(id: String) = Rest.delete { ctx =>
+    def delete(id: String) = Nap.delete { ctx =>
       ???
     }
 
-    def update(id: String) = Rest.update { ctx =>
+    def update(id: String) = Nap.update { ctx =>
       ???
     }
 
-    def patch(id: String) = Rest.patch { ctx =>
+    def patch(id: String) = Nap.patch { ctx =>
       ???
     }
 
-    def myAwesomeAction = Rest.action { ctx =>
+    def myAwesomeAction = Nap.action { ctx =>
       ???
     }
   }
@@ -179,48 +174,44 @@ object NestingCollectionResourceRouterTest {
     override def keyFormat: KeyFormat[KeyType] = KeyFormat.stringKeyFormat
     override implicit def resourceFormat: OFormat[Person] = Person.jsonFormat
     override def resourceName: String = "myNestedResource"
-    implicit val fields = Fields.apply[Person]
+    implicit val fields = Fields
 
     val ANCESTOR_KEY: AncestorKeys = ("parentKey" ::: RootParsedPathKey).asInstanceOf[AncestorKeys]
     val PATH_KEY: PathKey = ("resourceId" ::: ANCESTOR_KEY).asInstanceOf[PathKey]
 
-    def Rest[RACType, ResponseType] =
-      new RestActionBuilder[RACType, Unit, AnyContent, String, Person, ResponseType](
-        HeaderAccessControl.allowAll, BodyParsers.parse.anyContent, PartialFunction.empty)
-
-    def get(id: String, parentKeys: AncestorKeys) = Rest.get { ctx =>
+    def get(id: String, parentKeys: AncestorKeys) = Nap.get { ctx =>
       ???
     }
 
-    def multiGet(ids: Set[String], parentKeys: AncestorKeys) = Rest.multiGet { ctx =>
+    def multiGet(ids: Set[String], parentKeys: AncestorKeys) = Nap.multiGet { ctx =>
       ???
     }
 
-    def getAll(parentKeys: AncestorKeys) = Rest.getAll { ctx =>
+    def getAll(parentKeys: AncestorKeys) = Nap.getAll { ctx =>
       ???
     }
 
-    def me = Rest.finder { ctx =>
+    def me = Nap.finder { ctx =>
       ???
     }
 
-    def create(parentKeys: AncestorKeys) = Rest.create { ctx =>
+    def create(parentKeys: AncestorKeys) = Nap.create { ctx =>
       ???
     }
 
-    def delete(id: String, pathKey: PathKey) = Rest.delete { ctx =>
+    def delete(id: String, pathKey: PathKey) = Nap.delete { ctx =>
       ???
     }
 
-    def update(pathKey: PathKey) = Rest.update { ctx =>
+    def update(pathKey: PathKey) = Nap.update { ctx =>
       ???
     }
 
-    def patch(id: String, parentKeys: AncestorKeys) = Rest.patch { ctx =>
+    def patch(id: String, parentKeys: AncestorKeys) = Nap.patch { ctx =>
       ???
     }
 
-    def myAwesomeAction = Rest.action { ctx =>
+    def myAwesomeAction = Nap.action { ctx =>
       ???
     }
   }


### PR DESCRIPTION
As part of migrating over tests, I ended up streamlining the trait hierarchy for
Naptime. In short, I have removed the `FieldsBuilder` helper, and I've also
removed the `RestActionHelpers`, and just incorporated them into the main trait
hierarchy, as it pretty much makes no sense without them. (Internally to
Coursera, we have sub-traits that unify everything. This change is an effective
no-op for general user-land code that uses these child-traits, but will make it
much simpler to use naptime productively elsewhere, including in Naptime's own
tests!)