### PR TITLE
Design response model + EngineImpl improvements

### DIFF
--- a/naptime-testing/src/test/scala/org/coursera/naptime/NestedMacroCourierTests.scala
+++ b/naptime-testing/src/test/scala/org/coursera/naptime/NestedMacroCourierTests.scala
@@ -141,14 +141,15 @@ class NestedMacroCourierTests extends AssertionsForJUnit with ScalaFutures {
 
     val response = fetcher.data(request).futureValue
 
-    assert(1 === response.output.size)
-    assert(response.output.contains(CoursesResource.ID))
-    val coursesResponse = response.output(CoursesResource.ID)
-    assert(1 === coursesResponse.models.size)
-    assert("course-abc" === coursesResponse.models.head.get("name"),
-      s"Data map: ${coursesResponse.models.head}")
-    assert(None === coursesResponse.pagination.next)
-    assert(CoursesResource.ID.identifier === coursesResponse.key)
+    assert(1 === response.topLevelIds.size)
+    assert(1 === response.data.size)
+    assert(response.data.contains(CoursesResource.ID))
+    val coursesResponse = response.data(CoursesResource.ID)
+    assert(1 === coursesResponse.size)
+    assert(coursesResponse.contains("abc"))
+    assert("course-abc" === coursesResponse("abc").get("name"),
+      s"Data map: ${coursesResponse("abc")}")
+    // TODO: Check pagination
   }
 
   @Test
@@ -173,14 +174,16 @@ class NestedMacroCourierTests extends AssertionsForJUnit with ScalaFutures {
 
     val response = fetcher.data(request).futureValue
 
-    assert(1 === response.output.size)
-    assert(response.output.contains(CoursesResource.ID))
-    val coursesResponse = response.output(CoursesResource.ID)
-    assert(2 === coursesResponse.models.size)
-    assert("course-abc" === coursesResponse.models.head.get("name"),
-      s"Data map: ${coursesResponse.models.head}")
-    assert(None === coursesResponse.pagination.next)
-    assert(CoursesResource.ID.identifier === coursesResponse.key)
+
+    assert(1 === response.topLevelIds.size)
+    assert(1 === response.data.size)
+    assert(response.data.contains(CoursesResource.ID))
+    val coursesResponse = response.data(CoursesResource.ID)
+    assert(2 === coursesResponse.size)
+    assert(coursesResponse.contains("abc"))
+    assert("course-abc" === coursesResponse("abc").get("name"),
+      s"Data map: ${coursesResponse("abc")}")
+    // TODO: Check pagination
   }
 
   @Test
@@ -205,13 +208,14 @@ class NestedMacroCourierTests extends AssertionsForJUnit with ScalaFutures {
 
     val response = fetcher.data(request).futureValue
 
-    assert(1 === response.output.size)
-    assert(response.output.contains(CoursesResource.ID))
-    val coursesResponse = response.output(CoursesResource.ID)
-    assert(1 === coursesResponse.models.size)
-    assert("course-xyz" === coursesResponse.models.head.get("name"),
-      s"Data map: ${coursesResponse.models.head}")
-    assert(None === coursesResponse.pagination.next)
-    assert(CoursesResource.ID.identifier === coursesResponse.key)
+    assert(1 === response.topLevelIds.size)
+    assert(1 === response.data.size)
+    assert(response.data.contains(CoursesResource.ID))
+    val coursesResponse = response.data(CoursesResource.ID)
+    assert(1 === coursesResponse.size)
+    assert(coursesResponse.contains("xyz"))
+    assert("course-xyz" === coursesResponse("xyz").get("name"),
+      s"Data map: ${coursesResponse("xyz")}")
+    // TODO: Check pagination
   }
 }

--- a/naptime/src/main/scala/org/coursera/naptime/actions/RestAction.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/actions/RestAction.scala
@@ -28,6 +28,7 @@ import org.coursera.naptime.RestContext
 import org.coursera.naptime.RestResponse
 import org.coursera.naptime.access.HeaderAccessControl
 import org.coursera.naptime.ari.Response
+import org.coursera.naptime.ari.TopLevelRequest
 import play.api.Play
 import play.api.libs.iteratee.Enumeratee
 import play.api.libs.iteratee.Iteratee
@@ -88,7 +89,10 @@ trait RestAction[RACType, AuthType, BodyType, KeyType, ResourceType, ResponseTyp
     }
   }
 
-  private[naptime] def localRun(rh: RequestHeader, resourceName: ResourceName): Future[Response] = {
+  private[naptime] def localRun(
+      rh: RequestHeader,
+      resourceName: ResourceName,
+      topLevelRequest: TopLevelRequest): Future[Response] = {
     val authResult = restAuth.run(rh) // Kick off the authentication check in parallel
     restBodyParser(rh).mapM[Response] {
       case Left(bodyError) =>
@@ -123,7 +127,7 @@ trait RestAction[RACType, AuthType, BodyType, KeyType, ResourceType, ResponseTyp
                   highLevelResponse.flatMap { resp =>
                     restEngine match {
                       case engine2: RestActionCategoryEngine2[RACType, KeyType, ResourceType, ResponseType] =>
-                        engine2.mkResponse(rh, fieldsEngine, fields, includes, pagination, resp, resourceName)
+                        engine2.mkResponse(rh, fieldsEngine, fields, includes, pagination, resp, resourceName, topLevelRequest)
                       case _ =>
                         Future.failed(new IllegalArgumentException("Was not an engine2 resource.")) // TODO: better msg
                     }

--- a/naptime/src/main/scala/org/coursera/naptime/ari/fetcher/LocalFetcher.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/ari/fetcher/LocalFetcher.scala
@@ -62,7 +62,8 @@ class LocalFetcher @Inject() (
         handler match {
           case naptimeAction: RestAction[_, _, _, _, _, _] =>
             naptimeAction.localRun(fakePlayRequest,
-              ResourceName(resourceSchema.name, resourceSchema.version.map(_.toInt).getOrElse(0)))
+              ResourceName(resourceSchema.name, resourceSchema.version.map(_.toInt).getOrElse(0)),
+              topLevelRequest)
           case _ =>
             val msg = "Handler was not a RestAction"
             logger.error(msg)

--- a/naptime/src/main/scala/org/coursera/naptime/ari/models.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/ari/models.scala
@@ -1,15 +1,14 @@
 package org.coursera.naptime.ari
 
+import com.linkedin.data.DataList
 import com.linkedin.data.DataMap
 import com.linkedin.data.schema.DataSchema
 import org.coursera.naptime.ResourceName
-import org.coursera.naptime.ResponsePagination
 import org.coursera.naptime.schema.Resource
 import play.api.libs.json.JsValue
 import play.api.mvc.RequestHeader
 
 import scala.concurrent.Future
-import scala.collection.immutable
 
 /**
  * The engine layer presents this EngineAPI to the presentation layer. The engine layer handles query validation,
@@ -71,6 +70,8 @@ case class TopLevelRequest(resource: ResourceName, selection: RequestField)
 /**
  * Represents a requested field within a requested resource.
  *
+ * TODO: figure out directives
+ *
  * @param name The name of the requested field.
  * @param alias The name the field should be renamed to in the response.
  * @param args If the field takes parameters, they are encapsulated here.
@@ -79,21 +80,49 @@ case class TopLevelRequest(resource: ResourceName, selection: RequestField)
 case class RequestField(
   name: String,
   alias: Option[String],
-  args: Set[(String, JsValue)],
+  args: Set[(String, JsValue)], // TODO: Should JsValue be a specific ARI type?
   selections: List[RequestField])
-
-// TODO: Should JsValue be a specific ARI type?
 
 /**
  * All of the data required to assemble a response to an automatic includes query.
  *
- * @param output A map from resource name to a response
+ * TODO: performance test, and determine if mutable collections yield non-trivial performance improvements.
+ *
+ * @param topLevelIds A map from the top level requests to a DataList containing the ordered list of IDs for the
+ *                    top of the response
+ * @param data A map from the resource name to a Map of IDs to DataMaps.
  */
 case class Response(
-  output: Map[ResourceName, ResourceResponse]
-)
+  topLevelIds: Map[TopLevelRequest, DataList],
+  data: Map[ResourceName, Map[AnyRef, DataMap]]) {
 
-// TODO: figure out directives
+  // TODO: performance test this implementation, and consider optimizing it.
+  // Note: this operation potentially mutates the current response due to interior mutability.
+  def ++(other: Response): Response = {
+    val mergedTopLevel = topLevelIds ++ other.topLevelIds
+    val mergedData = (data.keySet ++ other.data.keySet).map { resourceName =>
+      val lhs = data.getOrElse(resourceName, Map.empty)
+      val rhs = other.data.getOrElse(resourceName, Map.empty)
+      val mergedMap = (lhs.keySet ++ rhs.keySet).map { key =>
+        val lh = lhs.get(key)
+        val rh = rhs.get(key)
+        val merged = (lh, rh) match {
+          case (None, None) =>
+            throw new IllegalStateException(s"Neither map had an entry for key $key.")
+          case (Some(dm), None) => dm
+          case (None, Some(dm)) => dm
+          case (Some(l), Some(r)) =>
+            l.putAll(r)
+            l
+        }
+        key -> merged
+      }.toMap
+      resourceName -> mergedMap
+    }.toMap
+    Response(mergedTopLevel, mergedData)
+  }
+}
 
-// TODO: key may change to a more sophisticated type. It should be a ResourceName, but with hydrated path parameters.
-case class ResourceResponse(key: String, models: Seq[DataMap], pagination: ResponsePagination)
+object Response {
+  val empty = Response(Map.empty, Map.empty)
+}

--- a/naptime/src/test/pegasus/org/coursera/naptime/ari/ResponseTest.scala
+++ b/naptime/src/test/pegasus/org/coursera/naptime/ari/ResponseTest.scala
@@ -1,0 +1,206 @@
+package org.coursera.naptime.ari
+
+import com.linkedin.data.DataList
+import com.linkedin.data.DataMap
+import org.coursera.naptime.ResourceName
+import org.junit.Test
+import org.scalatest.junit.AssertionsForJUnit
+import play.api.libs.json.JsNumber
+import play.api.libs.json.JsString
+
+import scala.collection.JavaConverters._
+
+class ResponseTest extends AssertionsForJUnit {
+
+  @Test
+  def emptyMerges(): Unit = {
+    val topLevelRequest = TopLevelRequest(ResourceName("courses", 1), RequestField(
+      name = "search",
+      alias = None,
+      args = Set("query" -> JsString("machine learning")),
+      selections = List.empty))
+    val topLevelDataList = new DataList(List("abc").asJava)
+    val response = Response(
+      topLevelIds = Map(topLevelRequest -> topLevelDataList),
+      data = Map(topLevelRequest.resource -> Map(
+        "abc" -> new DataMap(Map("id" -> "abc", "slug" -> "machine-learning").asJava))))
+
+    val merged = Response.empty ++ response
+
+    assert(1 === merged.topLevelIds.size)
+    assert(merged.topLevelIds.contains(topLevelRequest))
+    val topLevelResponse = merged.topLevelIds(topLevelRequest)
+    assert(1 === topLevelResponse.size())
+    assert("abc" === topLevelResponse.get(0))
+
+    assert(1 === merged.data.size)
+    assert(merged.data.contains(topLevelRequest.resource))
+    val coursesData = merged.data(topLevelRequest.resource)
+    assert(1 === coursesData.size)
+    assert(coursesData.contains("abc"))
+    val abcDataMap = coursesData("abc")
+    assert(2 === abcDataMap.size())
+    assert(abcDataMap.containsKey("id"))
+    assert(abcDataMap.containsKey("slug"))
+
+    val merged2 = response ++ Response.empty
+    assert(merged === merged2)
+  }
+
+  @Test
+  def mergeMultipleUnrelated(): Unit = {
+    val topLevelRequestCourses = TopLevelRequest(ResourceName("courses", 1), RequestField(
+      name = "search",
+      alias = None,
+      args = Set("query" -> JsString("machine learning")),
+      selections = List.empty))
+    val topLevelDataListCourses = new DataList(List("abc").asJava)
+    val responseCourses = Response(
+      topLevelIds = Map(topLevelRequestCourses -> topLevelDataListCourses),
+      data = Map(topLevelRequestCourses.resource -> Map(
+        "abc" -> new DataMap(Map("id" -> "abc", "slug" -> "machine-learning").asJava))))
+
+    val topLevelRequestInstructors = TopLevelRequest(ResourceName("instructors", 3), RequestField(
+      name = "get",
+      alias = None,
+      args = Set("id" -> JsNumber(123)),
+      selections = List.empty))
+    val topLevelDataListInstructors = new DataList(List(new Integer(123)).asJava)
+    val responseInstructors = Response(
+      topLevelIds = Map(topLevelRequestInstructors -> topLevelDataListInstructors),
+      data = Map(topLevelRequestInstructors.resource -> Map(
+        new Integer(123) -> new DataMap(Map("id" -> new Integer(123), "name" -> "Professor X").asJava))))
+
+    val merged = Response.empty ++ responseCourses ++ responseInstructors
+
+    assert(2 === merged.topLevelIds.size)
+    assert(merged.topLevelIds.contains(topLevelRequestCourses))
+    assert(merged.topLevelIds.contains(topLevelRequestInstructors))
+    val topLevelResponseCourses = merged.topLevelIds(topLevelRequestCourses)
+    assert(1 === topLevelResponseCourses.size())
+    assert("abc" === topLevelResponseCourses.get(0))
+    val topLevelResponseInstructors = merged.topLevelIds(topLevelRequestInstructors)
+    assert(1 === topLevelResponseInstructors.size())
+    assert(new Integer(123) === topLevelResponseInstructors.get(0))
+
+    assert(2 === merged.data.size)
+    assert(merged.data.contains(topLevelRequestCourses.resource))
+    val coursesData = merged.data(topLevelRequestCourses.resource)
+    assert(merged.data.contains(topLevelRequestInstructors.resource))
+    assert(1 === coursesData.size)
+    assert(coursesData.contains("abc"))
+    val abcDataMap = coursesData("abc")
+    assert(2 === abcDataMap.size())
+    assert(abcDataMap.containsKey("id"))
+    assert(abcDataMap.containsKey("slug"))
+
+    val instructorsData = merged.data(topLevelRequestInstructors.resource)
+    assert(1 === instructorsData.size)
+    assert(instructorsData.contains(new Integer(123)))
+    val instructor123DataMap = instructorsData(new Integer(123))
+    assert(2 === instructor123DataMap.size())
+    assert(instructor123DataMap.containsKey("id"))
+    assert(instructor123DataMap.containsKey("name"))
+  }
+
+  @Test
+  def mergedMultipleSingleResourceResponses(): Unit = {
+    val topLevelRequest1 = TopLevelRequest(ResourceName("courses", 1), RequestField(
+      name = "search",
+      alias = None,
+      args = Set("query" -> JsString("machine learning")),
+      selections = List.empty))
+    val topLevelDataList1 = new DataList(List("abc").asJava)
+    val response1 = Response(
+      topLevelIds = Map(topLevelRequest1 -> topLevelDataList1),
+      data = Map(topLevelRequest1.resource -> Map(
+        "abc" -> new DataMap(Map("id" -> "abc", "slug" -> "machine-learning").asJava))))
+
+    val topLevelRequest2 = TopLevelRequest(ResourceName("courses", 1), RequestField(
+      name = "get",
+      alias = None,
+      args = Set("id" -> JsString("xyz")),
+      selections = List.empty))
+    val topLevelDataList2 = new DataList(List("xyz").asJava)
+    val response2 = Response(
+      topLevelIds = Map(topLevelRequest2 -> topLevelDataList2),
+      data = Map(topLevelRequest2.resource -> Map(
+        "xyz" -> new DataMap(Map("id" -> "xyz", "slug" -> "pgm").asJava))))
+
+    val merged = response1 ++ response2
+
+    assert(2 === merged.topLevelIds.size)
+    assert(merged.topLevelIds.contains(topLevelRequest1))
+    val topLevelResponse1 = merged.topLevelIds(topLevelRequest1)
+    assert(1 === topLevelResponse1.size())
+    assert("abc" === topLevelResponse1.get(0))
+    assert(merged.topLevelIds.contains(topLevelRequest2))
+    val topLevelResponse2 = merged.topLevelIds(topLevelRequest2)
+    assert(1 === topLevelResponse2.size())
+    assert("xyz" === topLevelResponse2.get(0))
+
+    assert(1 === merged.data.size)
+    assert(merged.data.contains(topLevelRequest1.resource))
+    assert(merged.data.contains(topLevelRequest2.resource))
+    val coursesData = merged.data(topLevelRequest1.resource)
+    assert(2 === coursesData.size)
+    assert(coursesData.contains("abc"))
+    val abcDataMap = coursesData("abc")
+    assert(2 === abcDataMap.size())
+    assert(abcDataMap.containsKey("id"))
+    assert(abcDataMap.containsKey("slug"))
+    assert(coursesData.contains("xyz"))
+    val xyzDataMap = coursesData("xyz")
+    assert(2 === xyzDataMap.size())
+    assert(xyzDataMap.containsKey("id"))
+    assert(xyzDataMap.containsKey("slug"))
+  }
+
+  @Test
+  def mergeOverlappingResponses(): Unit = {
+    val topLevelRequest1 = TopLevelRequest(ResourceName("courses", 1), RequestField(
+      name = "search",
+      alias = None,
+      args = Set("query" -> JsString("machine learning")),
+      selections = List.empty))
+    val topLevelDataList1 = new DataList(List("abc").asJava)
+    val response1 = Response(
+      topLevelIds = Map(topLevelRequest1 -> topLevelDataList1),
+      data = Map(topLevelRequest1.resource -> Map(
+        "abc" -> new DataMap(Map("id" -> "abc", "slug" -> "machine-learning").asJava))))
+
+    val topLevelRequest2 = TopLevelRequest(ResourceName("courses", 1), RequestField(
+      name = "get",
+      alias = None,
+      args = Set("id" -> JsString("abc")),
+      selections = List.empty))
+    val topLevelDataList2 = new DataList(List("abc").asJava)
+    val response2 = Response(
+      topLevelIds = Map(topLevelRequest2 -> topLevelDataList2),
+      data = Map(topLevelRequest2.resource -> Map(
+        "abc" -> new DataMap(Map("id" -> "abc", "slug" -> "machine-learning").asJava))))
+
+    val merged = response1 ++ response2
+
+    assert(2 === merged.topLevelIds.size)
+    assert(merged.topLevelIds.contains(topLevelRequest1))
+    val topLevelResponse1 = merged.topLevelIds(topLevelRequest1)
+    assert(1 === topLevelResponse1.size())
+    assert("abc" === topLevelResponse1.get(0))
+    assert(merged.topLevelIds.contains(topLevelRequest2))
+    val topLevelResponse2 = merged.topLevelIds(topLevelRequest2)
+    assert(1 === topLevelResponse2.size())
+    assert("abc" === topLevelResponse2.get(0))
+
+    assert(1 === merged.data.size)
+    assert(topLevelRequest1.resource === topLevelRequest2.resource)
+    assert(merged.data.contains(topLevelRequest1.resource))
+    val coursesData = merged.data(topLevelRequest1.resource)
+    assert(1 === coursesData.size)
+    assert(coursesData.contains("abc"))
+    val abcDataMap = coursesData("abc")
+    assert(2 === abcDataMap.size())
+    assert(abcDataMap.containsKey("id"))
+    assert(abcDataMap.containsKey("slug"))
+  }
+}

--- a/naptime/src/test/scala/org/coursera/naptime/ari/engine/EngineImplTest.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/ari/engine/EngineImplTest.scala
@@ -1,12 +1,11 @@
 package org.coursera.naptime.ari.engine
 
 import com.google.inject.Injector
+import com.linkedin.data.DataList
 import org.coursera.naptime.ResourceName
-import org.coursera.naptime.ResponsePagination
 import org.coursera.naptime.ari.FetcherApi
 import org.coursera.naptime.ari.Request
 import org.coursera.naptime.ari.RequestField
-import org.coursera.naptime.ari.ResourceResponse
 import org.coursera.naptime.ari.Response
 import org.coursera.naptime.ari.TopLevelRequest
 import org.coursera.naptime.ari.graphql.models.MergedCourse
@@ -17,6 +16,7 @@ import org.coursera.naptime.router2.ResourceRouterBuilder
 import org.coursera.naptime.schema.Resource
 import org.coursera.naptime.schema.ResourceKind
 import org.junit.Test
+import org.mockito.Matchers.any
 import org.mockito.Mockito.when
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.junit.AssertionsForJUnit
@@ -24,7 +24,9 @@ import org.scalatest.mock.MockitoSugar
 import play.api.libs.json.JsString
 import play.api.test.FakeRequest
 
+import scala.collection.JavaConverters._
 import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
 
 class EngineImplTest extends AssertionsForJUnit with ScalaFutures with MockitoSugar {
 
@@ -32,7 +34,7 @@ class EngineImplTest extends AssertionsForJUnit with ScalaFutures with MockitoSu
 
   val fetcherApi = mock[FetcherApi]
 
-  val extraTypes = TYPE_SCHEMAS.map { case (key, value) => Keyed(key, value)}.toList
+  val extraTypes = TYPE_SCHEMAS.map { case (key, value) => Keyed(key, value) }.toList
 
   val courseRouterBuilder = mock[ResourceRouterBuilder]
   when(courseRouterBuilder.schema).thenReturn(COURSES_RESOURCE)
@@ -62,23 +64,28 @@ class EngineImplTest extends AssertionsForJUnit with ScalaFutures with MockitoSu
             RequestField("slug", None, Set.empty, List.empty),
             RequestField("name", None, Set.empty, List.empty))))))
 
+    val topLevelDataList = new DataList()
+    topLevelDataList.add(COURSE_A.id)
     val fetcherResponse = Response(
-      Map(COURSES_RESOURCE_ID -> ResourceResponse(
-        key = COURSES_RESOURCE_ID.identifier,
-        models = List(COURSE_A.data()),
-        pagination = ResponsePagination(next = None)))
-    )
+      topLevelIds = Map(request.topLevelRequests.head -> topLevelDataList),
+      data = Map(COURSES_RESOURCE_ID -> Map(
+        COURSE_A.id -> COURSE_A.data())))
 
     when(fetcherApi.data(request)).thenReturn(Future.successful(fetcherResponse))
 
     val result = engine.execute(request).futureValue
 
-    assert(result.output.contains(COURSES_RESOURCE_ID))
-    val coursesResult = result.output(COURSES_RESOURCE_ID)
-    assert(1 === coursesResult.models.length)
-    assert(COURSE_A.id === coursesResult.models.head.getString("id"))
-    assert(COURSE_A.name === coursesResult.models.head.getString("name"))
-    assert(COURSE_A.slug === coursesResult.models.head.getString("slug"))
+    assert(result.topLevelIds.contains(request.topLevelRequests.head))
+    assert(1 === result.topLevelIds(request.topLevelRequests.head).size())
+    assert(COURSE_A.id === result.topLevelIds(request.topLevelRequests.head).get(0))
+    assert(result.data.contains(COURSES_RESOURCE_ID))
+    val coursesData = result.data(COURSES_RESOURCE_ID)
+    assert(1 === coursesData.size)
+    assert(coursesData.contains(COURSE_A.id))
+    val courseAResponse = coursesData(COURSE_A.id)
+    assert(COURSE_A.id === courseAResponse.getString("id"))
+    assert(COURSE_A.name === courseAResponse.getString("name"))
+    assert(COURSE_A.slug === courseAResponse.getString("slug"))
   }
 
   @Test
@@ -96,27 +103,106 @@ class EngineImplTest extends AssertionsForJUnit with ScalaFutures with MockitoSu
             RequestField("name", None, Set.empty, List.empty),
             RequestField("title", None, Set.empty, List.empty))))))
 
+    val topLevelDataList = new DataList()
+    topLevelDataList.add(INSTRUCTOR_1.id)
     val fetcherResponse = Response(
-      Map(INSTRUCTORS_RESOURCE_ID -> ResourceResponse(
-        key = INSTRUCTORS_RESOURCE_ID.identifier,
-        models = List(INSTRUCTOR_1.data()),
-        pagination = ResponsePagination(next = None))))
+      topLevelIds = Map(request.topLevelRequests.head -> topLevelDataList),
+      data = Map(INSTRUCTORS_RESOURCE_ID -> Map(
+        INSTRUCTOR_1.id -> INSTRUCTOR_1.data())))
 
     when(fetcherApi.data(request)).thenReturn(Future.successful(fetcherResponse))
 
     val result = engine.execute(request).futureValue
 
-    assert(result.output.contains(INSTRUCTORS_RESOURCE_ID))
-    val instructorsResult = result.output(INSTRUCTORS_RESOURCE_ID)
-    assert(1 === instructorsResult.models.length)
-    assert(INSTRUCTOR_1.id === instructorsResult.models.head.getString("id"))
-    assert(INSTRUCTOR_1.name === instructorsResult.models.head.getString("name"))
-    assert(INSTRUCTOR_1.title === instructorsResult.models.head.getString("title"))
+    assert(result.topLevelIds.contains(request.topLevelRequests.head))
+    assert(1 === result.topLevelIds(request.topLevelRequests.head).size())
+    assert(INSTRUCTOR_1.id === result.topLevelIds(request.topLevelRequests.head).get(0))
+    assert(result.data.contains(INSTRUCTORS_RESOURCE_ID))
+    val instructorsData = result.data(INSTRUCTORS_RESOURCE_ID)
+    assert(1 === instructorsData.size)
+    assert(instructorsData.contains(INSTRUCTOR_1.id))
+    val instructor1Response = instructorsData(INSTRUCTOR_1.id)
+    assert(INSTRUCTOR_1.id === instructor1Response.getString("id"))
+    assert(INSTRUCTOR_1.name === instructor1Response.getString("name"))
+    assert(INSTRUCTOR_1.title === instructor1Response.getString("title"))
   }
+
+  // TODO: Check pagination.
 
   // TODO: Add sophisticated tests that involve joining resources.
 
   // TODO: Add invalid schema-based tests.
+
+  /**
+   * Runs 2 simple top level requests for independent resources, and ensures the response is appropriately merged.
+   */
+  @Test
+  def multiResourceFetch(): Unit = {
+    val request = Request(
+      requestHeader = FakeRequest(),
+      topLevelRequests = List(
+        TopLevelRequest(
+          resource = COURSES_RESOURCE_ID,
+          selection = RequestField(
+            name = "get",
+            alias = None,
+            args = Set("id" -> JsString(COURSE_A.id)),
+            selections = List(
+              RequestField("id", None, Set.empty, List.empty),
+              RequestField("slug", None, Set.empty, List.empty),
+              RequestField("name", None, Set.empty, List.empty)))),
+        TopLevelRequest(
+          resource = INSTRUCTORS_RESOURCE_ID,
+          selection = RequestField(
+            name = "InstructorsV1",
+            alias = None,
+            args = Set("id" -> JsString(INSTRUCTOR_1.id)),
+            selections = List(
+              RequestField("id", None, Set.empty, List.empty),
+              RequestField("name", None, Set.empty, List.empty),
+              RequestField("title", None, Set.empty, List.empty))))))
+
+    val topLevelDataListCourse = new DataList(List(COURSE_A.id).asJava)
+    val fetcherResponseCourse = Response(
+      topLevelIds = Map(request.topLevelRequests.head -> topLevelDataListCourse),
+      data = Map(COURSES_RESOURCE_ID -> Map(
+        COURSE_A.id -> COURSE_A.data())))
+    val topLevelDataListInstructor = new DataList()
+    topLevelDataListInstructor.add(INSTRUCTOR_1.id)
+    val fetcherResponseInstructors = Response(
+      topLevelIds = Map(request.topLevelRequests.tail.head -> topLevelDataListInstructor),
+      data = Map(INSTRUCTORS_RESOURCE_ID -> Map(
+        INSTRUCTOR_1.id -> INSTRUCTOR_1.data())))
+
+    when(fetcherApi.data(any())).thenReturn(
+      Future.successful(fetcherResponseCourse), Future.successful(fetcherResponseInstructors))
+
+    val result = engine.execute(request).futureValue
+
+    assert(result.topLevelIds.contains(request.topLevelRequests.head))
+    assert(1 === result.topLevelIds(request.topLevelRequests.head).size())
+    assert(COURSE_A.id === result.topLevelIds(request.topLevelRequests.head).get(0))
+    assert(result.data.contains(COURSES_RESOURCE_ID))
+    val coursesData = result.data(COURSES_RESOURCE_ID)
+    assert(1 === coursesData.size)
+    assert(coursesData.contains(COURSE_A.id))
+    val courseAResponse = coursesData(COURSE_A.id)
+    assert(COURSE_A.id === courseAResponse.getString("id"))
+    assert(COURSE_A.name === courseAResponse.getString("name"))
+    assert(COURSE_A.slug === courseAResponse.getString("slug"))
+
+    assert(result.topLevelIds.contains(request.topLevelRequests.head))
+    assert(1 === result.topLevelIds(request.topLevelRequests.head).size())
+    assert(INSTRUCTOR_1.id === result.topLevelIds(request.topLevelRequests.tail.head).get(0))
+    assert(result.data.contains(INSTRUCTORS_RESOURCE_ID))
+    val instructorsData = result.data(INSTRUCTORS_RESOURCE_ID)
+    assert(1 === instructorsData.size)
+    assert(instructorsData.contains(INSTRUCTOR_1.id))
+    val instructor1Response = instructorsData(INSTRUCTOR_1.id)
+    assert(INSTRUCTOR_1.id === instructor1Response.getString("id"))
+    assert(INSTRUCTOR_1.name === instructor1Response.getString("name"))
+    assert(INSTRUCTOR_1.title === instructor1Response.getString("title"))
+  }
 }
 
 object EngineImplTest {


### PR DESCRIPTION
This commit implements the long term response model, as per the design
discussions. It converts all ARI-related code to use it, and adds a
number of tests to ensure correctness.

Additionally, thanks to the new response model, we are able to implement
a more sophisticated handling of multiple top-level requests in the
engine.