### PR TITLE
Introduce HTTP-independent `AccessControl`

### DIFF
--- a/naptime-testing/src/main/scala/org/coursera/naptime/actions/RestActionTester.scala
+++ b/naptime-testing/src/main/scala/org/coursera/naptime/actions/RestActionTester.scala
@@ -43,7 +43,7 @@ trait RestActionTester { this: ScalaFutures =>
     def testAction(ctx: RestContext[AuthType, BodyType]): RestResponse[ResponseType] = {
       import play.api.libs.concurrent.Execution.Implicits.defaultContext
 
-      val updatedAuthEither = action.restAuth.check(ctx.auth)
+      val updatedAuthEither = action.restAuth.simulateAuthentication(ctx.auth)
 
       updatedAuthEither match {
         case Left(error) => RestError(error)

--- a/naptime/src/main/scala/org/coursera/naptime/access/AccessControl.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/access/AccessControl.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2016 Coursera Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.coursera.naptime.access
+
+import org.coursera.naptime.NaptimeActionException
+
+/**
+ * Control access to an API using Naptime's DSL.
+ *
+ * Implementation note: This access control abstraction is independent of whether requests arrive
+ * via HTTP or other means; until Naptime supports those other means, [[HeaderAccessControl]] is
+ * the only access control type. When that's supported, this trait will likely have more methods
+ * that make it more directly useful.
+ *
+ * @tparam A structured authentication result which is available to the API implementation after
+ *           access control is successful
+ */
+trait AccessControl[A] {
+
+  /**
+   * Used for exercising access control configurations in resource tests.
+   */
+  private[naptime] def check(authInfo: A): Either[NaptimeActionException, A]
+
+}

--- a/naptime/src/main/scala/org/coursera/naptime/access/AccessControl.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/access/AccessControl.scala
@@ -36,6 +36,6 @@ trait AccessControl[A] {
    * the authentication process (since that often involves data fetching, and should be unit tested
    * separately from resources).
    */
-  private[naptime] def simulateAuthentication(authInfo: A): Either[NaptimeActionException, A]
+  private[naptime] def simulateAuthentication(authentication: A): Either[NaptimeActionException, A]
 
 }

--- a/naptime/src/main/scala/org/coursera/naptime/access/AccessControl.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/access/AccessControl.scala
@@ -32,8 +32,10 @@ import org.coursera.naptime.NaptimeActionException
 trait AccessControl[A] {
 
   /**
-   * Used for exercising access control configurations in resource tests.
+   * Used for exercising access control configurations in resource tests. Simulates the result of
+   * the authentication process (since that often involves data fetching, and should be unit tested
+   * separately from resources).
    */
-  private[naptime] def check(authInfo: A): Either[NaptimeActionException, A]
+  private[naptime] def simulateAuthentication(authInfo: A): Either[NaptimeActionException, A]
 
 }

--- a/naptime/src/main/scala/org/coursera/naptime/access/HeaderAccessControl.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/access/HeaderAccessControl.scala
@@ -16,7 +16,6 @@
 
 package org.coursera.naptime.access
 
-import org.coursera.naptime.NaptimeActionException
 import org.coursera.naptime.access.authenticator.Authenticator
 import org.coursera.naptime.access.authenticator.Decorator
 import org.coursera.naptime.access.authenticator.HeaderAuthenticationParser
@@ -26,9 +25,6 @@ import org.coursera.naptime.access.combiner.And
 import org.coursera.naptime.access.combiner.AnyOf
 import org.coursera.naptime.access.combiner.EitherOf
 import play.api.mvc.RequestHeader
-
-import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
 
 /**
  * Control access to an API based on the [[RequestHeader]].
@@ -40,16 +36,7 @@ import scala.concurrent.Future
  * construction your [[HeaderAccessControl]] (using body parameters as necessary) and invoking
  * `runAndCheck` in your API body.
  */
-trait HeaderAccessControl[A] extends AccessControl[A] {
-
-  def runAndCheck(requestHeader: RequestHeader)(implicit ec: ExecutionContext): Future[A] =
-    run(requestHeader).map(_.left.map(throw _).merge)
-
-  def run(
-      requestHeader: RequestHeader)
-      (implicit ec: ExecutionContext): Future[Either[NaptimeActionException, A]]
-
-}
+trait HeaderAccessControl[A] extends AccessControl[RequestHeader, A]
 
 object HeaderAccessControl extends AnyOf with And with EitherOf {
 

--- a/naptime/src/main/scala/org/coursera/naptime/access/HeaderAccessControl.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/access/HeaderAccessControl.scala
@@ -40,7 +40,7 @@ import scala.concurrent.Future
  * construction your [[HeaderAccessControl]] (using body parameters as necessary) and invoking
  * `runAndCheck` in your API body.
  */
-trait HeaderAccessControl[A] {
+trait HeaderAccessControl[A] extends AccessControl[A] {
 
   def runAndCheck(requestHeader: RequestHeader)(implicit executionContext: ExecutionContext):
     Future[A] = run(requestHeader).map(_.left.map(throw _).merge)
@@ -49,10 +49,6 @@ trait HeaderAccessControl[A] {
       requestHeader: RequestHeader)
       (implicit executionContext: ExecutionContext): Future[Either[NaptimeActionException, A]]
 
-  /**
-   * Used for testing access control configurations in Naptime tests.
-   */
-  private[naptime] def check(authInfo: A): Either[NaptimeActionException, A]
 }
 
 object HeaderAccessControl extends AnyOf with And with EitherOf {

--- a/naptime/src/main/scala/org/coursera/naptime/access/HeaderAccessControl.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/access/HeaderAccessControl.scala
@@ -42,12 +42,12 @@ import scala.concurrent.Future
  */
 trait HeaderAccessControl[A] extends AccessControl[A] {
 
-  def runAndCheck(requestHeader: RequestHeader)(implicit executionContext: ExecutionContext):
-    Future[A] = run(requestHeader).map(_.left.map(throw _).merge)
+  def runAndCheck(requestHeader: RequestHeader)(implicit ec: ExecutionContext): Future[A] =
+    run(requestHeader).map(_.left.map(throw _).merge)
 
   def run(
       requestHeader: RequestHeader)
-      (implicit executionContext: ExecutionContext): Future[Either[NaptimeActionException, A]]
+      (implicit ec: ExecutionContext): Future[Either[NaptimeActionException, A]]
 
 }
 

--- a/naptime/src/main/scala/org/coursera/naptime/access/StructuredAccessControl.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/access/StructuredAccessControl.scala
@@ -41,18 +41,18 @@ case class StructuredAccessControl[A](
 
     Authenticator.authenticateAndRecover(authenticator, requestHeader).map { decoratedOption =>
       decoratedOption.map { either =>
-        either.right.flatMap { decorated =>
-          Authorizer.toResponse(authorizer.authorize(decorated), decorated)
-        }
+        either.right.flatMap(simulateAuthentication)
       }.getOrElse {
         StructuredAccessControl.missingResponse
       }
     }
   }
 
-  override private[naptime] def simulateAuthentication(authInfo: A): Either[NaptimeActionException, A] = {
-    Authorizer.toResponse(authorizer.authorize(authInfo), authInfo)
+  private[naptime] override def simulateAuthentication(authentication: A):
+    Either[NaptimeActionException, A] = {
+    Authorizer.toResponse(authorizer.authorize(authentication), authentication)
   }
+
 }
 
 object StructuredAccessControl {

--- a/naptime/src/main/scala/org/coursera/naptime/access/StructuredAccessControl.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/access/StructuredAccessControl.scala
@@ -50,7 +50,7 @@ case class StructuredAccessControl[A](
     }
   }
 
-  override private[naptime] def check(authInfo: A): Either[NaptimeActionException, A] = {
+  override private[naptime] def simulateAuthentication(authInfo: A): Either[NaptimeActionException, A] = {
     Authorizer.toResponse(authorizer.authorize(authInfo), authInfo)
   }
 }

--- a/naptime/src/main/scala/org/coursera/naptime/access/combiner/And.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/access/combiner/And.scala
@@ -56,8 +56,13 @@ private[access] trait And {
           }
         }
       }
-      override private[naptime] def simulateAuthentication(authInfo: (A, B)): Either[NaptimeActionException, (A, B)] = {
-        (controlA.simulateAuthentication(authInfo._1), controlB.simulateAuthentication(authInfo._2)) match {
+
+      override def simulateAuthentication(authentication: (A, B)):
+        Either[NaptimeActionException, (A, B)] = {
+        val results = Tuple2(
+          controlA.simulateAuthentication(authentication._1),
+          controlB.simulateAuthentication(authentication._2))
+        results match {
           case (Right(resultA), Right(resultB)) => Right((resultA, resultB))
           case (Left(err), _) => Left(err)
           case (_, Left(err)) => Left(err)
@@ -90,15 +95,20 @@ private[access] trait And {
             case (Right(authenticationA), Right(authenticationB), Right(authenticationC)) =>
               Right((authenticationA, authenticationB, authenticationC))
             case _ =>
-              List(resultA, resultB)
+              List(resultA, resultB, resultC)
                 .collectFirst { case Left(error) => Left(error) }
                 .head
           }
         }
       }
 
-      override private[naptime] def simulateAuthentication(authInfo: (A, B, C)): Either[NaptimeActionException, (A, B, C)] = {
-        (controlA.simulateAuthentication(authInfo._1), controlB.simulateAuthentication(authInfo._2), controlC.simulateAuthentication(authInfo._3)) match {
+      override private[naptime] def simulateAuthentication(authentication: (A, B, C)):
+        Either[NaptimeActionException, (A, B, C)] = {
+        val results = Tuple3(
+          controlA.simulateAuthentication(authentication._1),
+          controlB.simulateAuthentication(authentication._2),
+          controlC.simulateAuthentication(authentication._3))
+        results match {
           case (Right(a), Right(b), Right(c)) => Right((a, b, c))
           case (Left(err), _, _) => Left(err)
           case (_, Left(err), _) => Left(err)
@@ -107,4 +117,5 @@ private[access] trait And {
       }
     }
   }
+
 }

--- a/naptime/src/main/scala/org/coursera/naptime/access/combiner/And.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/access/combiner/And.scala
@@ -56,8 +56,8 @@ private[access] trait And {
           }
         }
       }
-      override private[naptime] def check(authInfo: (A, B)): Either[NaptimeActionException, (A, B)] = {
-        (controlA.check(authInfo._1), controlB.check(authInfo._2)) match {
+      override private[naptime] def simulateAuthentication(authInfo: (A, B)): Either[NaptimeActionException, (A, B)] = {
+        (controlA.simulateAuthentication(authInfo._1), controlB.simulateAuthentication(authInfo._2)) match {
           case (Right(resultA), Right(resultB)) => Right((resultA, resultB))
           case (Left(err), _) => Left(err)
           case (_, Left(err)) => Left(err)
@@ -97,8 +97,8 @@ private[access] trait And {
         }
       }
 
-      override private[naptime] def check(authInfo: (A, B, C)): Either[NaptimeActionException, (A, B, C)] = {
-        (controlA.check(authInfo._1), controlB.check(authInfo._2), controlC.check(authInfo._3)) match {
+      override private[naptime] def simulateAuthentication(authInfo: (A, B, C)): Either[NaptimeActionException, (A, B, C)] = {
+        (controlA.simulateAuthentication(authInfo._1), controlB.simulateAuthentication(authInfo._2), controlC.simulateAuthentication(authInfo._3)) match {
           case (Right(a), Right(b), Right(c)) => Right((a, b, c))
           case (Left(err), _, _) => Left(err)
           case (_, Left(err), _) => Left(err)

--- a/naptime/src/main/scala/org/coursera/naptime/access/combiner/AnyOf.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/access/combiner/AnyOf.scala
@@ -58,10 +58,11 @@ private[access] trait AnyOf {
         }
       }
 
-      override private[naptime] def simulateAuthentication(
-          authInfo: (Option[A], Option[B])): Either[NaptimeActionException, (Option[A], Option[B])] = {
-        val resultA = computeCheckResult(authInfo._1, controlA)
-        val resultB = computeCheckResult(authInfo._2, controlB)
+      override def simulateAuthentication(authentication: (Option[A], Option[B])):
+        Either[NaptimeActionException, (Option[A], Option[B])] = {
+
+        val resultA = simulateElement(authentication._1, controlA)
+        val resultB = simulateElement(authentication._2, controlB)
 
         (resultA, resultB) match {
           case (Left(errorA), Left(_)) => Left(errorA)
@@ -101,13 +102,12 @@ private[access] trait AnyOf {
       }
 
       override private[naptime] def simulateAuthentication(
-          authInfo: (Option[A], Option[B], Option[C])):
-          Either[NaptimeActionException, (Option[A], Option[B], Option[C])] = {
+          authentication: (Option[A], Option[B], Option[C])):
+        Either[NaptimeActionException, (Option[A], Option[B], Option[C])] = {
 
-
-        val resultA = computeCheckResult(authInfo._1, controlA)
-        val resultB = computeCheckResult(authInfo._2, controlB)
-        val resultC = computeCheckResult(authInfo._3, controlC)
+        val resultA = simulateElement(authentication._1, controlA)
+        val resultB = simulateElement(authentication._2, controlB)
+        val resultC = simulateElement(authentication._3, controlC)
 
         (resultA, resultB, resultC) match {
           case (Left(errorA), Left(_), Left(_)) => Left(errorA)
@@ -118,13 +118,11 @@ private[access] trait AnyOf {
     }
   }
 
-  /**
-   * Helper for the `check` functions to run the check functionality of a HeaderAccessControl.
-   */
-  private[this] def computeCheckResult[T](
-      elem: Option[T],
-      accessControl: HeaderAccessControl[T]): Either[NaptimeActionException, T] = {
-    elem.map(e => accessControl.simulateAuthentication(e)).getOrElse(StructuredAccessControl.missingResponse)
+  private[this] def simulateElement[T](element: Option[T], accessControl: HeaderAccessControl[T]):
+    Either[NaptimeActionException, T] = {
+    element
+      .map(accessControl.simulateAuthentication)
+      .getOrElse(StructuredAccessControl.missingResponse)
   }
 
 }

--- a/naptime/src/main/scala/org/coursera/naptime/access/combiner/AnyOf.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/access/combiner/AnyOf.scala
@@ -58,7 +58,7 @@ private[access] trait AnyOf {
         }
       }
 
-      override private[naptime] def check(
+      override private[naptime] def simulateAuthentication(
           authInfo: (Option[A], Option[B])): Either[NaptimeActionException, (Option[A], Option[B])] = {
         val resultA = computeCheckResult(authInfo._1, controlA)
         val resultB = computeCheckResult(authInfo._2, controlB)
@@ -100,7 +100,7 @@ private[access] trait AnyOf {
         }
       }
 
-      override private[naptime] def check(
+      override private[naptime] def simulateAuthentication(
           authInfo: (Option[A], Option[B], Option[C])):
           Either[NaptimeActionException, (Option[A], Option[B], Option[C])] = {
 
@@ -124,7 +124,7 @@ private[access] trait AnyOf {
   private[this] def computeCheckResult[T](
       elem: Option[T],
       accessControl: HeaderAccessControl[T]): Either[NaptimeActionException, T] = {
-    elem.map(e => accessControl.check(e)).getOrElse(StructuredAccessControl.missingResponse)
+    elem.map(e => accessControl.simulateAuthentication(e)).getOrElse(StructuredAccessControl.missingResponse)
   }
 
 }

--- a/naptime/src/main/scala/org/coursera/naptime/access/combiner/EitherOf.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/access/combiner/EitherOf.scala
@@ -60,13 +60,13 @@ private[access] trait EitherOf {
         }
       }
 
-      override private[naptime] def simulateAuthentication(
-          authInfo: Either[A, B]): Either[NaptimeActionException, Either[A, B]] = {
-        authInfo match {
-          case Left(authA) =>
-            controlA.simulateAuthentication(authA).right.map(Left.apply)
-          case Right(authB) =>
-            controlB.simulateAuthentication(authB).right.map(Right.apply)
+      override def simulateAuthentication(
+          authentication: Either[A, B]): Either[NaptimeActionException, Either[A, B]] = {
+        authentication match {
+          case Left(authenticationA) =>
+            controlA.simulateAuthentication(authenticationA).right.map(Left.apply)
+          case Right(authenticationB) =>
+            controlB.simulateAuthentication(authenticationB).right.map(Right.apply)
         }
       }
     }

--- a/naptime/src/main/scala/org/coursera/naptime/access/combiner/EitherOf.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/access/combiner/EitherOf.scala
@@ -60,13 +60,13 @@ private[access] trait EitherOf {
         }
       }
 
-      override private[naptime] def check(
+      override private[naptime] def simulateAuthentication(
           authInfo: Either[A, B]): Either[NaptimeActionException, Either[A, B]] = {
         authInfo match {
           case Left(authA) =>
-            controlA.check(authA).right.map(Left.apply)
+            controlA.simulateAuthentication(authA).right.map(Left.apply)
           case Right(authB) =>
-            controlB.check(authB).right.map(Right.apply)
+            controlB.simulateAuthentication(authB).right.map(Right.apply)
         }
       }
     }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.2.0"
+version in ThisBuild := "0.2.1"


### PR DESCRIPTION
@saeta 

Also included:
* I renamed access control's `check` to describe its purpose better and added various Scaladoc.
* I fixed a small bug where `HeaderAccessControl.and` arity 3 ignored the last access control's failure.