### PR TITLE
Add strong ETags for backwards-compatibility

### DIFF
--- a/naptime/src/main/scala/org/coursera/naptime/ETag.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/ETag.scala
@@ -20,28 +20,69 @@ import org.coursera.common.stringkey.StringKeyFormat
 import org.coursera.common.stringkey.StringKeyFormat.Implicits.OrFormat
 
 /**
- * Note: Naptime always uses weak validators because the framework does not guarantee byte-equality
- * between responses.
- *
- * @param weakValidator tag without surrounding `"`s; these are added by Naptime
+ * Resources should always use weak validators because Naptime does not guarantee byte-equality
+ * between responses. See [[ETag.Weak]].
  */
-case class ETag(weakValidator: String) {
-  // See https://tools.ietf.org/html/rfc7232#section-2.3.
-  require(
-    !weakValidator.contains("\"\\"),
-    """Characters '"' and '\' not allowed in ETags""")
-}
+sealed trait ETag
 
 object ETag {
 
-  private[this] val weakValidatorRegex = "W/\"(.*)\"".r
+  def apply(weakValidator: String): Weak = Weak(weakValidator)
 
   implicit val stringKeyFormat: StringKeyFormat[ETag] = {
-    def from(s: String): Option[ETag] = s match {
-      case weakValidatorRegex(tag) => Some(ETag(tag))
-      case _ => None
+    StringKeyFormat.unimplementedFormat[ETag]
+      .orFormat[Weak]
+      .orFormat[Strong]
+  }
+
+  /**
+   * @param weakValidator tag without surrounding `"`s; these are added by Naptime
+   */
+  case class Weak(weakValidator: String) extends ETag {
+    // See https://tools.ietf.org/html/rfc7232#section-2.3.
+    require(
+      !weakValidator.contains("\"\\"),
+      """Characters '"' and '\' not allowed in ETags""")
+  }
+
+  object Weak {
+
+    private[this] val weakValidatorRegex = "W/\"(.*)\"".r
+
+    implicit val stringKeyFormat: StringKeyFormat[Weak] = {
+      def from(s: String): Option[Weak] = s match {
+        case weakValidatorRegex(tag) => Some(Weak(tag))
+        case _ => None
+      }
+      StringKeyFormat.delegateFormat(from, weak => s"""W/"${weak.weakValidator}"""")
     }
-    StringKeyFormat.delegateFormat(from, eTag => s"""W/"${eTag.weakValidator}"""")
+
+  }
+
+  /**
+   * @param strongValidator tag without surrounding `"`s; these are added by Naptime
+   */
+  @deprecated(message = "Use weak validators; see `ETag`'s Scaladoc", since = "0.1.6")
+  case class Strong(strongValidator: String) extends ETag {
+    // See https://tools.ietf.org/html/rfc7232#section-2.3.
+    require(
+      !strongValidator.contains("\"\\"),
+      """Characters '"' and '\' not allowed in ETags""")
+  }
+
+  object Strong {
+
+    private[this] val strongValidatorRegex = "\"(.*)\"".r
+
+    implicit val stringKeyFormat: StringKeyFormat[Strong] = {
+      def from(s: String): Option[Strong] = s match {
+        case strongValidatorRegex(tag) => Some(Strong(tag))
+        case _ => None
+      }
+      StringKeyFormat.delegateFormat(from, strong => s""""${strong.strongValidator}"""")
+    }
+
   }
 
 }
+

--- a/naptime/src/test/scala/org/coursera/naptime/ETagTest.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/ETagTest.scala
@@ -23,18 +23,31 @@ import org.scalatest.junit.AssertionsForJUnit
 class ETagTest extends AssertionsForJUnit {
 
   @Test
-  def serialization(): Unit = {
-    assertResult("W/\"abc\"")(StringKey(ETag("abc")).key)
+  def weakSerialization(): Unit = {
+    assertResult("W/\"abc\"")(StringKey(ETag.Weak("abc")).key)
+    assertResult("W/\"abc\"")(StringKey(ETag.Weak("abc"): ETag).key)
   }
 
   @Test
-  def deserialization(): Unit = {
-    assertResult(StringKey("W/\"abc\"").asOpt[ETag])(Some(ETag("abc")))
+  def weakDeserialization(): Unit = {
+    val stringKey = StringKey("W/\"abc\"")
+    assertResult(stringKey.asOpt[ETag.Weak])(Some(ETag.Weak("abc")))
+    assertResult(stringKey.asOpt[ETag])(Some(ETag.Weak("abc")))
+    assertResult(stringKey.asOpt[ETag.Strong])(None)
   }
 
   @Test
-  def deserializationRejectStrong(): Unit = {
-    assertResult(StringKey("\"abc\"").asOpt[ETag])(None)
+  def strongSerialization(): Unit = {
+    assertResult("\"abc\"")(StringKey(ETag.Strong("abc")).key)
+    assertResult("\"abc\"")(StringKey(ETag.Strong("abc"): ETag).key)
+  }
+
+  @Test
+  def strongDeserialization(): Unit = {
+    val stringKey = StringKey("\"abc\"")
+    assertResult(stringKey.asOpt[ETag.Strong])(Some(ETag.Strong("abc")))
+    assertResult(stringKey.asOpt[ETag])(Some(ETag.Strong("abc")))
+    assertResult(stringKey.asOpt[ETag.Weak])(None)
   }
 
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.1.6"
+version in ThisBuild := "0.1.7"


### PR DESCRIPTION
@saeta 

I've marked them as deprecated already because they're not actually correct to use and we should remove them as soon as we fix the few existing APIs.