### PR TITLE
[Engine2] Add links for metaprogramming.

### DIFF
--- a/naptime/src/main/scala/org/coursera/naptime/models.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/models.scala
@@ -16,6 +16,7 @@
 
 package org.coursera.naptime
 
+import com.linkedin.data.DataMap
 import org.coursera.naptime.QueryStringParser.NaptimeParseError
 import play.api.http.Status
 import play.api.i18n.Lang
@@ -26,6 +27,7 @@ import play.api.mvc.RequestHeader
 
 import scala.annotation.implicitNotFound
 import play.api.libs.json.OFormat
+
 import scala.annotation.tailrec
 import scala.collection.immutable
 import scala.util.Failure
@@ -257,9 +259,26 @@ sealed case class Fields[T](
     field -> JsString(resourceName.identifier)
   }.toList
 
+  /**
+   * Generates the JsObject that goes inside the `links` field in responses for
+   * Play-Json engines.
+   * @param fieldsToInclude
+   * @return
+   */
   private[naptime] def makeMetaRelationsMap(fieldsToInclude: Set[String]): JsObject = {
     val filtered = relationsInJson.filter(field => fieldsToInclude.contains(field._1))
     JsObject(filtered)
+  }
+
+  private[naptime] def makeLinksRelationsMap(
+      links: DataMap,
+      name: String,
+      includes: RequestIncludes): Unit = {
+    val relationMap = new DataMap()
+    links.put(name, relationMap)
+    relations.foreach { case (field, resourceName) =>
+      relationMap.put(field, resourceName.identifier)
+    }
   }
 
   private[naptime] def computeFields(rh: RequestHeader): Try[RequestFields] = {

--- a/naptime/src/test/scala/org/coursera/naptime/actions/RestActionCategoryEngine2Test.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/actions/RestActionCategoryEngine2Test.scala
@@ -684,6 +684,40 @@ class RestActionCategoryEngine2Test extends AssertionsForJUnit with ScalaFutures
       "paging" -> Json.obj(),
       "linked" -> Json.obj())
     assert(expected3 === content3)
+
+    val wireResponse4 = engine.mkResponse(
+      request = FakeRequest(),
+      resourceFields = coursesFields,
+      requestFields = queryFields,
+      requestIncludes = queryIncludes.copy(fields = queryIncludes.fields + "_links"),
+      pagination = RequestPagination(limit = 10, start = None, isDefault = true),
+      response = response)
+    val content4: JsValue = Helpers.contentAsJson(Future.successful(wireResponse4))
+    val expected4 = Json.obj(
+      "elements" -> Json.arr(
+        Json.obj(
+          "id" -> "my-course-id",
+          "name" -> "my best course",
+          "description" -> "My favorite course",
+          "instructorIds" -> Json.arr(3L))),
+      "paging" -> Json.obj(),
+      "linked" -> Json.obj(
+        "partners.v1" -> Json.arr(
+          Json.obj(
+            "id" -> "uuid-abc_123",
+            "name" -> "School of awesome",
+            "slug" -> "school-of-awesome")),
+        "instructors.v1" -> Json.arr(
+          Json.obj(
+            "id" -> 3L,
+            "name" -> "Prof Example"))),
+      "links" -> Json.obj(
+        "elements" -> Json.obj(
+          "instructorIds" -> "instructors.v1"),
+        "instructors.v1" -> Json.obj(
+          "partner" -> "partners.v1"),
+        "partners.v1" -> Json.obj()))
+    assert(expected4 === content4)
   }
 
 


### PR DESCRIPTION
A requester can request to include the links metadata
which will provide some information about how the
relations relate to each other.