### PR TITLE
[Engine2] Serialize Facets Correctly

### DIFF
--- a/naptime/src/main/scala/org/coursera/naptime/actions/RestActionCategoryEngine2.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/actions/RestActionCategoryEngine2.scala
@@ -229,7 +229,7 @@ object RestActionCategoryEngine2 {
       val facetArray = new DataList()
       val facetMap = new DataMap()
       facetMap.put("facetEntries", facetArray)
-      dataMap.put(key, facetArray)
+      dataMap.put(key, facetMap)
       value.fieldCardinality.foreach { cardinality =>
         facetMap.put("fieldCardinality", new java.lang.Long(cardinality))
       }


### PR DESCRIPTION
The new engine2 implementation had a bug in serialization
when serializing facets. This commit fixes the bug, and
adds a unit test to ensure there are no regressions in the
future.