### PR TITLE
Incorporate related resource information in schema

### DIFF
--- a/naptime-testing/src/test/pegasus/org/coursera/naptime/Course.courier
+++ b/naptime-testing/src/test/pegasus/org/coursera/naptime/Course.courier
@@ -1,0 +1,7 @@
+namespace org.coursera.naptime
+
+record Course {
+  name: string
+  description: string
+  instructors: array[InstructorId]
+}

--- a/naptime-testing/src/test/pegasus/org/coursera/naptime/Instructor.courier
+++ b/naptime-testing/src/test/pegasus/org/coursera/naptime/Instructor.courier
@@ -1,0 +1,7 @@
+namespace org.coursera.naptime
+
+record Instructor {
+  name: string
+  title: string
+  bio: string
+}

--- a/naptime-testing/src/test/pegasus/org/coursera/naptime/InstructorId.courier
+++ b/naptime-testing/src/test/pegasus/org/coursera/naptime/InstructorId.courier
@@ -1,0 +1,3 @@
+namespace org.coursera.naptime
+
+typeref InstructorId = string

--- a/naptime-testing/src/test/pegasus/org/coursera/naptime/couriertests/ExpectedMergedCourse.courier
+++ b/naptime-testing/src/test/pegasus/org/coursera/naptime/couriertests/ExpectedMergedCourse.courier
@@ -1,0 +1,14 @@
+namespace org.coursera.naptime.couriertests
+
+import org.coursera.naptime.InstructorId
+
+record ExpectedMergedCourse {
+  id: string
+
+  name: string
+
+  description: string
+
+  @related = "instructors.v1"
+  instructors: array[InstructorId]
+}

--- a/naptime-testing/src/test/scala/org/coursera/naptime/NestedMacroCourierTests.scala
+++ b/naptime-testing/src/test/scala/org/coursera/naptime/NestedMacroCourierTests.scala
@@ -1,0 +1,107 @@
+package org.coursera.naptime
+
+import com.linkedin.data.schema.DataSchema
+import com.linkedin.data.schema.RecordDataSchema
+import org.coursera.naptime.couriertests.ExpectedMergedCourse
+import org.coursera.naptime.model.Keyed
+import org.coursera.naptime.resources.CourierCollectionResource
+import org.coursera.naptime.router2.Router
+import org.junit.Test
+import org.scalatest.junit.AssertionsForJUnit
+
+/**
+ * This test suite uses Courier to exercise advanced use cases for Naptime.
+ */
+object NestedMacroCourierTests {
+
+  class CoursesResource extends CourierCollectionResource[String, Course] {
+    override def resourceName: String = "courses"
+
+    override implicit lazy val Fields: Fields[Course] = BaseFields.withRelated("instructors" -> ResourceName("instructors", 1))
+
+    /**
+     * This `var` can be overridden to help fake out the implementation in particular functions.
+     */
+    var relatedFunction: Option[String => List[String]] = None
+
+    private[this] def fallbackRelatedFunction(id: String): List[String] = {
+      id match {
+        case "abc" => List("123")
+        case "xyz" => List.empty
+        case "qrs" => List("456", "789")
+        case _ => List.empty
+      }
+    }
+
+    private[this] def makeCourse(id: String): Keyed[String, Course] = {
+      val relatedInstructors = relatedFunction.getOrElse(fallbackRelatedFunction _)(id)
+
+      Keyed(id, Course(s"course-$id", s"$id description", relatedInstructors))
+    }
+
+    def get(id: String) = Nap.get { ctx =>
+      Ok(makeCourse(id))
+    }
+
+    def multiGet(ids: Set[String]) = Nap.multiGet { ctx =>
+      Ok(ids.map(id => makeCourse(id)).toList)
+    }
+
+    def search(query: Option[String]) = Nap.finder { ctx =>
+      val ids = query.map(List(_)).getOrElse(List("abc", "qrs"))
+      Ok(ids.map(id => makeCourse(id)))
+    }
+
+    def byInstructor(instructorId: String) = Nap.finder { ctx =>
+      val ids = instructorId match {
+        case "123" => List("xyz")
+        case "456" => List("xyz", "abc")
+        case "789" => List("qrs")
+        case _ => List.empty
+      }
+      Ok(ids.map(id => makeCourse(id)))
+    }
+  }
+
+  class InstructorsResource extends CourierCollectionResource[String, Instructor] {
+    override def resourceName: String = "instructors"
+
+    def multiGet(ids: Set[String]) = Nap.multiGet { ctx =>
+      ???
+    }
+
+  }
+
+  val courseRouter = Router.build[CoursesResource]
+  val instructorRouter = Router.build[InstructorsResource]
+}
+
+class NestedMacroCourierTests extends AssertionsForJUnit {
+
+  @Test
+  def checkCoursesMergedType(): Unit = {
+    val types = NestedMacroCourierTests.courseRouter.types
+    assert(3 === types.size, s"Got $types")
+    val mergedTypeOpt = types.find(_.key == "org.coursera.naptime.NestedMacroCourierTests.CoursesResource.Model")
+    assert(mergedTypeOpt.isDefined)
+    val mergedType = mergedTypeOpt.get
+    assert(!mergedType.value.hasError)
+    assert(mergedType.value.getType === DataSchema.Type.RECORD)
+    val mergedValueRecord = mergedType.value.asInstanceOf[RecordDataSchema]
+    assert(4 === mergedValueRecord.getFields.size(), mergedValueRecord)
+    val instructorsField = mergedValueRecord.getField("instructors")
+    assert(null != instructorsField, instructorsField)
+    assert(null != instructorsField.getProperties)
+    val typesProperty = instructorsField.getProperties.get(Types.Relations.PROPERTY_NAME)
+    assert(null != typesProperty)
+    assert(typesProperty.isInstanceOf[String])
+    assert(typesProperty === "instructors.v1")
+  }
+
+  @Test
+  def checkMergedCourseModelSchema(): Unit = {
+    val types = NestedMacroCourierTests.courseRouter.types
+    val mergedType = types.find(_.key == "org.coursera.naptime.NestedMacroCourierTests.CoursesResource.Model").get
+    assert(ExpectedMergedCourse.SCHEMA.getFields === mergedType.value.asInstanceOf[RecordDataSchema].getFields)
+  }
+}

--- a/naptime-testing/src/test/scala/org/coursera/naptime/NestedMacroTests.scala
+++ b/naptime-testing/src/test/scala/org/coursera/naptime/NestedMacroTests.scala
@@ -634,14 +634,17 @@ class NestedMacroTests extends AssertionsForJUnit with MockitoSugar {
   @Test
   def typesTest(): Unit = {
     val types = PersonResource.routerBuilder.types
-    assert(types.size === 1)
-    assert(types.head.key === "org.coursera.naptime.PersonResource.Model")
-    assert(!types.head.value.hasError)
-    assert(types.head.value.isComplex)
-    assert(types.head.value.getType === DataSchema.Type.RECORD)
-    assert(types.head.value.isInstanceOf[RecordDataSchema])
-    assert(types.head.value.asInstanceOf[RecordDataSchema].getFields.size() === 3)
-    assert(types.head.value.asInstanceOf[RecordDataSchema].getFields.toList.map(_.getName).toSet ===
+    assert(types.size === 3)
+    val resourceType = types.find(_.key === "org.coursera.naptime.PersonResource.Model").getOrElse {
+      assert(false, "Could not find merged type in types list.")
+      ???
+    }
+    assert(!resourceType.value.hasError)
+    assert(resourceType.value.isComplex)
+    assert(resourceType.value.getType === DataSchema.Type.RECORD)
+    assert(resourceType.value.isInstanceOf[RecordDataSchema])
+    assert(resourceType.value.asInstanceOf[RecordDataSchema].getFields.size() === 3)
+    assert(resourceType.value.asInstanceOf[RecordDataSchema].getFields.toList.map(_.getName).toSet ===
       Set("id", "name", "email"))
   }
 
@@ -673,14 +676,18 @@ class NestedMacroTests extends AssertionsForJUnit with MockitoSugar {
   @Test
   def nestedTypes(): Unit = {
     val types = FriendsResource.routerBuilder.types
-    assert(types.size === 1)
-    assert(types.head.key === "org.coursera.naptime.FriendsResource.Model")
-    assert(!types.head.value.hasError)
-    assert(types.head.value.isComplex)
-    assert(types.head.value.getType === DataSchema.Type.RECORD)
-    assert(types.head.value.isInstanceOf[RecordDataSchema])
-    assert(types.head.value.asInstanceOf[RecordDataSchema].getFields.size() === 3)
-    assert(types.head.value.asInstanceOf[RecordDataSchema].getFields.toList.map(_.getName).toSet ===
+    assert(types.size === 3)
+    val resourceModel = types.find(_.key === "org.coursera.naptime.FriendsResource.Model").getOrElse {
+      assert(false, "Could not find constructed merged type.")
+      ???
+    }
+    assert(resourceModel.key === "org.coursera.naptime.FriendsResource.Model")
+    assert(!resourceModel.value.hasError)
+    assert(resourceModel.value.isComplex)
+    assert(resourceModel.value.getType === DataSchema.Type.RECORD)
+    assert(resourceModel.value.isInstanceOf[RecordDataSchema])
+    assert(resourceModel.value.asInstanceOf[RecordDataSchema].getFields.size() === 3)
+    assert(resourceModel.value.asInstanceOf[RecordDataSchema].getFields.toList.map(_.getName).toSet ===
       Set("id", "friendshipQuality", "friendsSince"))
   }
 

--- a/naptime/src/main/scala/org/coursera/naptime/models.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/models.scala
@@ -347,6 +347,8 @@ object Fields {
   }
 
   val FIELDS_HEADER = "X-Coursera-Naptime-Fields"
+
+  private[naptime] val FAKE_FIELDS: Fields[_] = Fields(Set.empty, FieldsFunction.default, Map.empty)(null)
 }
 
 // TODO(saeta): FieldFn should also take advantage of the authentication applied. This will require

--- a/naptime/src/main/scala/org/coursera/naptime/router2/ResourceRouter.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/router2/ResourceRouter.scala
@@ -55,7 +55,7 @@ trait ResourceRouterBuilder {
     *
     * @return An instance of [[ResourceClass]] that has _NOT_ had its constructor called.
     */
-  protected[this] def stubInstance: ResourceClass = {
+  protected[this] lazy val stubInstance: ResourceClass = {
     import sun.reflect.ReflectionFactory
 
     val rf = ReflectionFactory.getReflectionFactory

--- a/naptime/src/test/scala/org/coursera/naptime/TypesTest.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/TypesTest.scala
@@ -31,7 +31,8 @@ class TypesTest extends AssertionsForJUnit {
     val resultingType = Types.computeAsymType(
       "org.coursera.naptime.TestResource.Model",
       new IntegerDataSchema,
-      Course.SCHEMA)
+      Course.SCHEMA,
+      Fields.FAKE_FIELDS)
 
     assert(!resultingType.isErrorRecord)
     assert(resultingType.getFields().size() == 3)
@@ -49,7 +50,8 @@ class TypesTest extends AssertionsForJUnit {
     val resultingType = Types.computeAsymType(
       "org.coursera.naptime.ComplexTestResource.Model",
       EnrollmentId.SCHEMA,
-      Course.SCHEMA)
+      Course.SCHEMA,
+      Fields.FAKE_FIELDS)
 
     assert(!resultingType.isErrorRecord)
     assert(resultingType.getFields().size() == 5)


### PR DESCRIPTION
Summary:
In order to build the automatic resource inclusion engine, to support
GraphQL, and add links to the documentation between related resources,
we need to incorporate the related fields information into the "merged"
type schema.

Because the Engine, GraphQL and others are centered around Courier and
Pegasus schemas, I've begun constructing a set of classes that can form
the basis for a more integration-style test suite in the
`NestedMacroCourierTests` class. The first test in this class is a test
of the related fields information functionality added in this commit.

Because we are centering upon courier models, I've added a couple extra
abstract classes that reduce the amount of boilerplate required for
resources using courier types.