### PR TITLE
Support basic joins.

### DIFF
--- a/naptime/src/main/scala/org/coursera/naptime/ari/engine/EngineImpl.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/ari/engine/EngineImpl.scala
@@ -2,42 +2,108 @@ package org.coursera.naptime.ari.engine
 
 import javax.inject.Inject
 
-import com.linkedin.data.schema.DataSchema
+import com.linkedin.data.schema.RecordDataSchema
+import com.typesafe.scalalogging.StrictLogging
+import org.coursera.naptime.ResourceName
+import org.coursera.naptime.Types.Relations
 import org.coursera.naptime.ari.EngineApi
 import org.coursera.naptime.ari.FetcherApi
 import org.coursera.naptime.ari.Request
+import org.coursera.naptime.ari.RequestField
 import org.coursera.naptime.ari.Response
+import org.coursera.naptime.ari.TopLevelRequest
 import org.coursera.naptime.router2.NaptimeRoutes
 import org.coursera.naptime.schema.Resource
+import play.api.libs.json.JsString
 
+import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
 class EngineImpl @Inject() (
     naptimeRoutes: NaptimeRoutes,
     fetcher: FetcherApi)
-    (implicit executionContext: ExecutionContext) extends EngineApi {
+    (implicit executionContext: ExecutionContext) extends EngineApi with StrictLogging {
 
-  override val schemas: Seq[Resource] = naptimeRoutes.routerBuilders.map(_.schema).toList
+  private[this] val resourceSchemas: Map[ResourceName, Resource] = naptimeRoutes.schemaMap.flatMap {
+    case (_, schema) if schema.parentClass.isEmpty => // TODO: handle sub resources
+      val resourceName = ResourceName(schema.name, version = schema.version.getOrElse(0L).toInt)
+      Some(resourceName -> schema)
+    case (_, schema) =>
+      logger.warn(s"Cannot handle nested resource $schema")
+      None
+  }
 
-  override val models: Map[String, DataSchema] =
-    naptimeRoutes.routerBuilders.foldLeft(Map[String, DataSchema]()) { case (allTypes, routerBuilder) =>
-      allTypes ++ routerBuilder.types.flatMap { keyedSchema =>
-        keyedSchema.value match {
-          case recordSchemaValue: DataSchema => Some(keyedSchema.key -> recordSchemaValue)
-          case _ => None
-        }
-      }
-    }
+  private[this] val mergedTypes = naptimeRoutes.routerBuilders.flatMap(_.types.map(_.tuple))
+    .filter(_._2.isInstanceOf[RecordDataSchema])
+    .map(tuple => tuple._1 -> tuple._2.asInstanceOf[RecordDataSchema]).toMap
 
   override def execute(request: Request): Future[Response] = {
     val responseFutures = request.topLevelRequests.map { topLevelRequest =>
-      val singleRequest = Request(request.requestHeader, List(topLevelRequest))
-      fetcher.data(singleRequest)
+      executeTopLevelRequest(request, topLevelRequest)
     }
     val futureResponses = Future.sequence(responseFutures)
     futureResponses.map { responses =>
       responses.foldLeft(Response.empty)(_ ++ _)
+    }
+  }
+
+  private[this] def executeTopLevelRequest(request: Request, topLevelRequest: TopLevelRequest): Future[Response] = {
+    val singleRequest = Request(request.requestHeader, List(topLevelRequest))
+    val topLevelResponse = fetcher.data(singleRequest)
+
+    topLevelResponse.flatMap { topLevelResponse =>
+      // If we have a schema, we can perform automatic resource inclusion.
+      (for {
+        topLevelSchema <- resourceSchemas.get(topLevelRequest.resource)
+        mergedType <- mergedTypes.get(topLevelSchema.mergedType)
+      } yield {
+        val topLevelData = topLevelResponse.data.get(topLevelRequest.resource).toIterable.flatMap { dataMap =>
+          dataMap.values
+        }
+        val nestedLookups = topLevelRequest.selection.selections.filter(_.selections.nonEmpty)
+        val additionalResponses = nestedLookups.map { nestedField =>
+          val relatedResource = Option(mergedType.getField(nestedField.name)).flatMap { field =>
+            Option(field.getProperties.get(Relations.PROPERTY_NAME)).map {
+              case idString: String =>
+                ResourceName.parse(idString).getOrElse {
+                  throw new IllegalStateException(s"Could not parse identifier '$idString' for field '$field' in " +
+                    s"merged type $mergedType")
+                }
+              case identifier =>
+                throw new IllegalStateException(s"Unexpected type for identifier '$identifier' for field '$field' " +
+                  s"in merged type $mergedType")
+            }
+          }.getOrElse {
+            throw new IllegalStateException(s"Could not find nested field $nestedField on merged type $mergedType")
+          }
+
+          val multiGetIds = topLevelData.flatMap { elem =>
+            // TODO: support single foreign key relations (currently this supports only nested lists)
+            val field = Option(elem.getDataList(nestedField.name)).map(_.asScala).getOrElse {
+              logger.debug(s"Field $nestedField was not found / was not a data list in $elem for query $request")
+              List.empty
+            }
+            field
+          }.toSet.map[String, Set[String]](_.toString).mkString(",") // TODO: escape appropriately.
+
+          val relatedTopLevelRequest = TopLevelRequest(
+            resource = relatedResource,
+            selection = RequestField(
+              name = "multiGet",
+              alias = None,
+              args = Set("ids" -> JsString(multiGetIds)), // TODO: pass through original request fields for pagination / etc.
+              selections = nestedField.selections))
+          val relatedRequest = Request(request.requestHeader, List(relatedTopLevelRequest))
+          fetcher.data(relatedRequest).map { response =>
+            // Exclude the top level ids in the response.
+            Response(topLevelIds = Map.empty, data = response.data)
+          }
+        }
+        Future.sequence(additionalResponses).map { additionalResponses =>
+          additionalResponses.foldLeft(topLevelResponse)(_ ++ _)
+        }
+      }).getOrElse(Future.successful(topLevelResponse))
     }
   }
 }

--- a/naptime/src/main/scala/org/coursera/naptime/ari/models.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/ari/models.scala
@@ -2,9 +2,7 @@ package org.coursera.naptime.ari
 
 import com.linkedin.data.DataList
 import com.linkedin.data.DataMap
-import com.linkedin.data.schema.DataSchema
 import org.coursera.naptime.ResourceName
-import org.coursera.naptime.schema.Resource
 import play.api.libs.json.JsValue
 import play.api.mvc.RequestHeader
 
@@ -27,16 +25,6 @@ trait EngineApi {
    *         layer to turn that into the response format as required.
    */
   def execute(request: Request): Future[Response]
-
-  /**
-   * Gets the Naptime schema currently in use by the presentation layer.
-   */
-  def schemas: Seq[Resource]
-
-  /**
-   * The set of all the types that make up this collection of resources.
-   */
-  def models: Map[String, DataSchema]
 }
 
 /**


### PR DESCRIPTION
This commit adds support for a single level of automated nested/joining
of related resources. Subsequent commits will add support for more
foreign-key types of joins, as well as support alternate joins such
as reverse includes / etc.

Additionally, this commit cleans up the engine API. There were unused
components of the engine API that won't be used. By removing the
unnecessary additional fields in the engine API, we avoid tangling the
code and subsequent developer confusion.