### PR TITLE
Add If-None-Match tests for Engine2's

### DIFF
--- a/naptime/src/test/scala/org/coursera/naptime/actions/RestActionCategoryEngine2Test.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/actions/RestActionCategoryEngine2Test.scala
@@ -344,6 +344,16 @@ class RestActionCategoryEngine2Test extends AssertionsForJUnit with ScalaFutures
   }
 
   @Test
+  def playJsonGet1IfNoneMatch(): Unit = {
+    val response1 = testEmptyRequestBody(PlayJsonTestResource.get1(4))
+    assert(response1.header.headers.contains(HeaderNames.ETAG))
+    val etag = response1.header.headers(HeaderNames.ETAG)
+    val request2 = standardFakeRequest.withHeaders(HeaderNames.IF_NONE_MATCH -> etag)
+    val response2 = testEmptyRequestBody(PlayJsonTestResource.get1(4), request2)
+    assert(response2.header.status === Status.NOT_MODIFIED)
+  }
+
+  @Test
   def playJsonGet2(): Unit = {
     testEmptyRequestBody(PlayJsonTestResource.get2(1))
   }
@@ -420,6 +430,16 @@ class RestActionCategoryEngine2Test extends AssertionsForJUnit with ScalaFutures
     assert(response1.header.headers.get(HeaderNames.ETAG) === response2.header.headers.get(HeaderNames.ETAG))
     // Check for stability in ETag computation.
     assert(Some("\"1468630371\"") === response1.header.headers.get(HeaderNames.ETAG))
+  }
+
+  @Test
+  def courierGet1IfNoneMatch(): Unit = {
+    val response1 = testEmptyRequestBody(CourierTestResource.get1("etagTest"))
+    assert(response1.header.headers.contains(HeaderNames.ETAG))
+    val etag = response1.header.headers(HeaderNames.ETAG)
+    val request2 = standardFakeRequest.withHeaders(HeaderNames.IF_NONE_MATCH -> etag)
+    val response2 = testEmptyRequestBody(CourierTestResource.get1("etagTest"), request2)
+    assert(response2.header.status === Status.NOT_MODIFIED)
   }
 
   @Test
@@ -537,10 +557,11 @@ class RestActionCategoryEngine2Test extends AssertionsForJUnit with ScalaFutures
 
   private[this] val fieldsQueryParam = s"${RelatedResources.CaseClass.relatedName.identifier}(name)," +
     s"${RelatedResources.Courier.relatedName.identifier}(name)"
+  private[this] val standardFakeRequest =
+    FakeRequest("GET", s"/?includes=relatedCaseClass,relatedCourier&fields=$fieldsQueryParam")
   private[this] def testEmptyRequestBody(
       actionToTest: RestAction[_, _, AnyContent, _, _, _],
-      request: FakeRequest[AnyContentAsEmpty.type] =
-        FakeRequest("GET", s"/?includes=relatedCaseClass,relatedCourier&fields=$fieldsQueryParam"),
+      request: FakeRequest[AnyContentAsEmpty.type] = standardFakeRequest,
       strictMode: Boolean = false): Result = {
     val result = runTestRequest(actionToTest, request)
     Validators.assertValidResponse(result, strictMode = strictMode)

--- a/naptime/src/test/scala/org/coursera/naptime/actions/util/Validators.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/actions/util/Validators.scala
@@ -25,6 +25,7 @@ import play.api.libs.json.JsString
 import play.api.libs.json.JsValue
 import play.api.libs.json.JsNull
 import play.api.mvc.Result
+import play.api.test.Helpers.contentAsBytes
 import play.api.test.Helpers.contentAsJson
 import play.api.test.Helpers.defaultAwaitTimeout
 import play.api.http.MimeTypes
@@ -48,6 +49,10 @@ object Validators extends AssertionsForJUnit {
     result.header.status match {
       case Status.OK | Status.CREATED | Status.NO_CONTENT =>
         assertValidSuccessResponse(result, strictMode)
+      case Status.NOT_MODIFIED =>
+        assert(result.header.headers.get(HeaderNames.CONTENT_TYPE).isEmpty)
+        assert(result.header.headers.get(HeaderNames.ETAG).isDefined)
+        assert(0 === contentAsBytes(Future.successful(result)).length)
       case code if code >= 400 && code < 500 =>
         assertClientErrorResponse(result)
       case code if code >= 500 =>


### PR DESCRIPTION
Test the engine2 implementations to ensure they perform correctly
in the presence of If-None-Match headers and correctly return
HTTP 304 NOT MODIFIED responses with empty bodies.