### PR TITLE
Bugfix: Ensure datamap & contents are mutable.

### DIFF
--- a/naptime/src/main/scala/org/coursera/naptime/actions/NaptimeSerializer.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/actions/NaptimeSerializer.scala
@@ -79,7 +79,7 @@ object NaptimeSerializer {
               map.put(name, list)
               serializeList(a, list)
             case o: JsObject =>
-              val childMap = new DataMap(o.value.size)
+              val childMap = new DataMap(o.value.size) // TODO: verify Map.size is fast.
               map.put(name, childMap)
               serializeMap(o, childMap)
           }

--- a/naptime/src/main/scala/org/coursera/naptime/actions/RestActionCategoryEngine2.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/actions/RestActionCategoryEngine2.scala
@@ -47,7 +47,9 @@ import play.api.mvc.Result
 import play.api.mvc.Results
 import java.io.IOException
 
+import com.linkedin.data.ByteString
 import org.coursera.naptime.RequestIncludes
+import org.coursera.naptime.actions.util.DataMapUtils
 import org.coursera.naptime.model.KeyFormat
 import org.coursera.naptime.model.Keyed
 
@@ -117,6 +119,7 @@ object RestActionCategoryEngine2 {
       serializer: NaptimeSerializer[V],
       requestFields: RequestFields,
       fields: Fields[V]): RequestFields = {
+
     // Compute the set of field names provided by the Key type to avoid filtering them out in the
     // response serializer. (This is to maintain backwards compatibility with the legacy Rest
     // Engines.)
@@ -137,7 +140,7 @@ object RestActionCategoryEngine2 {
       val keyMap = NaptimeSerializer.PlayJson.serialize(key)
       // Insert all the value entries into the data map.
       for (elem <- valueDataMap.entrySet) {
-        dataMap.put(elem.getKey, elem.getValue)
+        dataMap.put(elem.getKey, DataMapUtils.ensureMutable(elem.getValue))
       }
       wireConverter.foreach { converter =>
         converter.convertUnionToTypedDefinitionInPlace(dataMap)

--- a/naptime/src/main/scala/org/coursera/naptime/actions/util/DataMapUtils.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/actions/util/DataMapUtils.scala
@@ -1,0 +1,46 @@
+package org.coursera.naptime.actions.util
+
+import com.linkedin.data.DataList
+import com.linkedin.data.DataMap
+
+/**
+ * Some utilities to ensure whole trees of DataMaps are mutable.
+ */
+object DataMapUtils {
+  // TODO: Profile for performance.
+  def ensureMutable(obj: AnyRef): AnyRef = {
+    obj match {
+      case list: DataList => ensureMutableList(list)
+      case map: DataMap => ensureMutableMap(map)
+      case _ => obj
+    }
+  }
+
+  def ensureMutableList(list: DataList): DataList = {
+    if (list.isMadeReadOnly) {
+      val mutableList = new DataList(list.size())
+      val iterator = list.iterator()
+      while (iterator.hasNext) {
+        val i = iterator.next()
+        mutableList.add(i)
+      }
+      mutableList
+    } else {
+      for (i <- 0 until list.size) {
+        list.set(i, ensureMutable(list.get(i)))
+      }
+      list
+    }
+  }
+
+  def ensureMutableMap(map: DataMap): DataMap = {
+    // TODO: check to see if we can skip doing a pessimistic copy.
+    val mutableMap = new DataMap()
+    val iterator = map.entrySet().iterator()
+    while (iterator.hasNext) {
+      val entry = iterator.next()
+      mutableMap.put(entry.getKey, ensureMutable(entry.getValue))
+    }
+    mutableMap
+  }
+}

--- a/naptime/src/test/pegasus/org/coursera/naptime/actions/CoursePlatform.courier
+++ b/naptime/src/test/pegasus/org/coursera/naptime/actions/CoursePlatform.courier
@@ -1,0 +1,6 @@
+namespace org.coursera.naptime.actions
+
+enum CoursePlatform {
+  OldPlatform
+  NewPlatform
+}

--- a/naptime/src/test/pegasus/org/coursera/naptime/actions/Domain.courier
+++ b/naptime/src/test/pegasus/org/coursera/naptime/actions/Domain.courier
@@ -1,0 +1,6 @@
+namespace org.coursera.naptime.actions
+
+record Domain {
+  domain: DomainId
+  subdomain: SubDomainId?
+}

--- a/naptime/src/test/pegasus/org/coursera/naptime/actions/DomainId.courier
+++ b/naptime/src/test/pegasus/org/coursera/naptime/actions/DomainId.courier
@@ -1,0 +1,7 @@
+namespace org.coursera.naptime.actions
+
+/**
+ * Id for Domain
+ */
+@scala.class = "org.coursera.naptime.actions.DomainId"
+typeref DomainId = Slug

--- a/naptime/src/test/pegasus/org/coursera/naptime/actions/ExpandedCourse.courier
+++ b/naptime/src/test/pegasus/org/coursera/naptime/actions/ExpandedCourse.courier
@@ -1,0 +1,8 @@
+namespace org.coursera.naptime.actions
+
+record ExpandedCourse {
+  name: string
+  description: string
+  platform: CoursePlatform = "OldPlatform"
+  domains: array[Domain]
+}

--- a/naptime/src/test/pegasus/org/coursera/naptime/actions/Slug.courier
+++ b/naptime/src/test/pegasus/org/coursera/naptime/actions/Slug.courier
@@ -1,0 +1,15 @@
+namespace org.coursera.naptime.actions
+
+/**
+ * It is a human-readable identifier such as &quot;machine-learning&quot;, which is suitable for URL.
+ * Previously it has been mostly used for ondemand course. This is now being shared for other purposes.
+ * It has arbitrary restrictions on the slug. Changing its validation may cause ondemand course to have
+ * unexpected behavior
+ */
+@scala.class = "org.coursera.naptime.actions.Slug"
+@scala.validate = {
+  "regex": {
+    "regex": "[a-z0-9-]{1,80}"
+  }
+}
+typeref Slug = string

--- a/naptime/src/test/pegasus/org/coursera/naptime/actions/SubDomainId.courier
+++ b/naptime/src/test/pegasus/org/coursera/naptime/actions/SubDomainId.courier
@@ -1,0 +1,4 @@
+namespace org.coursera.naptime.actions
+
+@scala.class = "org.coursera.naptime.actions.SubdomainId"
+typeref SubDomainId = Slug

--- a/naptime/src/test/scala/org/coursera/naptime/actions/DomainId.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/actions/DomainId.scala
@@ -1,0 +1,15 @@
+package org.coursera.naptime.actions
+
+import org.coursera.common.stringkey.StringKeyFormat
+import org.coursera.naptime.model.KeyFormat
+
+case class DomainId(id: Slug)
+
+object DomainId {
+
+  implicit val stringKeyFormat: StringKeyFormat[DomainId] =
+    StringKeyFormat.caseClassFormat(apply, unapply)
+
+  implicit val keyFormat: KeyFormat[DomainId] = KeyFormat.idAsStringOnly
+
+}

--- a/naptime/src/test/scala/org/coursera/naptime/actions/Slug.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/actions/Slug.scala
@@ -1,0 +1,78 @@
+package org.coursera.naptime.actions
+
+
+import org.coursera.common.jsonformat.JsonFormats
+import org.coursera.common.stringkey.StringKeyFormat
+import play.api.libs.json.Format
+
+import scala.annotation.tailrec
+
+/**
+ * A somewhat-human-readable identifier. This will generally look like "what-is-machine-learning".
+ * This is suitable for URLs, etc. which require unique but readable identifiers that may be
+ * (very infrequently) changed.
+ *
+ *
+ * This is a Coursera-defined notion of slug and you should not expect it to match any external standard.
+ * Do not change the validation because lots of existing opencourse data expects the existing validation.
+ */
+case class Slug(string: String) {
+  require(
+    Slug.ValidRegex.pattern.matcher(string).matches,
+    s"Slug not allowed: $string")
+}
+
+object Slug {
+
+  implicit val stringKeyFormat: StringKeyFormat[Slug] =
+    StringKeyFormat.delegateFormat[Slug, String](
+      key => try {
+        Some(Slug(key))
+      } catch {
+        case e: IllegalArgumentException => None
+      }, _.string)
+
+  implicit val format: Format[Slug] = JsonFormats.stringKeyFormat
+
+  private val ValidRegex = """[a-z0-9\-]+""".r
+  private val MaxSlugLength = 80
+
+  /**
+   * Method to create a URL friendly slug string from a given input string
+   * Most of the logic for this has been copied from Play framework's Java
+   * extension implementation here:
+   * https://github.com/playframework/play1/blob/b835b790c795bddd7d41ac6a4a7a1eb6922fab2f/framework/src/play/templates/JavaExtensions.java#L368.
+   */
+  def slugify(input: String): Slug = {
+    // Convert the unicode input to ascii. This ensures that non Latin based languages have
+    // reasonable conversions.
+    val slugString = input //Junidecode.unidecode(input)
+      .replaceAll("([a-z])'s([^a-z])", "$1s$2") // Convert apostrophes.
+      .replaceAll("[^a-zA-Z0-9]", "-")  // Convert all non alphanumeric characters with hyphen.
+      .replaceAll("-{2,}", "-")  // Collapse multiple hyphens into one
+      .stripPrefix("-")
+      .stripSuffix("-")
+      .toLowerCase
+
+    val words = slugString.split("-").toList
+    if (words.head.length() > MaxSlugLength) {
+      Slug(words.head.take(MaxSlugLength))
+    } else {
+      @tailrec
+      def buildTruncatedSlug(currentWord: String, wordList: List[String]): String = {
+        wordList match {
+          case firstWord :: tail =>
+            val candidate = currentWord + "-" + firstWord
+            if (candidate.length() > MaxSlugLength) {
+              currentWord
+            } else {
+              buildTruncatedSlug(candidate, tail)
+            }
+          case Nil => currentWord
+        }
+      }
+      Slug(buildTruncatedSlug(words.head, words.drop(1)))
+    }
+  }
+
+}

--- a/naptime/src/test/scala/org/coursera/naptime/actions/SubDomainId.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/actions/SubDomainId.scala
@@ -1,0 +1,15 @@
+package org.coursera.naptime.actions
+
+import org.coursera.common.stringkey.StringKeyFormat
+import org.coursera.naptime.model.KeyFormat
+
+case class SubdomainId(id: Slug)
+
+object SubdomainId {
+
+  implicit val stringKeyFormat: StringKeyFormat[SubdomainId] =
+    StringKeyFormat.caseClassFormat(apply, unapply)
+
+  implicit val keyFormat: KeyFormat[SubdomainId] = KeyFormat.idAsStringOnly
+
+}

--- a/naptime/src/test/scala/org/coursera/naptime/actions/util/DataMapUtilsTests.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/actions/util/DataMapUtilsTests.scala
@@ -1,0 +1,85 @@
+package org.coursera.naptime.actions.util
+
+import com.linkedin.data.DataList
+import com.linkedin.data.DataMap
+import org.junit.Test
+import org.scalatest.junit.AssertionsForJUnit
+
+class DataMapUtilsTests extends AssertionsForJUnit {
+
+  @Test
+  def mutableMapUnchanged(): Unit = {
+    val myMap = new DataMap()
+    assert(myMap == DataMapUtils.ensureMutable(myMap))
+  }
+
+  @Test
+  def mutableNonEmptyMapUnchanged(): Unit = {
+    val myMap = new DataMap()
+    myMap.put("1", new Integer(1))
+    myMap.put("2", new Integer(2))
+    assert(myMap == DataMapUtils.ensureMutable(myMap))
+  }
+
+  @Test
+  def nonComplexUnchanged(): Unit = {
+    val myString = "myString"
+    assert(myString eq DataMapUtils.ensureMutable(myString))
+
+    val myInt = new Integer(2)
+    assert(myInt eq DataMapUtils.ensureMutable(myInt))
+
+  }
+
+  @Test
+  def mutableListUnchanged(): Unit = {
+    val myList = new DataList()
+    assert(myList eq DataMapUtils.ensureMutable(myList))
+  }
+
+  @Test
+  def mutableNonEmptyListUnchanged(): Unit = {
+    val myList = new DataList()
+    myList.add("1")
+    myList.add(new Integer(2))
+    assert(myList eq DataMapUtils.ensureMutable(myList))
+  }
+
+  @Test
+  def ensureImmutableListIsMutable(): Unit = {
+    val myList = new DataList()
+    myList.setReadOnly()
+    val mutableList = DataMapUtils.ensureMutable(myList)
+    assert(!mutableList.asInstanceOf[DataList].isMadeReadOnly)
+  }
+
+  @Test
+  def ensureNestedImmutableIsMadeMutable(): Unit = {
+    val immutable = new DataMap()
+    immutable.put("1", "one")
+    immutable.setReadOnly()
+
+    val wrappingList = new DataList()
+    wrappingList.add(immutable)
+
+    val wrappingMap = new DataMap()
+    wrappingMap.put("list", wrappingList)
+
+    val fullyMutable = DataMapUtils.ensureMutable(wrappingMap)
+    assert(fullyMutable.isInstanceOf[DataMap])
+    assert(!fullyMutable.asInstanceOf[DataMap].isMadeReadOnly)
+    assert(wrappingMap == fullyMutable)
+
+    val mutableList = fullyMutable.asInstanceOf[DataMap].get("list")
+    assert(mutableList.isInstanceOf[DataList])
+    assert(!mutableList.asInstanceOf[DataList].isMadeReadOnly)
+    assert(mutableList == wrappingList)
+    assert(mutableList eq wrappingList)
+
+    val innerMap = mutableList.asInstanceOf[DataList].get(0)
+    assert(innerMap.isInstanceOf[DataMap])
+    assert(innerMap == immutable)
+    assert(!innerMap.asInstanceOf[DataMap].isMadeReadOnly)
+    assert(innerMap.asInstanceOf[DataMap].get("1") == "one")
+  }
+}

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.1.0"
+version in ThisBuild := "0.1.1"


### PR DESCRIPTION
We encountered an exception in production @ Coursera regarding
a problem with immutable components of the data maps. Because we
do deep processing, we need to ensure that everything is mutable.
This commit recursively checks the tree and ensures that it is
mutable.

Exception found in production @ Coursera:

java.lang.UnsupportedOperationException: Cannot mutate a read-only map
        at com.linkedin.data.collections.CheckedMap.checkMutability(CheckedMap.java:298) ~[com.linkedin.pegasus.data-3.1.1.jar:na]
        at com.linkedin.data.collections.CheckedMap.clear(CheckedMap.java:158) ~[com.linkedin.pegasus.data-3.1.1.jar:na]
        at org.coursera.pegasus.TypedDefinitionHandler.convertFromPegasus(TypedDefinitionHandler.java:69) ~[org.coursera.naptime.naptime-pegasus-0.1.0.jar:0.1.0]
        at org.coursera.pegasus.TypedDefinitionDataCoercer$TypedDefinitionFromPegasusVisitor.visit(TypedDefinitionDataCoercer.java:79) ~[org.coursera.naptime.naptime-pegasus-0.1.0.jar:0.1.0]
        at org.coursera.pegasus.TypedDefinitionDataCoercer.visitUnionTyperefs(TypedDefinitionDataCoercer.java:207) ~[org.coursera.naptime.naptime-pegasus-0.1.0.jar:0.1.0]
        at org.coursera.pegasus.TypedDefinitionDataCoercer.visitUnionTyperefs(TypedDefinitionDataCoercer.java:186) ~[org.coursera.naptime.naptime-pegasus-0.1.0.jar:0.1.0]
        at org.coursera.pegasus.TypedDefinitionDataCoercer.visitUnionTyperefs(TypedDefinitionDataCoercer.java:228) ~[org.coursera.naptime.naptime-pegasus-0.1.0.jar:0.1.0]
        at org.coursera.pegasus.TypedDefinitionDataCoercer.visitUnionTyperefs(TypedDefinitionDataCoercer.java:186) ~[org.coursera.naptime.naptime-pegasus-0.1.0.jar:0.1.0]
        at org.coursera.pegasus.TypedDefinitionDataCoercer.convertUnionToTypedDefinitionInPlace(TypedDefinitionDataCoercer.java:116) ~[org.coursera.naptime.naptime-pegasus-0.1.0.jar:0.1.0]
        at org.coursera.naptime.actions.RestActionCategoryEngine2$$anonfun$serializeCollection$1$$anonfun$apply$4.apply(RestActionCategoryEngine2.scala:143) ~[org.coursera.naptime.naptime_2.11-0.1.0.jar:0.1.0]
        at org.coursera.naptime.actions.RestActionCategoryEngine2$$anonfun$serializeCollection$1$$anonfun$apply$4.apply(RestActionCategoryEngine2.scala:142) ~[org.coursera.naptime.naptime_2.11-0.1.0.jar:0.1.0]
        at scala.Option.foreach(Option.scala:257) ~[org.scala-lang.scala-library-2.11.7.jar:na]
        at org.coursera.naptime.actions.RestActionCategoryEngine2$$anonfun$serializeCollection$1.apply(RestActionCategoryEngine2.scala:142) ~[org.coursera.naptime.naptime_2.11-0.1.0.jar:0.1.0]
        at org.coursera.naptime.actions.RestActionCategoryEngine2$$anonfun$serializeCollection$1.apply(RestActionCategoryEngine2.scala:130) ~[org.coursera.naptime.naptime_2.11-0.1.0.jar:0.1.0]
        at scala.collection.immutable.List.foreach(List.scala:381) ~[org.scala-lang.scala-library-2.11.7.jar:na]
        at org.coursera.naptime.actions.RestActionCategoryEngine2$.serializeCollection(RestActionCategoryEngine2.scala:130) ~[org.coursera.naptime.naptime_2.11-0.1.0.jar:0.1.0]
        at org.coursera.naptime.actions.RestActionCategoryEngine2$.org$coursera$naptime$actions$RestActionCategoryEngine2$$buildResponse(RestActionCategoryEngine2.scala:243) ~[org.coursera.naptime.naptime_2.11-0.1.0.jar:0.1.0]
        at org.coursera.naptime.actions.RestActionCategoryEngine2$$anon$6$$anonfun$mkResponse$6.apply(RestActionCategoryEngine2.scala:403) ~[org.coursera.naptime.naptime_2.11-0.1.0.jar:0.1.0]
        at org.coursera.naptime.actions.RestActionCategoryEngine2$$anon$6$$anonfun$mkResponse$6.apply(RestActionCategoryEngine2.scala:402) ~[org.coursera.naptime.naptime_2.11-0.1.0.jar:0.1.0]
        at org.coursera.naptime.actions.RestActionCategoryEngine2$.org$coursera$naptime$actions$RestActionCategoryEngine2$$mkOkResponse(RestActionCategoryEngine2.scala:64) ~[org.coursera.naptime.naptime_2.11-0.1.0.jar:0.1.0]
        at org.coursera.naptime.actions.RestActionCategoryEngine2$$anon$6.mkResponse(RestActionCategoryEngine2.scala:402) ~[org.coursera.naptime.naptime_2.11-0.1.0.jar:0.1.0]
        at org.coursera.naptime.actions.RestAction$$anonfun$apply$3$$anonfun$apply$7$$anonfun$apply$9$$anonfun$1$$anonfun$apply$10$$anonfun$org$coursera$naptime$actions$RestAction$class$$anonfun$$anonfun$$anonfun$$anonfun$$anonfun$$run$1$2.apply(RestAction.scala:115) ~[org.coursera.naptime.naptime_2.11-0.1.0.jar:0.1.0]
        at org.coursera.naptime.actions.RestAction$$anonfun$apply$3$$anonfun$apply$7$$anonfun$apply$9$$anonfun$1$$anonfun$apply$10$$anonfun$org$coursera$naptime$actions$RestAction$class$$anonfun$$anonfun$$anonfun$$anonfun$$anonfun$$run$1$2.apply(RestAction.scala:114) ~[org.coursera.naptime.naptime_2.11-0.1.0.jar:0.1.0]
        at scala.util.Success$$anonfun$map$1.apply(Try.scala:237) ~[org.scala-lang.scala-library-2.11.7.jar:na]
        at scala.util.Try$.apply(Try.scala:192) ~[org.scala-lang.scala-library-2.11.7.jar:na]
        at scala.util.Success.map(Try.scala:237) ~[org.scala-lang.scala-library-2.11.7.jar:na]
        ... 14 common frames omitted