### PR TITLE
Relax type restrictions for actions.

### DIFF
--- a/naptime-testing/src/test/scala/org/coursera/naptime/NestedMacroTests.scala
+++ b/naptime-testing/src/test/scala/org/coursera/naptime/NestedMacroTests.scala
@@ -19,6 +19,7 @@ package org.coursera.naptime
 import com.linkedin.data.schema.DataSchema
 import com.linkedin.data.schema.RecordDataSchema
 import org.coursera.naptime.actions.NaptimeSerializer.AnyWrites._
+import org.coursera.naptime.actions.NaptimeActionSerializer.AnyWrites._
 import org.coursera.naptime.courier.CourierFormats
 import org.coursera.naptime.model.KeyFormat
 import org.coursera.naptime.model.Keyed

--- a/naptime-testing/src/test/scala/org/coursera/naptime/NonNestedMacroTests.scala
+++ b/naptime-testing/src/test/scala/org/coursera/naptime/NonNestedMacroTests.scala
@@ -17,6 +17,7 @@
 package org.coursera.naptime
 
 import org.coursera.common.stringkey.StringKeyFormat
+import org.coursera.naptime.actions.NaptimeActionSerializer.AnyWrites._
 import org.coursera.naptime.actions.NaptimeSerializer.AnyWrites._
 import org.coursera.naptime.model.KeyFormat
 import org.coursera.naptime.model.Keyed

--- a/naptime-testing/src/test/scala/org/coursera/naptime/router2/PlayNaptimeRouterIntegrationTest.scala
+++ b/naptime-testing/src/test/scala/org/coursera/naptime/router2/PlayNaptimeRouterIntegrationTest.scala
@@ -17,6 +17,7 @@
 package org.coursera.naptime.router2
 
 import com.google.inject.Guice
+import org.coursera.naptime.actions.NaptimeActionSerializer.AnyWrites._
 import org.coursera.naptime.actions.NaptimeSerializer.AnyWrites._
 import org.coursera.naptime.model.KeyFormat
 import org.coursera.naptime.model.Keyed

--- a/naptime/src/main/scala/org/coursera/naptime/actions/NaptimeActionSerializer.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/actions/NaptimeActionSerializer.scala
@@ -1,0 +1,81 @@
+package org.coursera.naptime.actions
+
+import java.nio.charset.StandardCharsets
+
+import com.linkedin.data.codec.JacksonDataCodec
+import com.linkedin.data.schema.DataSchema
+import com.linkedin.data.schema.NullDataSchema
+import com.linkedin.data.schema.StringDataSchema
+import com.linkedin.data.template.RecordTemplate
+import play.api.http.ContentTypes
+import play.api.libs.json.Format
+import play.api.libs.json.JsValue
+import play.api.libs.json.Json
+
+/**
+ * Actions have far fewer restrictions on the response type than other actions. We thus define a looser
+ * serializer API (as compared to [[NaptimeSerializer]].
+ */
+trait NaptimeActionSerializer[T] {
+  def serialize(t: T): Array[Byte]
+  def contentType(t: T): String
+  def schema(t: T): Option[DataSchema]
+}
+
+object NaptimeActionSerializer {
+  implicit def courierModel[T <: RecordTemplate]: NaptimeActionSerializer[T] = {
+    new NaptimeActionSerializer[T] {
+      override def serialize(t: T): Array[Byte] = {
+        val codec = new JacksonDataCodec()
+        val bytes = codec.mapToBytes(t.data())
+        bytes
+      }
+      override def contentType(t: T): String = ContentTypes.JSON
+      override def schema(t: T): Option[DataSchema] = Some(t.schema())
+    }
+  }
+
+  implicit object PlayJson extends NaptimeActionSerializer[JsValue] {
+    override def serialize(t: JsValue): Array[Byte] = Json.stringify(t).getBytes(StandardCharsets.UTF_8)
+
+    override def schema(t: JsValue): Option[DataSchema] = None
+
+    override def contentType(t: JsValue): String = ContentTypes.JSON
+  }
+
+  implicit def playJsonFormats[T](implicit playJsonFormat: Format[T]): NaptimeActionSerializer[T] = {
+    new NaptimeActionSerializer[T] {
+      override def serialize(t: T): Array[Byte] = PlayJson.serialize(Json.toJson(t))
+
+      override def contentType(t: T): String = ContentTypes.JSON
+
+      override def schema(t: T): Option[DataSchema] = None
+    }
+  }
+
+  implicit object Strings extends NaptimeActionSerializer[String] {
+    override def serialize(t: String): Array[Byte] = t.getBytes(StandardCharsets.UTF_8)
+
+    override def schema(t: String): Option[DataSchema] = Some(new StringDataSchema)
+
+    override def contentType(t: String): String = ContentTypes.TEXT
+  }
+
+  implicit object UnitWriter extends NaptimeActionSerializer[Unit] {
+    override def serialize(t: Unit): Array[Byte] = Array.emptyByteArray
+
+    override def contentType(t: Unit): String = ContentTypes.TEXT
+
+    override def schema(t: Unit): Option[DataSchema] = Some(new NullDataSchema)
+  }
+
+  object AnyWrites {
+    implicit object AnyWrites extends NaptimeActionSerializer[Any] {
+      override def serialize(t: Any): Array[Byte] = t.toString.getBytes(StandardCharsets.UTF_8)
+
+      override def contentType(t: Any): String = ContentTypes.TEXT
+
+      override def schema(t: Any): Option[DataSchema] = None
+    }
+  }
+}

--- a/naptime/src/main/scala/org/coursera/naptime/actions/RestActionCategoryEngine2.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/actions/RestActionCategoryEngine2.scala
@@ -492,8 +492,7 @@ trait RestActionCategoryEngine2 {
   }
 
   implicit def actionActionCategoryEngine[Key, Resource, Response](
-      implicit naptimeSerializer: NaptimeSerializer[Resource], keyFormat: KeyFormat[Key],
-      responseWrites: NaptimeSerializer[Response]):
+      implicit responseWrites: NaptimeActionSerializer[Response]):
     RestActionCategoryEngine[ActionRestActionCategory, Key, Resource, Response] = {
 
     new RestActionCategoryEngine[ActionRestActionCategory, Key, Resource, Response] {
@@ -506,8 +505,7 @@ trait RestActionCategoryEngine2 {
           response: RestResponse[Response]): Result = {
         mkOkResponse(response) { ok =>
           val responseBody = responseWrites.serialize(ok.content)
-          val codec = new JacksonDataCodec() // No filtering (maintains backwards compatibility)
-          Results.Ok(codec.mapToBytes(responseBody)).as(ContentTypes.JSON)
+          Results.Ok(responseBody).as(responseWrites.contentType(ok.content))
         }
       }
     }

--- a/naptime/src/test/scala/org/coursera/naptime/access/HeaderAccessControlCombinersTest.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/access/HeaderAccessControlCombinersTest.scala
@@ -37,6 +37,8 @@ class HeaderAccessControlCombinersTest extends AssertionsForJUnit with ScalaFutu
 
   import HeaderAccessControlCombinersTest._
 
+  override def spanScaleFactor: Double = 10
+
   def runEither(
       left: StructuredAccessControl[String] = LEFT,
       right: StructuredAccessControl[String] = RIGHT)

--- a/naptime/src/test/scala/org/coursera/naptime/router2/NestingCollectionResourceRouterTest.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/router2/NestingCollectionResourceRouterTest.scala
@@ -17,6 +17,7 @@
 package org.coursera.naptime.router2
 
 import org.coursera.common.stringkey.StringKeyFormat
+import org.coursera.naptime.actions.NaptimeActionSerializer.AnyWrites._
 import org.coursera.naptime.actions.NaptimeSerializer.AnyWrites._
 import org.coursera.naptime.model.KeyFormat
 import org.coursera.naptime.actions.RestActionBuilder


### PR DESCRIPTION
Previously Engine2's required that the response object in actions be
serializable to a `DataMap`. This is too restrictive, because actions
are the escape hatches from the Naptime system, and must thus support
responses of strings, `JsValues`, and other primitive types. We thus
define a new type that is more general and more flexible to support
actions.