### PR TITLE
Add initial GraphQL parsing library

### DIFF
--- a/naptime/build.sbt
+++ b/naptime/build.sbt
@@ -8,6 +8,7 @@ libraryDependencies ++= Seq(
   jodaTime,
   jodaConvert,
   playJson,
+  sangria,
   scalaGuice,
   scalaLogging,
   "org.scala-lang" % "scala-reflect" % scalaVersion.value,

--- a/naptime/src/main/scala/org/coursera/naptime/ari/graphql/GraphQL.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/ari/graphql/GraphQL.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 Coursera Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.coursera.naptime.ari.graphql
 
 import javax.inject.Inject

--- a/naptime/src/main/scala/org/coursera/naptime/ari/graphql/SangriaGraphQlParser.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/ari/graphql/SangriaGraphQlParser.scala
@@ -1,0 +1,78 @@
+package org.coursera.naptime.ari.graphql
+
+import org.coursera.naptime.ResourceName
+import org.coursera.naptime.ari.Request
+import org.coursera.naptime.ari.RequestField
+import org.coursera.naptime.ari.TopLevelRequest
+import play.api.libs.json.JsNull
+import play.api.libs.json.JsNumber
+import play.api.libs.json.JsValue
+import play.api.mvc.RequestHeader
+import sangria.ast.Argument
+import sangria.ast.Field
+import sangria.ast.BigIntValue
+import sangria.ast.IntValue
+import sangria.ast.Value
+import sangria.parser.QueryParser
+
+object SangriaGraphQlParser extends GraphQlParser {
+
+  def parse(request: String, requestHeader: RequestHeader): Option[Request] = {
+    val parsedDocumentOption = QueryParser.parse(request).toOption
+    // TODO(bryan): Handle error cases here
+    val topLevelRequests = for {
+      parsedDocument <- parsedDocumentOption.toList
+      operation <- parsedDocument.operations
+      operationName <- operation._1.toList
+      operationData = operation._2
+      selection <- operationData.selections
+      field <- {
+        (selection match {
+          case field: Field => Some(field)
+          case _ => None
+        }).toList
+      }
+      resource <- fieldNameToNaptimeResource(field.name).toList
+    } yield {
+      TopLevelRequest(resource, parseField(field))
+    }
+    Some(Request(requestHeader, topLevelRequests))
+  }
+
+  def parseField(field: Field): RequestField = {
+    val subfields = field.selections.flatMap {
+      case subfield: Field => Some(parseField(subfield))
+      case _ => None
+    }
+    RequestField(
+      field.name,
+      field.alias,
+      field.arguments.map(parseArgument).toSet,
+      subfields)
+  }
+
+  def parseArgument(argument: Argument): (String, JsValue) = {
+    // TODO(bryan): Handle other value types here
+    val parsedValue: JsValue = argument.value match {
+      case IntValue(value, _, _) => JsNumber(value)
+      case BigIntValue(value, _, _) => JsNumber(BigDecimal(value))
+      case a: Value => JsNull
+    }
+    (argument.name, parsedValue)
+  }
+
+  val TOP_LEVEL_RESOURCE_REGEX = "([\\w\\d]+)V(\\d)".r
+
+  def fieldNameToNaptimeResource(fieldName: String): Option[ResourceName] = {
+    fieldName match {
+      case TOP_LEVEL_RESOURCE_REGEX(resourceName, version) =>
+        try {
+          Some(ResourceName(resourceName, version.toInt))
+        } catch {
+          case e: NumberFormatException => None
+        }
+      case _ => None
+    }
+  }
+
+}

--- a/naptime/src/main/scala/org/coursera/naptime/ari/graphql/SangriaGraphQlParser.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/ari/graphql/SangriaGraphQlParser.scala
@@ -1,22 +1,65 @@
+/*
+ * Copyright 2016 Coursera Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.coursera.naptime.ari.graphql
 
 import org.coursera.naptime.ResourceName
 import org.coursera.naptime.ari.Request
 import org.coursera.naptime.ari.RequestField
 import org.coursera.naptime.ari.TopLevelRequest
+import play.api.libs.json.JsArray
+import play.api.libs.json.JsBoolean
 import play.api.libs.json.JsNull
 import play.api.libs.json.JsNumber
+import play.api.libs.json.JsObject
+import play.api.libs.json.JsString
 import play.api.libs.json.JsValue
 import play.api.mvc.RequestHeader
-import sangria.ast.Argument
+import sangria.ast.BigDecimalValue
 import sangria.ast.Field
 import sangria.ast.BigIntValue
+import sangria.ast.BooleanValue
+import sangria.ast.EnumValue
+import sangria.ast.FloatValue
 import sangria.ast.IntValue
+import sangria.ast.ListValue
+import sangria.ast.NullValue
+import sangria.ast.ObjectField
+import sangria.ast.ObjectValue
+import sangria.ast.StringValue
 import sangria.ast.Value
+import sangria.ast.VariableValue
 import sangria.parser.QueryParser
 
+/**
+  * The SangriaGraphQlParser uses the [Sangria library](https://github.com/sangria-graphql/sangria)
+  * to parse a GraphQL input into a Naptime ARI [[Request]] for further processing.
+  */
 object SangriaGraphQlParser extends GraphQlParser {
 
+  /**
+    * For a given request, consisting of a GraphQL query (represented as a string) and a
+    * [[RequestHeader]], parse the input into a Naptime [[Request]] to be passed to the
+    * [[org.coursera.naptime.ari.EngineApi]]
+    *
+    * @param request A string representation of a GraphQL query / mutation
+    * @param requestHeader RequestHeader from the incoming request, which gets propagated down to
+    *                      the engine. May be used for authentication at a future time.
+    * @return a [[Request]] if the parsing of the request was successful, otherwise None
+    */
   def parse(request: String, requestHeader: RequestHeader): Option[Request] = {
     val parsedDocumentOption = QueryParser.parse(request).toOption
     // TODO(bryan): Handle error cases here
@@ -39,7 +82,7 @@ object SangriaGraphQlParser extends GraphQlParser {
     Some(Request(requestHeader, topLevelRequests))
   }
 
-  def parseField(field: Field): RequestField = {
+  private[this] def parseField(field: Field): RequestField = {
     val subfields = field.selections.flatMap {
       case subfield: Field => Some(parseField(subfield))
       case _ => None
@@ -47,23 +90,40 @@ object SangriaGraphQlParser extends GraphQlParser {
     RequestField(
       field.name,
       field.alias,
-      field.arguments.map(parseArgument).toSet,
+      field.arguments.map(argument => (argument.name, parseValue(argument.value))).toSet,
       subfields)
   }
 
-  def parseArgument(argument: Argument): (String, JsValue) = {
-    // TODO(bryan): Handle other value types here
-    val parsedValue: JsValue = argument.value match {
+  private[this] def parseValue(sangriaValue: Value): JsValue = {
+    sangriaValue match {
       case IntValue(value, _, _) => JsNumber(value)
       case BigIntValue(value, _, _) => JsNumber(BigDecimal(value))
+      case FloatValue(value, _, _) => JsNumber(value)
+      case BigDecimalValue(value, _, _) => JsNumber(value)
+      case StringValue(value, _, _) => JsString(value)
+      case BooleanValue(value, _, _) => JsBoolean(value)
+      case EnumValue(value, _, _) => JsString(value)
+      case ListValue(value, _, _) => JsArray(value.map(parseValue))
+      case VariableValue(value, _, _) => JsString(value)
+      case NullValue(_, _) => JsNull
+      case ObjectValue(fields, _, _) => JsObject(fields.map { case ObjectField(name, value, _, _) =>
+        name -> parseValue(value)
+      })
       case a: Value => JsNull
     }
-    (argument.name, parsedValue)
   }
 
   val TOP_LEVEL_RESOURCE_REGEX = "([\\w\\d]+)V(\\d)".r
 
+  /**
+    * Converts a GraphQL top-level field name to a standard Naptime [[ResourceName]].
+    * For example, CoursesV1 gets parsed as ResourceName("Courses", 1).
+    * Invalid field names will return a None.
+    * @param fieldName field name string, in the format CoursesV1
+    * @return parsed [[ResourceName]] if successful, None if unsuccessful.
+    */
   def fieldNameToNaptimeResource(fieldName: String): Option[ResourceName] = {
+    // TODO(bryan): provide more information on a parse error than simply returning a None
     fieldName match {
       case TOP_LEVEL_RESOURCE_REGEX(resourceName, version) =>
         try {

--- a/naptime/src/main/scala/org/coursera/naptime/ari/graphql/graphqlParser.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/ari/graphql/graphqlParser.scala
@@ -1,0 +1,10 @@
+package org.coursera.naptime.ari.graphql
+
+import org.coursera.naptime.ari.Request
+import play.api.mvc.RequestHeader
+
+trait GraphQlParser {
+
+  def parse(request: String, requestHeader: RequestHeader): Option[Request]
+
+}

--- a/naptime/src/main/scala/org/coursera/naptime/ari/graphql/graphqlParser.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/ari/graphql/graphqlParser.scala
@@ -1,8 +1,29 @@
+/*
+ * Copyright 2016 Coursera Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.coursera.naptime.ari.graphql
 
 import org.coursera.naptime.ari.Request
 import play.api.mvc.RequestHeader
 
+/**
+  * The GraphQlParser represents the GraphQL segment of the Naptime ARI presentation layer.
+  * This segment is responsible for converting a GraphQL query (represented as a string) into a
+  * common [[Request]] class that can be parsed and evaluated by the ARI engine.
+  */
 trait GraphQlParser {
 
   def parse(request: String, requestHeader: RequestHeader): Option[Request]

--- a/naptime/src/test/scala/org/coursera/naptime/ari/graphql/SangriaGraphQlParserTest.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/ari/graphql/SangriaGraphQlParserTest.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 Coursera Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.coursera.naptime.ari.graphql
 
 import org.coursera.naptime.ResourceName
@@ -10,7 +26,6 @@ import play.api.libs.json.JsNumber
 import play.api.test.FakeRequest
 
 import scala.collection.immutable
-
 
 class SangriaGraphQlParserTest extends AssertionsForJUnit {
 

--- a/naptime/src/test/scala/org/coursera/naptime/ari/graphql/SangriaGraphQlParserTest.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/ari/graphql/SangriaGraphQlParserTest.scala
@@ -1,0 +1,227 @@
+package org.coursera.naptime.ari.graphql
+
+import org.coursera.naptime.ResourceName
+import org.coursera.naptime.ari.Request
+import org.coursera.naptime.ari.RequestField
+import org.coursera.naptime.ari.TopLevelRequest
+import org.junit.Test
+import org.scalatest.junit.AssertionsForJUnit
+import play.api.libs.json.JsNumber
+import play.api.test.FakeRequest
+
+import scala.collection.immutable
+
+
+class SangriaGraphQlParserTest extends AssertionsForJUnit {
+
+  val requestHeader = FakeRequest()
+
+  @Test
+  def parseEmpty(): Unit = {
+    val query =
+      """
+        query EmptyQuery {
+          root
+        }
+      """
+    val response = SangriaGraphQlParser.parse(query, requestHeader)
+    assert(response.get === Request(requestHeader, immutable.Seq.empty))
+  }
+
+  @Test
+  def parseSimple(): Unit = {
+    val query =
+      """
+        query EmptyQuery {
+          CoursesV1
+        }
+      """
+    val response = SangriaGraphQlParser.parse(query, requestHeader)
+    val expectedRequest = Request(requestHeader, immutable.Seq(
+      TopLevelRequest(
+        ResourceName("Courses", 1),
+        RequestField(
+          name = "CoursesV1",
+          alias = None,
+          args = Set.empty,
+          selections = List.empty))))
+    assert(response.get === expectedRequest)
+  }
+
+  @Test
+  def parseFields(): Unit = {
+    val query =
+      """
+        query EmptyQuery {
+          CoursesV1 {
+            id
+          }
+        }
+      """
+    val response = SangriaGraphQlParser.parse(query, requestHeader)
+    val expectedRequest = Request(requestHeader, immutable.Seq(
+      TopLevelRequest(
+        ResourceName("Courses", 1),
+        RequestField(
+          name = "CoursesV1",
+          alias = None,
+          args = Set.empty,
+          selections = List(
+            RequestField(
+              name = "id",
+              alias = None,
+              args = Set.empty,
+              selections = List.empty))))))
+    assert(response.get === expectedRequest)
+  }
+
+  @Test
+  def parseAliases(): Unit = {
+    val query =
+      """
+        query EmptyQuery {
+          course: CoursesV1 {
+            myId: id
+          }
+        }
+      """
+    val response = SangriaGraphQlParser.parse(query, requestHeader)
+    val expectedRequest = Request(requestHeader, immutable.Seq(
+      TopLevelRequest(
+        ResourceName("Courses", 1),
+        RequestField(
+          name = "CoursesV1",
+          alias = Some("course"),
+          args = Set.empty,
+          selections = List(
+            RequestField(
+              name = "id",
+              alias = Some("myId"),
+              args = Set.empty,
+              selections = List.empty))))))
+    assert(response.get === expectedRequest)
+  }
+
+  @Test
+  def parseDeeplyNested(): Unit = {
+    val query =
+      """
+        query EmptyQuery {
+          course: CoursesV1 {
+            id {
+              slug
+            }
+          }
+        }
+      """
+    val response = SangriaGraphQlParser.parse(query, requestHeader)
+    val expectedRequest = Request(requestHeader, immutable.Seq(
+      TopLevelRequest(
+        ResourceName("Courses", 1),
+        RequestField(
+          name = "CoursesV1",
+          alias = Some("course"),
+          args = Set.empty,
+          selections = List(
+            RequestField(
+              name = "id",
+              alias = None,
+              args = Set.empty,
+              selections = List(
+                RequestField(
+                  name = "slug",
+                  alias = None,
+                  args = Set.empty,
+                  selections = List.empty))))))))
+    assert(response.get === expectedRequest)
+  }
+
+  @Test
+  def parseMulti(): Unit = {
+    val query =
+      """
+        query EmptyQuery {
+          CoursesV1 {
+            id
+          }
+          InstructorsV1 {
+            id
+            firstName
+          }
+        }
+      """
+    val response = SangriaGraphQlParser.parse(query, requestHeader)
+    val expectedRequest = Request(requestHeader, immutable.Seq(
+      TopLevelRequest(
+        ResourceName("Courses", 1),
+        RequestField(
+          name = "CoursesV1",
+          alias = None,
+          args = Set.empty,
+          selections = List(
+            RequestField(
+              name = "id",
+              alias = None,
+              args = Set.empty,
+              selections = List.empty)))),
+      TopLevelRequest(
+        ResourceName("Instructors", 1),
+        RequestField(
+          name = "InstructorsV1",
+          alias = None,
+          args = Set.empty,
+          selections = List(
+            RequestField(
+              name = "id",
+              alias = None,
+              args = Set.empty,
+              selections = List.empty),
+            RequestField(
+              name = "firstName",
+              alias = None,
+              args = Set.empty,
+              selections = List.empty))))))
+    assert(response.get === expectedRequest)
+  }
+
+  @Test
+  def parseArguments(): Unit = {
+    val query =
+      """
+        query EmptyQuery {
+          CoursesV1(limit: 10) {
+            id
+          }
+        }
+      """
+    val response = SangriaGraphQlParser.parse(query, requestHeader)
+    val expectedRequest = Request(requestHeader, immutable.Seq(
+      TopLevelRequest(
+        ResourceName("Courses", 1),
+        RequestField(
+          name = "CoursesV1",
+          alias = None,
+          args = Set(("limit", JsNumber(10))),
+          selections = List(
+            RequestField(
+              name = "id",
+              alias = None,
+              args = Set.empty,
+              selections = List.empty))))))
+    assert(response.get === expectedRequest)
+  }
+
+  @Test
+  def resourceNameParse(): Unit = {
+    assert(SangriaGraphQlParser.fieldNameToNaptimeResource("CoursesV0") ===
+      Some(ResourceName("Courses", 0)))
+    assert(SangriaGraphQlParser.fieldNameToNaptimeResource("V1DetailsV1") ===
+      Some(ResourceName("V1Details", 1)))
+    assert(SangriaGraphQlParser.fieldNameToNaptimeResource("Courses.V0") === None)
+    assert(SangriaGraphQlParser.fieldNameToNaptimeResource("Courses") === None)
+    assert(SangriaGraphQlParser.fieldNameToNaptimeResource("CoursesV") === None)
+    assert(SangriaGraphQlParser.fieldNameToNaptimeResource("V0") === None)
+    assert(SangriaGraphQlParser.fieldNameToNaptimeResource("?V0") === None)
+  }
+
+}

--- a/project/NamedDependencies.scala
+++ b/project/NamedDependencies.scala
@@ -35,6 +35,7 @@ trait NamedDependencies { this: PluginVersionProvider =>
   val playJson = "com.typesafe.play" %% "play-json" % playVersion
   val playTestCompile = ("com.typesafe.play" %% "play-test" % playVersion)
     .excludeAll(new ExclusionRule(organization="org.specs2"))
+  val sangria = "org.sangria-graphql" %% "sangria" % "0.7.1"
   val scalaGuice = "net.codingwell" %% "scala-guice" % "4.0.0"
   val scalaLogging = "com.typesafe.scala-logging" %% "scala-logging" % "3.1.0"
 


### PR DESCRIPTION
- Adds sangria dependency to Naptime
- Adds a GraphQL Parser object that can parse a GraphQL String into a Naptime Request object
- Recursively parses fields into Naptime RequestFields
- Adds unit tests for parsing

Still a few TODOs left around error handling and argument parsing (GraphQL AST types into JSON)

PTAL @saeta 