### PR TITLE
Use Engine2's by default.

### DIFF
--- a/naptime-testing/src/test/scala/org/coursera/naptime/NestedMacroTests.scala
+++ b/naptime-testing/src/test/scala/org/coursera/naptime/NestedMacroTests.scala
@@ -18,6 +18,7 @@ package org.coursera.naptime
 
 import com.linkedin.data.schema.DataSchema
 import com.linkedin.data.schema.RecordDataSchema
+import org.coursera.naptime.actions.NaptimeSerializer.AnyWrites._
 import org.coursera.naptime.courier.CourierFormats
 import org.coursera.naptime.model.KeyFormat
 import org.coursera.naptime.model.Keyed

--- a/naptime-testing/src/test/scala/org/coursera/naptime/NonNestedMacroTests.scala
+++ b/naptime-testing/src/test/scala/org/coursera/naptime/NonNestedMacroTests.scala
@@ -17,6 +17,7 @@
 package org.coursera.naptime
 
 import org.coursera.common.stringkey.StringKeyFormat
+import org.coursera.naptime.actions.NaptimeSerializer.AnyWrites._
 import org.coursera.naptime.model.KeyFormat
 import org.coursera.naptime.model.Keyed
 import org.coursera.naptime.actions.RestActionBuilder

--- a/naptime-testing/src/test/scala/org/coursera/naptime/router2/PlayNaptimeRouterIntegrationTest.scala
+++ b/naptime-testing/src/test/scala/org/coursera/naptime/router2/PlayNaptimeRouterIntegrationTest.scala
@@ -17,6 +17,7 @@
 package org.coursera.naptime.router2
 
 import com.google.inject.Guice
+import org.coursera.naptime.actions.NaptimeSerializer.AnyWrites._
 import org.coursera.naptime.model.KeyFormat
 import org.coursera.naptime.model.Keyed
 import org.coursera.naptime.ComplexEmailType

--- a/naptime/src/main/scala/org/coursera/naptime/actions/NaptimeSerializer.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/actions/NaptimeSerializer.scala
@@ -140,4 +140,21 @@ object NaptimeSerializer {
       override def schema(t: T): Option[DataSchema] = None
     }
   }
+
+  /**
+   * Useful for mocking tests / etc.
+   */
+  object AnyWrites {
+    implicit val anyWrites: NaptimeSerializer[Any] = new NaptimeSerializer[Any] {
+      override def serialize(t: Any): DataMap = {
+        val m = new DataMap()
+        m.put("id", t.toString)
+        m
+      }
+
+      override def schema(t: Any): Option[DataSchema] = {
+        None
+      }
+    }
+  }
 }

--- a/naptime/src/main/scala/org/coursera/naptime/actions/RestActionCategoryEngine.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/actions/RestActionCategoryEngine.scala
@@ -59,7 +59,7 @@ trait RestActionCategoryEngine[Category, Key, Resource, Response] {
       response: RestResponse[Response]): Result
 }
 
-object RestActionCategoryEngine extends PlayJsonRestActionCategoryEngine
+object RestActionCategoryEngine extends RestActionCategoryEngine2 // Courier-centric engines
 
 /**
  * Define the mappings between category engines.

--- a/naptime/src/main/scala/org/coursera/naptime/actions/RestActionCategoryEngine2.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/actions/RestActionCategoryEngine2.scala
@@ -57,11 +57,13 @@ import org.coursera.naptime.model.Keyed
 
 import scala.collection.JavaConversions._
 
+object RestActionCategoryEngine2 extends RestActionCategoryEngine2
+
 /**
  * 2nd generation engines with Pegasus DataMaps at the core. To use, import them at the top of your
  * file.
  */
-object RestActionCategoryEngine2 {
+trait RestActionCategoryEngine2 {
 
   private[this] def mkOkResponse[T](r: RestResponse[T])(fn: Ok[T] => Result) = {
     r match {

--- a/naptime/src/test/scala/org/coursera/naptime/actionCategoriesTests.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/actionCategoriesTests.scala
@@ -3,6 +3,7 @@ package org.coursera.naptime
 import org.coursera.naptime.model.KeyFormat
 import org.coursera.naptime.model.Keyed
 import org.coursera.common.stringkey.StringKeyFormat
+import org.coursera.naptime.actions.PlayJsonRestActionCategoryEngine
 import org.coursera.naptime.actions.RestAction
 import org.coursera.naptime.actions.RestActionCategoryEngine
 import org.coursera.naptime.actions.util.Validators
@@ -227,7 +228,7 @@ class ETagRestActionCategoryEngineTest extends AssertionsForJUnit with ScalaFutu
     val result = "test result"
     val okResponse = Ok(result)
 
-    val etag = RestActionCategoryEngine.mkETagHeader(testPagination, okResponse, jsObject)
+    val etag = PlayJsonRestActionCategoryEngine.mkETagHeader(testPagination, okResponse, jsObject)
     assert(etag._1 === HeaderNames.ETAG)
     assertETagHeaderValueFormat(etag._2)
   }
@@ -240,7 +241,7 @@ class ETagRestActionCategoryEngineTest extends AssertionsForJUnit with ScalaFutu
     val pagination = RequestPagination(20, None, isDefault = true)
     val naptimeResponse = Ok(Keyed(1, TestResponse(foo = "bar"))).withETag(ETag("asdf"))
 
-    val engine = RestActionCategoryEngine.getActionCategoryEngine[Int, TestResponse](
+    val engine = PlayJsonRestActionCategoryEngine.getActionCategoryEngine[Int, TestResponse](
       TestResponse.writes, intKeyFormat)
 
     val response = engine.mkResponse(req, fields, QueryFields.empty, QueryIncludes.empty,

--- a/naptime/src/test/scala/org/coursera/naptime/router2/NestingCollectionResourceRouterTest.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/router2/NestingCollectionResourceRouterTest.scala
@@ -17,6 +17,7 @@
 package org.coursera.naptime.router2
 
 import org.coursera.common.stringkey.StringKeyFormat
+import org.coursera.naptime.actions.NaptimeSerializer.AnyWrites._
 import org.coursera.naptime.model.KeyFormat
 import org.coursera.naptime.actions.RestActionBuilder
 import org.coursera.naptime.access.HeaderAccessControl

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.1.8"
+version in ThisBuild := "0.2.0"


### PR DESCRIPTION
Engine2's have been tested in production @ Coursera, and
they seem to be behaving. Therefore, we're going to roll
forward and use Engine2's by default. (You can roll back
by importing the old PlayJson engines.)