### PR TITLE
RestEngine2's: Carefully test resources

### DIFF
--- a/naptime/src/main/scala/org/coursera/naptime/actions/RestActionCategoryEngine.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/actions/RestActionCategoryEngine.scala
@@ -57,6 +57,8 @@ trait RestActionCategoryEngine[Category, Key, Resource, Response] {
       response: RestResponse[Response]): Result
 }
 
+object RestActionCategoryEngine extends PlayJsonRestActionCategoryEngine
+
 /**
  * Define the mappings between category engines.
  *
@@ -65,7 +67,7 @@ trait RestActionCategoryEngine[Category, Key, Resource, Response] {
  * trait, this would allow for different resources to have different engines available. That said,
  * this must all be sealed to disallow further 'customization'.
  */
-object RestActionCategoryEngine {
+trait PlayJsonRestActionCategoryEngine {
 
   private[this] def mkOkResponse[T](r: RestResponse[T])(fn: Ok[T] => Result) = {
     r match {
@@ -352,3 +354,5 @@ object RestActionCategoryEngine {
     }
   }
 }
+
+object PlayJsonRestActionCategoryEngine extends PlayJsonRestActionCategoryEngine

--- a/naptime/src/main/scala/org/coursera/naptime/models.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/models.scala
@@ -262,6 +262,8 @@ sealed case class Fields[T](
     JsObject(filtered)
   }
 
+  private[naptime] val inverseRelations = relations.map(_.swap)
+
   private[naptime] def computeFields(rh: RequestHeader): Try[RequestFields] = {
     // Try the header override first
     rh.headers.get(Fields.FIELDS_HEADER).map { fieldsHeader =>

--- a/naptime/src/main/scala/org/coursera/naptime/utilities.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/utilities.scala
@@ -42,7 +42,6 @@ private[naptime] object JsonUtilities {
       (implicit writes: OWrites[T], keyFormat: KeyFormat[K]): JsObject = {
     val filtered = JsonUtilities.filterJsonFields(Keyed.writes.writes(obj), fields)
 
-    // TODO(saeta): Modify this to reflect the resolution in INFRA-2754.
     val keyFields = keyFormat.format.writes(obj.key)
 
     keyFields ++ filtered

--- a/naptime/src/test/scala/org/coursera/naptime/actionCategoriesTests.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/actionCategoriesTests.scala
@@ -5,9 +5,9 @@ import org.coursera.naptime.model.Keyed
 import org.coursera.common.stringkey.StringKeyFormat
 import org.coursera.naptime.actions.RestAction
 import org.coursera.naptime.actions.RestActionCategoryEngine
+import org.coursera.naptime.actions.util.Validators
 import org.coursera.naptime.resources.CollectionResource
 import org.coursera.naptime.resources.TopLevelCollectionResource
-import org.coursera.naptime.util.Validators
 import org.junit.Test
 import org.scalatest.concurrent.IntegrationPatience
 import org.scalatest.concurrent.ScalaFutures

--- a/naptime/src/test/scala/org/coursera/naptime/actions/RestActionCategoryEngine2Test.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/actions/RestActionCategoryEngine2Test.scala
@@ -16,37 +16,47 @@
 
 package org.coursera.naptime.actions
 
+import org.coursera.common.stringkey.StringKey
 import org.coursera.naptime.courier.CourierFormats
 import org.coursera.naptime.model.KeyFormat
 import org.coursera.naptime.model.Keyed
 import org.coursera.naptime.RestError
 import org.coursera.naptime.NaptimeActionException
 import org.coursera.naptime.Errors
+import org.coursera.naptime.Fields
 import org.coursera.naptime.Ok
-import org.coursera.naptime.access.HeaderAccessControl
+import org.coursera.naptime.ResourceName
+import org.coursera.naptime.actions.util.Validators
 import org.coursera.naptime.resources.TopLevelCollectionResource
-import org.coursera.naptime.util.Validators
 import org.junit.Test
+import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.junit.AssertionsForJUnit
 import play.api.http.HeaderNames
 import play.api.http.Status
 import play.api.http.Writeable
 import play.api.libs.iteratee.Enumerator
+import play.api.libs.json.JsArray
+import play.api.libs.json.JsObject
 import play.api.libs.json.Json
 import play.api.libs.json.OFormat
 import play.api.mvc.AnyContent
 import play.api.mvc.AnyContentAsEmpty
-import play.api.mvc.BodyParsers
 import play.api.mvc.RequestHeader
 import play.api.mvc.Result
 import play.api.test.FakeRequest
+import play.api.test.Helpers
+import play.api.test.Helpers.defaultAwaitTimeout
 
-import scala.concurrent.Await
+import scala.concurrent.Future
 import scala.concurrent.duration._
 
 object RestActionCategoryEngine2Test {
 
   case class Person(name: String, email: String)
+
+  object Person {
+    implicit val jsonFormat: OFormat[Person] = Json.format[Person]
+  }
 
   /**
    * A test resource used for testing the DataMap-centric rest engines. (Uses Play-JSON adapters)
@@ -57,26 +67,38 @@ object RestActionCategoryEngine2Test {
    * In general, it is a very bad idea to have multiple gets, creates, etc, in a single resource.
    */
   object PlayJsonTestResource
-    extends TopLevelCollectionResource[String, Person] {
-    override def keyFormat: KeyFormat[String] = KeyFormat.stringKeyFormat
-    override def resourceName: String = "testResource"
-    override implicit val resourceFormat: OFormat[Person] = Json.format[Person]
-    implicit val fields = Fields.withDefaultFields("name")
+    extends TopLevelCollectionResource[Int, Person] {
+    import RestActionCategoryEngine2._
 
-    def get1(id: String) = Nap.get { ctx =>
-      Ok(Keyed(id, Person(id, s"$id@coursera.org")))
+    override def keyFormat: KeyFormat[Int] = KeyFormat.intKeyFormat
+    override def resourceName: String = "testResource"
+    override implicit val resourceFormat: OFormat[Person] = Person.jsonFormat
+    implicit val fields = Fields.withDefaultFields("name").withRelated(
+      "relatedCaseClass" -> RelatedResources.CaseClass.relatedName,
+      "relatedCourier" -> RelatedResources.Courier.relatedName)
+
+    def get1(id: Int) = Nap.get { ctx =>
+      RelatedResources.addRelated {
+        Ok(Keyed(id, Person(s"$id", s"$id@coursera.org")))
+      }
     }
 
-    def get2(id: String) = Nap.get { ctx =>
+    def get2(id: Int) = Nap.get { ctx =>
       Errors.NotFound(errorCode = "id", msg = s"Bad id $id")
     }
 
+    def multiGet(ids: Set[Int]) = Nap.multiGet { ctx =>
+      RelatedResources.addRelated {
+        Ok(ids.map(id => Keyed(id, Person(s"$id", s"$id@coursera.org"))).toSeq)
+      }
+    }
+
     def create1 = Nap.create { ctx =>
-      Ok(Keyed("newId", Some(Person("newId", "newId@coursera.org"))))
+      Ok(Keyed(2, Some(Person("newId", "newId@coursera.org"))))
     }
 
     def create2 = Nap.create { ctx =>
-      Ok(Keyed("newId2", None))
+      Ok(Keyed(3, None))
     }
 
     def create3 = Nap.catching {
@@ -85,7 +107,7 @@ object RestActionCategoryEngine2Test {
       throw new RuntimeException("boooooooom")
     }
 
-    def delete1(id: String) = Nap.delete {
+    def delete1(id: Int) = Nap.delete {
       Ok(())
     }
   }
@@ -100,20 +122,32 @@ object RestActionCategoryEngine2Test {
    */
   object CourierTestResource
     extends TopLevelCollectionResource[String, Course] {
+    import RestActionCategoryEngine2._
+
     override def keyFormat: KeyFormat[String] = KeyFormat.stringKeyFormat
     override def resourceName: String = "testResource"
     override implicit val resourceFormat: OFormat[Course] =
       CourierFormats.recordTemplateFormats[Course]
-    implicit val fields = Fields.withDefaultFields("name")
+    implicit val fields = Fields.withDefaultFields("name").withRelated(
+      "relatedCaseClass" -> RelatedResources.CaseClass.relatedName,
+      "relatedCourier" -> RelatedResources.Courier.relatedName)
 
     def mk(id: String): Course = Course(s"$id name", s"$id description")
 
     def get1(id: String) = Nap.get { ctx =>
-      Ok(Keyed(id, mk(id)))
+      RelatedResources.addRelated {
+        Ok(Keyed(id, mk(id)))
+      }
     }
 
     def get2(id: String) = Nap.get { ctx =>
       Errors.NotFound(errorCode = "id", msg = s"Bad id: $id")
+    }
+
+    def multiGet(ids: Set[String]) = Nap.multiGet { ctx =>
+      RelatedResources.addRelated {
+        Ok(ids.map(id => Keyed(id, mk(id))).toSeq)
+      }
     }
 
     def create1 = Nap.create { ctx =>
@@ -125,7 +159,8 @@ object RestActionCategoryEngine2Test {
     }
 
     def create3 = Nap.catching {
-      case e: RuntimeException => RestError(NaptimeActionException(Status.BAD_REQUEST, Some("boom"), None))
+      case e: RuntimeException =>
+        RestError(NaptimeActionException(Status.BAD_REQUEST, Some("boom"), None))
     }.create { ctx =>
       throw new RuntimeException("boooooooom")
     }
@@ -134,77 +169,344 @@ object RestActionCategoryEngine2Test {
       Ok(())
     }
   }
+
+  object CourierKeyedTestResource
+    extends TopLevelCollectionResource[EnrollmentId, Course] {
+    import RestActionCategoryEngine2._
+
+    override def resourceName: String = "testResource"
+    implicit val sessionIdStringKeyFormat = CourierFormats.recordTemplateStringKeyFormat[EnrollmentId]
+    override implicit def keyFormat =
+      KeyFormat.idAsStringWithFields(CourierFormats.recordTemplateFormats[EnrollmentId])
+    override implicit def resourceFormat: OFormat[Course] = CourierFormats.recordTemplateFormats[Course]
+    implicit val fields = Fields.withDefaultFields("name").withRelated(
+      "relatedCaseClass" -> RelatedResources.CaseClass.relatedName,
+      "relatedCourier" -> RelatedResources.Courier.relatedName)
+
+    def mk(id: EnrollmentId): Course = Course(s"${StringKey(id).key} name", s"$id description")
+
+    object EnrollmentIds {
+      val a = EnrollmentId(userId = 1225, courseId = SessionId(courseId = "abc", iterationId = 2))
+      val b = EnrollmentId(userId = 2, courseId = SessionId(courseId = "xyz", iterationId = 8))
+    }
+
+    def get1(id: EnrollmentId) = Nap.get { ctx =>
+      RelatedResources.addRelated {
+        Ok(Keyed(id, mk(id)))
+      }
+    }
+
+    def get2(id: EnrollmentId) = Nap.get { ctx =>
+      Errors.NotFound(errorCode = "id", msg = s"Bad id: $id")
+    }
+
+    def multiGet(ids: Set[EnrollmentId]) = Nap.multiGet { ctx =>
+      RelatedResources.addRelated {
+        Ok(ids.map(id => Keyed(id, mk(id))).toSeq)
+      }
+    }
+
+    def create1 = Nap.create { ctx =>
+      Ok(Keyed(EnrollmentIds.a, Some(mk(EnrollmentIds.a))))
+    }
+
+    def create2 = Nap.create { ctx =>
+      Ok(Keyed(EnrollmentIds.b, None))
+    }
+
+    def create3 = Nap.catching {
+      case e: RuntimeException =>
+        RestError(NaptimeActionException(Status.BAD_REQUEST, Some("boom"), None))
+    }.create { ctx =>
+      throw new RuntimeException("boooooooom")
+    }
+
+    def delete1(id: EnrollmentId) = Nap.delete {
+      Ok(())
+    }
+  }
+
+  object RelatedResources extends AssertionsForJUnit {
+    object CaseClass {
+      val relatedName = ResourceName("relatedCaseClass", 2)
+      implicit val fields = Fields[Person]
+
+      val related = Seq(
+        Keyed(1, Person("related1", "1@related.com"))
+      )
+
+      def addRelated[T](ok: Ok[T]): Ok[T] = {
+        ok.withRelated(relatedName, related)
+      }
+    }
+
+    object Courier {
+      val relatedName = ResourceName("relatedCourier", 3)
+      implicit val format = CourierFormats.recordTemplateFormats[Course]
+      implicit val fields = Fields[Course]
+
+      val related = Seq(
+        Keyed(1, Course("relatedCourse1", "All about the first related course!"))
+      )
+
+      def addRelated[T](ok: Ok[T]): Ok[T] = {
+        ok.withRelated(relatedName, related)
+      }
+    }
+
+    def addRelated[T](ok: Ok[T]): Ok[T] = {
+      val withCaseClass = CaseClass.addRelated(ok)
+      val withCourier = Courier.addRelated(withCaseClass)
+      withCourier
+    }
+
+    private[this] def checkBasicResponseForRelated(response: Result): (JsObject, JsObject) = {
+      val bodyContent = Helpers.contentAsJson(Future.successful(response))
+      assert(bodyContent.isInstanceOf[JsObject])
+      val json = bodyContent.asInstanceOf[JsObject]
+      assert(json.value.contains("elements"))
+      assert(json.value.contains("linked"))
+      assert((json \ "linked").toOption.isDefined, s"Linked: ${json \ "linked"}")
+      assert((json \ "linked").validate[JsObject].asOpt.isDefined,
+        s"Got ${(json \ "linked").validate[JsObject]}. Json: $json")
+      val linked = (json \ "linked").validate[JsObject].get
+      (linked, json)
+    }
+
+    def assertRelatedPresent(response: Result): Unit = {
+      val (linked, json) = checkBasicResponseForRelated(response)
+      assert(linked.value.size === 2, s"Response: $json")
+      val expected = Json.obj(
+        CaseClass.relatedName.identifier -> Json.arr(
+          Json.obj(
+            "id" -> 1,
+            "name" -> "related1")),
+        Courier.relatedName.identifier -> Json.arr(
+          Json.obj(
+            "id" -> 1,
+            "name" -> "relatedCourse1")))
+      assert(expected === linked, s"Linked was not what we expected. Got $linked")
+    }
+
+    def assertRelatedAbsent(response: Result): Unit = {
+      val (linked, json) = checkBasicResponseForRelated(response)
+      assert(linked.value.size === 0, s"Response: $json")
+    }
+  }
 }
 
-class RestActionCategoryEngine2Test extends AssertionsForJUnit {
+class RestActionCategoryEngine2Test extends AssertionsForJUnit with ScalaFutures {
   import RestActionCategoryEngine2Test._
-  private[this] implicit val typicalDuration = 1.second
+
+  // Increase timeout a bit.
+  override def spanScaleFactor: Double = 10
+
+  // TODO(saeta): Unit test ETag construction.
 
   @Test
   def playJsonGet1(): Unit = {
-    testEmptyBody(PlayJsonTestResource.get1("test"))
+    val response = testEmptyRequestBody(PlayJsonTestResource.get1(1))
+    RelatedResources.assertRelatedPresent(response)
+    val elements = assertElements(response)
+    val expected = Json.arr(
+      Json.obj(
+        "id" -> 1,
+        "name" -> "1"))
+    assert(expected === elements)
+  }
+
+  @Test
+  def playJsonGet1NoRelated(): Unit = {
+    val response = testEmptyRequestBody(PlayJsonTestResource.get1(1), FakeRequest())
+    RelatedResources.assertRelatedAbsent(response)
+    val elements = assertElements(response)
+    val expected = Json.arr(
+      Json.obj(
+        "id" -> 1,
+        "name" -> "1"))
+    assert(expected === elements)
   }
 
   @Test
   def playJsonGet2(): Unit = {
-    testEmptyBody(PlayJsonTestResource.get2("test"))
+    testEmptyRequestBody(PlayJsonTestResource.get2(1))
+  }
+
+  @Test
+  def playJsonMultiGet(): Unit = {
+    val response = testEmptyRequestBody(PlayJsonTestResource.multiGet(Set(1, 2)))
+    RelatedResources.assertRelatedPresent(response)
+  }
+
+  @Test
+  def playJsonMultiGetNoRelated(): Unit = {
+    val response = testEmptyRequestBody(PlayJsonTestResource.multiGet(Set(1, 2)), FakeRequest())
+    RelatedResources.assertRelatedAbsent(response)
   }
 
   @Test
   def playJsonCreate1(): Unit = {
-    testEmptyBody(PlayJsonTestResource.create1)
+    testEmptyRequestBody(PlayJsonTestResource.create1)
   }
 
   @Test
   def playJsonCreate2(): Unit = {
-    testEmptyBody(PlayJsonTestResource.create2)
+    testEmptyRequestBody(PlayJsonTestResource.create2)
   }
 
   @Test
   def playJsonCreate3(): Unit = {
-    testEmptyBody(PlayJsonTestResource.create3)
+    testEmptyRequestBody(PlayJsonTestResource.create3)
   }
 
   @Test
   def playJsonDelete1(): Unit = {
-    testEmptyBody(PlayJsonTestResource.delete1("test"))
+    testEmptyRequestBody(PlayJsonTestResource.delete1(1))
   }
 
   @Test
   def courierGet1(): Unit = {
-    testEmptyBody(CourierTestResource.get1("test"))
+    val response = testEmptyRequestBody(CourierTestResource.get1("test"))
+    RelatedResources.assertRelatedPresent(response)
+    val elements = assertElements(response)
+    val expected = Json.arr(
+      Json.obj(
+        "id" -> "test",
+        "name" -> "test name"))
+    assert(expected === elements)
+  }
+
+  @Test
+  def courierGet1NoRelated(): Unit = {
+    val response = testEmptyRequestBody(CourierTestResource.get1("test"), FakeRequest())
+    RelatedResources.assertRelatedAbsent(response)
+    val elements = assertElements(response)
+    val expected = Json.arr(
+      Json.obj(
+        "id" -> "test",
+        "name" -> "test name"))
+    assert(expected === elements)
   }
 
   @Test
   def courierGet2(): Unit = {
-    testEmptyBody(CourierTestResource.get2("test"))
+    testEmptyRequestBody(CourierTestResource.get2("test"))
+  }
+
+  @Test
+  def courierMultiGet(): Unit = {
+    val response = testEmptyRequestBody(CourierTestResource.multiGet(Set("test1", "test2")))
+    RelatedResources.assertRelatedPresent(response)
+  }
+
+  @Test
+  def courierMultiGetNoRelated(): Unit = {
+    val response = testEmptyRequestBody(CourierTestResource.multiGet(Set("test1", "test2")), FakeRequest())
+    RelatedResources.assertRelatedAbsent(response)
   }
 
   @Test
   def courierCreate1(): Unit = {
-    testEmptyBody(CourierTestResource.create1)
+    testEmptyRequestBody(CourierTestResource.create1)
   }
 
   @Test
   def courierCreate2(): Unit = {
-    testEmptyBody(CourierTestResource.create2)
+    testEmptyRequestBody(CourierTestResource.create2)
   }
 
   @Test
   def courierCreate3(): Unit = {
-    testEmptyBody(CourierTestResource.create3)
+    testEmptyRequestBody(CourierTestResource.create3)
   }
 
   @Test
   def courierDelete1(): Unit = {
-    testEmptyBody(CourierTestResource.delete1("test"))
+    testEmptyRequestBody(CourierTestResource.delete1("test"))
   }
+
+
+  @Test
+  def courierKeyedGet1(): Unit = {
+    val response = testEmptyRequestBody(CourierKeyedTestResource.get1(CourierKeyedTestResource.EnrollmentIds.a))
+    RelatedResources.assertRelatedPresent(response)
+    val elements = assertElements(response)
+    val expected = Json.arr(
+      Json.obj(
+        "id" -> "1225~abc!~2",
+        "courseId" -> Json.obj(
+          "iterationId" -> 2,
+          "courseId" -> "abc"),
+        "userId" -> 1225,
+        "name" -> "1225~abc!~2 name"))
+    assert(expected === elements)
+  }
+
+  @Test
+  def courierKeyedGet1NoRelated(): Unit = {
+    val response = testEmptyRequestBody(CourierKeyedTestResource.get1(CourierKeyedTestResource.EnrollmentIds.a),
+      FakeRequest())
+    RelatedResources.assertRelatedAbsent(response)
+    val elements = assertElements(response)
+    val expected = Json.arr(
+      Json.obj(
+        "id" -> "1225~abc!~2",
+        "courseId" -> Json.obj(
+          "iterationId" -> 2,
+          "courseId" -> "abc"),
+        "userId" -> 1225,
+        "name" -> "1225~abc!~2 name"))
+    assert(expected === elements)
+  }
+
+  @Test
+  def courierKeyedGet2(): Unit = {
+    testEmptyRequestBody(CourierKeyedTestResource.get2(CourierKeyedTestResource.EnrollmentIds.a))
+  }
+
+  @Test
+  def courierKeyedMultiGet(): Unit = {
+    val response = testEmptyRequestBody(CourierKeyedTestResource.multiGet(Set(
+      CourierKeyedTestResource.EnrollmentIds.a, CourierKeyedTestResource.EnrollmentIds.b)))
+    RelatedResources.assertRelatedPresent(response)
+  }
+
+  @Test
+  def courierKeyedMultiGetNoRelated(): Unit = {
+    val response = testEmptyRequestBody(CourierKeyedTestResource.multiGet(Set(
+      CourierKeyedTestResource.EnrollmentIds.a, CourierKeyedTestResource.EnrollmentIds.b)), FakeRequest())
+    RelatedResources.assertRelatedAbsent(response)
+  }
+
+  @Test
+  def courierKeyedCreate1(): Unit = {
+    testEmptyRequestBody(CourierKeyedTestResource.create1)
+  }
+
+  @Test
+  def courierKeyedCreate2(): Unit = {
+    testEmptyRequestBody(CourierKeyedTestResource.create2)
+  }
+
+  @Test
+  def courierKeyedCreate3(): Unit = {
+    testEmptyRequestBody(CourierKeyedTestResource.create3)
+  }
+
+  @Test
+  def courierKeyedDelete1(): Unit = {
+    testEmptyRequestBody(CourierKeyedTestResource.delete1(CourierKeyedTestResource.EnrollmentIds.b))
+  }
+
 
   // Test helpers here and below.
 
-  private[this] def testEmptyBody(
+  private[this] val fieldsQueryParam = s"${RelatedResources.CaseClass.relatedName.identifier}(name)," +
+    s"${RelatedResources.Courier.relatedName.identifier}(name)"
+  private[this] def testEmptyRequestBody(
       actionToTest: RestAction[_, _, AnyContent, _, _, _],
-      request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest(),
+      request: FakeRequest[AnyContentAsEmpty.type] =
+        FakeRequest("GET", s"/?includes=relatedCaseClass,relatedCourier&fields=$fieldsQueryParam"),
       strictMode: Boolean = false): Result = {
     val result = runTestRequest(actionToTest, request)
     Validators.assertValidResponse(result, strictMode = strictMode)
@@ -214,30 +516,34 @@ class RestActionCategoryEngine2Test extends AssertionsForJUnit {
   private[this] def runTestRequestInternal[BodyType](
       restAction: RestAction[_, _, BodyType, _, _, _],
       request: RequestHeader,
-      body: Enumerator[Array[Byte]] = Enumerator.empty)
-      (implicit duration: FiniteDuration): Result = {
+      body: Enumerator[Array[Byte]] = Enumerator.empty): Result = {
     val iteratee = restAction.apply(request)
     val resultFut = body.run(iteratee)
-    Await.result(resultFut, duration)
+    resultFut.futureValue
   }
-
 
   private[this] def runTestRequest[BodyType](restAction: RestAction[_, _, BodyType, _, _, _],
     fakeRequest: FakeRequest[BodyType])(
-    implicit duration: FiniteDuration,
-    writeable: Writeable[BodyType]): Result = {
+    implicit writeable: Writeable[BodyType]): Result = {
     val requestWithHeader = writeable.contentType.map { ct =>
       fakeRequest.withHeaders(HeaderNames.CONTENT_TYPE -> ct)
     }.getOrElse(fakeRequest)
     val b = Enumerator(fakeRequest.body).through(writeable.toEnumeratee)
-    runTestRequestInternal(restAction, requestWithHeader, b)(duration)
+    runTestRequestInternal(restAction, requestWithHeader, b)
   }
 
   private[this] def runTestRequest(restAction: RestAction[_, _, AnyContent, _, _, _],
-    fakeRequest: FakeRequest[AnyContentAsEmpty.type])(
-    implicit duration: FiniteDuration): Result = {
-    runTestRequestInternal(restAction, fakeRequest)(duration)
+    fakeRequest: FakeRequest[AnyContentAsEmpty.type]): Result = {
+    runTestRequestInternal(restAction, fakeRequest)
   }
 
+  private[this] def assertElements(response: Result): JsArray = {
+    val bodyContent = Helpers.contentAsJson(Future.successful(response))
+    assert(bodyContent.isInstanceOf[JsObject])
+    val json = bodyContent.asInstanceOf[JsObject]
+    val elements = (json \ "elements").validate[JsArray]
+    assert(elements.isSuccess, s"Elements was not a JsArray: $elements. $bodyContent")
+    elements.get
+  }
 
 }

--- a/naptime/src/test/scala/org/coursera/naptime/actions/util/Validators.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/actions/util/Validators.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.coursera.naptime.util
+package org.coursera.naptime.actions.util
 
 import org.scalatest.junit.AssertionsForJUnit
 import play.api.http.HeaderNames


### PR DESCRIPTION
In order to ensure a smooth migration to the 2nd-generation engines,
I've fleshed out a more sophisticated test suite that ensures that
the new engines behave appropriately.