### PR TITLE
Support single element joins.

### DIFF
--- a/naptime/src/main/scala/org/coursera/naptime/ari/graphql/SangriaGraphQlSchemaBuilder.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/ari/graphql/SangriaGraphQlSchemaBuilder.scala
@@ -317,6 +317,7 @@ class SangriaGraphQlSchemaBuilder(
         context => getSangriaResolverForSchema(typerefField.getDereferencedDataSchema, fieldName)
       case unionField: UnionDataSchema => context => context.value.getDataMap(fieldName)
       case arrayField: ArrayDataSchema => context => context.value.getDataList(fieldName)
+      case recordField: RecordDataSchema => context => context.value.getDataMap(fieldName)
     }
 
     baseResolver.andThen(res => Value(res))

--- a/naptime/src/test/pegasus/org/coursera/naptime/ari/graphql/models/Coordinates.courier
+++ b/naptime/src/test/pegasus/org/coursera/naptime/ari/graphql/models/Coordinates.courier
@@ -1,0 +1,16 @@
+namespace org.coursera.naptime.ari.graphql.models
+
+/**
+ * Geographical coordinates for a university for display on a map.
+ */
+record Coordinates {
+  /**
+   * The latitude of a location on the globe.
+   */
+  latitude: double
+
+  /**
+   * The longitude of a location on the globe.
+   */
+  longitude: double
+}

--- a/naptime/src/test/pegasus/org/coursera/naptime/ari/graphql/models/MergedCourse.courier
+++ b/naptime/src/test/pegasus/org/coursera/naptime/ari/graphql/models/MergedCourse.courier
@@ -1,7 +1,5 @@
 namespace org.coursera.naptime.ari.graphql.models
 
-import org.coursera.naptime.ari.graphql.models.InstructorId
-
 record MergedCourse {
   id: string
 
@@ -13,6 +11,9 @@ record MergedCourse {
 
   @related = "instructors.v1"
   instructors: array[InstructorId]
+
+  @related = "partners.v1"
+  partner: PartnerId
 
   originalId: union[int, string]
 }

--- a/naptime/src/test/pegasus/org/coursera/naptime/ari/graphql/models/MergedPartner.courier
+++ b/naptime/src/test/pegasus/org/coursera/naptime/ari/graphql/models/MergedPartner.courier
@@ -1,0 +1,14 @@
+namespace org.coursera.naptime.ari.graphql.models
+
+record MergedPartner {
+  id: PartnerId
+
+  name: string
+
+  slug: string
+
+  geolocation: Coordinates
+
+  // TODO: add reverse relations.
+
+}

--- a/naptime/src/test/pegasus/org/coursera/naptime/ari/graphql/models/PartnerId.courier
+++ b/naptime/src/test/pegasus/org/coursera/naptime/ari/graphql/models/PartnerId.courier
@@ -1,0 +1,3 @@
+namespace org.coursera.naptime.ari.graphql.models
+
+typeref PartnerId = int

--- a/naptime/src/test/scala/org/coursera/naptime/ari/graphql/SangriaGraphQlSchemaBuilderTest.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/ari/graphql/SangriaGraphQlSchemaBuilderTest.scala
@@ -19,6 +19,7 @@ package org.coursera.naptime.ari.graphql
 import org.coursera.courier.templates.ScalaRecordTemplate
 import org.coursera.naptime.ari.graphql.models.MergedCourse
 import org.coursera.naptime.ari.graphql.models.MergedInstructor
+import org.coursera.naptime.ari.graphql.models.MergedPartner
 import org.coursera.naptime.schema.Resource
 import org.coursera.naptime.schema.ResourceKind
 import org.junit.Test
@@ -51,11 +52,23 @@ class SangriaGraphQlSchemaBuilderTest extends AssertionsForJUnit {
     className = "",
     attributes = List.empty)
 
-  val allResources = Set(courseResource, instructorResource)
+  val partnersResource = Resource(
+    kind = ResourceKind.COLLECTION,
+    name = "partners",
+    version = Some(1),
+    keyType = "",
+    valueType = "",
+    mergedType = "org.coursera.naptime.ari.graphql.models.MergedPartner",
+    handlers = List.empty,
+    className = "",
+    attributes = List.empty)
+
+  val allResources = Set(courseResource, instructorResource, partnersResource)
 
   val schemaTypes = Map(
     "org.coursera.naptime.ari.graphql.models.MergedCourse" -> MergedCourse.SCHEMA,
-    "org.coursera.naptime.ari.graphql.models.MergedInstructor" -> MergedInstructor.SCHEMA)
+    "org.coursera.naptime.ari.graphql.models.MergedInstructor" -> MergedInstructor.SCHEMA,
+    "org.coursera.naptime.ari.graphql.models.MergedPartner" -> MergedPartner.SCHEMA)
 
   val builder = new SangriaGraphQlSchemaBuilder(allResources, schemaTypes)
 
@@ -66,7 +79,7 @@ class SangriaGraphQlSchemaBuilderTest extends AssertionsForJUnit {
     val courseResourceObjectType =
       courseResourceType.asInstanceOf[ObjectType[Unit, ScalaRecordTemplate]]
     val fieldNames = courseResourceObjectType.fieldsByName.keySet
-    val expectedFieldNames = Set("name", "description", "slug", "instructors", "id", "originalId")
+    val expectedFieldNames = Set("name", "description", "slug", "instructors", "id", "originalId", "partner")
     assert(fieldNames === expectedFieldNames)
   }
 


### PR DESCRIPTION
In this commit, we add support for joining against single foreign key
fields.

Additionally, we add a test to ensure that complex fields do not cause
the engine trouble.