### PR TITLE
Fix computing full path.

### DIFF
--- a/naptime/src/main/scala/org/coursera/naptime/router2/NaptimePlayRouter.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/router2/NaptimePlayRouter.scala
@@ -142,7 +142,8 @@ case class NaptimePlayRouter (
       * @return (PathWithoutKeys, PathWithKeySuffix)
       */
     def computeFullPath(resourceSchema: schema.Resource): (String, String) = {
-      val previous = if (resourceSchema.parentClass.isDefined) {
+      val previous = if (resourceSchema.parentClass.isDefined &&
+          !resourceSchema.parentClass.contains("org.coursera.naptime.resources.RootResource")) {
         try {
           computeFullPath(naptimeRoutes.schemaMap(resourceSchema.parentClass.get))._2
         } catch {


### PR DESCRIPTION
Computing the full path is required to display the correct documentation.
In order to handle nested resources correctly, we need to stop recursing
when we hit the root resource. This commit fixes that.