### PR TITLE
Make flaky test more reliable.

### DIFF
--- a/naptime/src/test/scala/org/coursera/naptime/actionCategoriesTests.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/actionCategoriesTests.scala
@@ -107,6 +107,8 @@ object RestActionCategoryEngineTest {
 class RestActionCategoryEngineTest extends AssertionsForJUnit with ScalaFutures {
   import RestActionCategoryEngineTest._
 
+  override def spanScaleFactor: Double = 10
+
   @Test
   def get1(): Unit = {
     testEmptyBody(SampleResource.get1(1))


### PR DESCRIPTION
It appears as if we regularly see timeouts when running asynchronous
tests in travis-ci. In order to make it more reliable, we should
scale the timeouts a bit.