### PR TITLE
Augment Resource.courier to include mergedType

### DIFF
--- a/naptime-testing/src/test/scala/org/coursera/naptime/NestedMacroTests.scala
+++ b/naptime-testing/src/test/scala/org/coursera/naptime/NestedMacroTests.scala
@@ -658,7 +658,8 @@ class NestedMacroTests extends AssertionsForJUnit with MockitoSugar {
     assert(schema.name === "people")
     assert(schema.version === Some(1))
     assert(schema.keyType === "string")
-    assert(schema.bodyType === "org.coursera.naptime.PersonResource.Model")
+    assert(schema.valueType === "org.coursera.naptime.Person")
+    assert(schema.mergedType === "org.coursera.naptime.PersonResource.Model")
     assert(schema.handlers.length === 13)
     assert(schema.handlers.filter(_.kind == HandlerKind.FINDER).map(_.name).toSet ===
       Set("byEmail", "byUsernameAndDomain", "complex", "complexWithDefault", "byUsernameSorted"))
@@ -698,7 +699,9 @@ class NestedMacroTests extends AssertionsForJUnit with MockitoSugar {
     assert(schema.kind === ResourceKind.COLLECTION)
     assert(schema.name === "friends")
     assert(schema.version === Some(1))
-    assert(schema.bodyType === "org.coursera.naptime.FriendsResource.Model")
+    assert(schema.keyType === "string")
+    assert(schema.valueType === "org.coursera.naptime.FriendshipInfo")
+    assert(schema.mergedType === "org.coursera.naptime.FriendsResource.Model")
     assert(schema.handlers.length === 11)
     assert(schema.handlers.filter(_.kind == HandlerKind.FINDER).map(_.name).toSet ===
       Set("byEmail", "byUsernameAndDomain", "withDefaults", "complex"))

--- a/naptime/src/main/pegasus/org/coursera/naptime/schema/Resource.courier
+++ b/naptime/src/main/pegasus/org/coursera/naptime/schema/Resource.courier
@@ -31,9 +31,14 @@ record Resource {
   keyType: TypeName
 
   /**
+   * The fully qualified name of the type corresponding to the values for this resource.
+   */
+  valueType: TypeName
+
+  /**
    * The fully qualified name of the type corresponding to response elements for this resource.
    */
-  bodyType: TypeName
+  mergedType: TypeName
 
   /**
    * The supported operations.

--- a/naptime/src/main/scala/org/coursera/naptime/router2/MacroImpls.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/router2/MacroImpls.scala
@@ -184,7 +184,8 @@ class MacroImpls(val c: blackbox.Context) {
               "??? (resourceName should be def not val)"),
             version = Some(stubInstance.resourceVersion),
             keyType = ${keyType(resourceType)},
-            bodyType = ${mergedType(resourceType)},
+            valueType = ${valueType(resourceType)},
+            mergedType = ${mergedType(resourceType)},
             parentClass = $parentResourceName,
             handlers = List(..${trees.flatMap(_._2)}),
             className = ${resourceType.toString},
@@ -196,10 +197,6 @@ class MacroImpls(val c: blackbox.Context) {
       """
       debug(s"NaptimeRouterBuilder macro code for $resourceType : ${showCode(finalResource)}")
       finalResource
-    }
-
-    private[this] def mergedType(resourceType: c.Type): String = {
-      resourceType.toString + ".Model"
     }
 
     private[this] def keyType(resourceType: c.Type): c.Tree = {
@@ -214,6 +211,17 @@ class MacroImpls(val c: blackbox.Context) {
         q"${keyType.toString}"
       }
     }
+
+    private[this] def valueType(resourceType: c.Type): c.Tree = {
+      val collectionTypeView = resourceType.baseType(COLLECTION_RESOURCE_TYPE.typeSymbol)
+      val bodyType = collectionTypeView.typeArgs(2)
+      q"${bodyType.toString}"
+    }
+
+    private[this] def mergedType(resourceType: c.Type): String = {
+      resourceType.toString + ".Model"
+    }
+
 
     private[this] def getRecordSchemaForType(targetType: c.Type): c.Tree = {
       if (targetType <:< SCALA_RECORD_TEMPLATE) {


### PR DESCRIPTION
As part of the asymmetric models approach we've adopted, we compute a
merged type that is composed of the union of the fields between the
key and the value. Sometimes, however, it's important to see the
unadulterated value type. For this, we now expose both the valueType
and the mergedType. Previously, the exposed bodyType was the mergedType,
and the valueType was not exposed at all. Hopefully with this rename,
we've also settled on good names for these types.