### PR TITLE
Engine2: Don't elide multi-hop includes.

### DIFF
--- a/naptime/src/main/scala/org/coursera/naptime/models.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/models.scala
@@ -262,8 +262,6 @@ sealed case class Fields[T](
     JsObject(filtered)
   }
 
-  private[naptime] val inverseRelations = relations.map(_.swap)
-
   private[naptime] def computeFields(rh: RequestHeader): Try[RequestFields] = {
     // Try the header override first
     rh.headers.get(Fields.FIELDS_HEADER).map { fieldsHeader =>

--- a/naptime/src/test/pegasus/org/coursera/naptime/actions/ExpandedCourse.courier
+++ b/naptime/src/test/pegasus/org/coursera/naptime/actions/ExpandedCourse.courier
@@ -6,4 +6,5 @@ record ExpandedCourse {
   platform: CoursePlatform = "OldPlatform"
   domains: array[Domain]
   courseQnAs: array[CourseQnA]
+  instructorIds: array[InstructorId]
 }

--- a/naptime/src/test/pegasus/org/coursera/naptime/actions/Instructor.courier
+++ b/naptime/src/test/pegasus/org/coursera/naptime/actions/Instructor.courier
@@ -1,0 +1,12 @@
+namespace org.coursera.naptime.actions
+
+/**
+ * An instructor teaches a course.
+ *
+ * Note: this is a very incomplete representation.
+ */
+record Instructor {
+  name: string
+  bio: TranslatableString?
+  partner: PartnerId
+}

--- a/naptime/src/test/pegasus/org/coursera/naptime/actions/InstructorId.courier
+++ b/naptime/src/test/pegasus/org/coursera/naptime/actions/InstructorId.courier
@@ -1,0 +1,8 @@
+namespace org.coursera.naptime.actions
+
+/**
+ * Partners are identified by a long id
+ *
+ * TODO: add validation (e.g. min)
+ */
+typeref InstructorId = long

--- a/naptime/src/test/pegasus/org/coursera/naptime/actions/Partner.courier
+++ b/naptime/src/test/pegasus/org/coursera/naptime/actions/Partner.courier
@@ -1,0 +1,29 @@
+namespace org.coursera.naptime.actions
+
+/**
+ * A partner to our hypothetical catalog of courses.
+ */
+record Partner {
+  /**
+   * A human readable name corresponding to the partner.
+   *
+   * Note: because some partners may have different names for different
+   * languages, we mark the name as a TranslatableString.
+   */
+  name: TranslatableString
+
+  /**
+   * An alternate "id" for the name. (Used in URLs)
+   */
+  slug: Slug
+
+  /**
+   * Biographical information about the partner.
+   */
+  description: TranslatableString?
+
+  /**
+   * The instructors associated with this partner.
+   */
+  instructorIds: array[InstructorId] = []
+}

--- a/naptime/src/test/pegasus/org/coursera/naptime/actions/PartnerId.courier
+++ b/naptime/src/test/pegasus/org/coursera/naptime/actions/PartnerId.courier
@@ -1,0 +1,9 @@
+namespace org.coursera.naptime.actions
+
+/**
+ * Partners are identified by a UUID type string.
+ *
+ * TODO: typeref a UUID instead of a generic string.
+ * TODO: add validation on the type (including length limits, allowed characters, etc.)
+ */
+typeref PartnerId = string

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.1.2"
+version in ThisBuild := "0.1.3"


### PR DESCRIPTION
If a request to resource A requests included resource B, and related to B
also includes resource C, we need to include the lists for A, B, and C.
Previously we only included the "first-hop" related includes. Now, we
include all transitively included related resources.

This bug was discovered in the production rollout of Engine2's. I was
able to reproduce it with a unit test case, implemented the fix, and
confirmed the new test case passes.