### PR TITLE
Use fully-qualified reference to Keyed

### DIFF
--- a/naptime/src/main/scala/org/coursera/naptime/router2/MacroImpls.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/router2/MacroImpls.scala
@@ -277,8 +277,8 @@ class MacroImpls(val c: blackbox.Context) {
               bodySchema,
               stubInstance.Fields))
         }).toList ++ List(
-          keySchemaOption.map(Keyed(${keyType.typeSymbol.fullName}, _)),
-          bodySchemaOption.map(Keyed(${bodyType.typeSymbol.fullName}, _))).flatten
+          keySchemaOption.map(org.coursera.naptime.model.Keyed(${keyType.typeSymbol.fullName}, _)),
+          bodySchemaOption.map(org.coursera.naptime.model.Keyed(${bodyType.typeSymbol.fullName}, _))).flatten
       }"""
     }
 


### PR DESCRIPTION
The latest version of naptime causes the following error when compiling:
```
[error] /Users/bryan/base/coursera/infra-services/services/rapidash/app/org/coursera/rapidash/RapidashModule.scala:40: not found: value Keyed
[error]     bindResource[AppResource]
```

Using the full reference to `Keyed` should resolve this.

PTAL @saeta . cc @yifan-coursera 