### PR TITLE
Support arbitrary recursive nesting of resources.

### DIFF
--- a/naptime/src/test/pegasus/org/coursera/naptime/ari/graphql/models/MergedInstructor.courier
+++ b/naptime/src/test/pegasus/org/coursera/naptime/ari/graphql/models/MergedInstructor.courier
@@ -13,4 +13,7 @@ record MergedInstructor {
 
   @related = "courses.v1"
   courses: array[CourseId]
+
+  @related = "partners.v1"
+  partner: PartnerId
 }

--- a/naptime/src/test/scala/org/coursera/naptime/ari/engine/EngineImplTest.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/ari/engine/EngineImplTest.scala
@@ -19,7 +19,6 @@ import org.coursera.naptime.schema.Resource
 import org.coursera.naptime.schema.ResourceKind
 import org.hamcrest.Matcher
 import org.junit.Test
-import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatcher
 import org.mockito.Matchers.any
 import org.mockito.Matchers.argThat
@@ -46,14 +45,13 @@ class InstructorsResource
  * TODO:
  *  - Check pagination (both in response, and in requests)
  *  - Add invalid schema tests
- *  - Add multi-level joining (not just at the top level)
  *  - Add infinite-recursive joining. (Also investigate caching / short circuit evaluation.)
  *  - Add reverse-includes tests.
  *  - Add naptime resource failures (i.e. related include fetch fails.)
  *     - Add multiple independent top level requests with partial failures.
- *  - Add tests to verify correct ID escaping for multigets.
- *  - Add tests for correct handling of field arguments.
- *  - Add tests for subresources.
+ *  - Add tests to verify correct ID escaping.
+ *  - Add tests for correct handling of request field arguments (pagination, reverse includes arguments).
+ *  - Add tests for sub-resources.
  *  - Add a test to check for optimal fetching. (i.e. fetch courses -> instructors,
  *    and courses -> partners, and instructors -> partners, and ensure that there is only a single
  *    multi-get made on the partners resource.)
@@ -548,6 +546,122 @@ class EngineImplTest extends AssertionsForJUnit with ScalaFutures with MockitoSu
     assert(PARTNER_123.slug === partner123Response.getString("slug"))
     assert(PARTNER_123.geolocation.data() === partner123Response.getDataMap("geolocation"))
   }
+
+  /**
+   * Tests joining not just to the top level request, but to sub-requests.
+   */
+  @Test
+  def multiHopJoining(): Unit = {
+    val partnerField =
+      RequestField("partner", None, Set.empty, List(
+        RequestField("id", None, Set.empty, List.empty),
+        RequestField("name", None, Set.empty, List.empty),
+        RequestField("slug", None, Set.empty, List.empty),
+        RequestField("geolocation", None, Set.empty, List(
+          RequestField("latitude", None, Set.empty, List.empty),
+          RequestField("longitude", None, Set.empty, List.empty)))))
+    val instructorField =
+      RequestField("instructors", None, Set.empty, List(
+        RequestField("id", None, Set.empty, List.empty),
+        RequestField("name", None, Set.empty, List.empty),
+        partnerField))
+    val request = Request(
+      requestHeader = FakeRequest(),
+      topLevelRequests = List(
+        TopLevelRequest(
+          resource = COURSES_RESOURCE_ID,
+          selection = RequestField(
+            name = "search",
+            alias = None,
+            args = Set("query" -> JsString("ai classes")),
+            selections = List(
+              RequestField("id", None, Set.empty, List.empty),
+              RequestField("slug", None, Set.empty, List.empty),
+              RequestField("name", None, Set.empty, List.empty),
+              instructorField)))))
+
+    val fetcherResponseCourse = Response(
+      topLevelIds = Map(request.topLevelRequests.head -> new DataList(List(COURSE_A.id, COURSE_B.id).asJava)),
+      data = Map(COURSES_RESOURCE_ID -> Map(COURSE_A.id -> COURSE_A.data(), COURSE_B.id -> COURSE_B.data())))
+
+    val expectedInstructorRequest = TopLevelRequest(
+      resource = INSTRUCTORS_RESOURCE_ID,
+      selection = RequestField(
+        name = "multiGet",
+        alias = None,
+        args = Set("ids" -> JsString(s"${INSTRUCTOR_1.id},${INSTRUCTOR_2.id}")),
+        selections = instructorField.selections))
+    val fetcherResponseInstructors = Response(
+      topLevelIds = Map(expectedInstructorRequest -> new DataList(List(INSTRUCTOR_1.id, INSTRUCTOR_2.id).asJava)),
+      data = Map(INSTRUCTORS_RESOURCE_ID -> Map(
+        INSTRUCTOR_1.id -> INSTRUCTOR_1.data(), INSTRUCTOR_2.id -> INSTRUCTOR_2.data())))
+
+    val expectedPartnersRequest = TopLevelRequest(
+      resource = PARTNERS_RESOURCE_ID,
+      selection = RequestField(
+        name = "multiGet",
+        alias = None,
+        args = Set("ids" -> JsString(s"${PARTNER_123.id}")),
+        selections = partnerField.selections))
+    val fetcherResponsePartners = Response(
+      topLevelIds = Map(expectedPartnersRequest -> new DataList(List(new Integer(PARTNER_123.id)).asJava)),
+      data = Map(PARTNERS_RESOURCE_ID -> Map(new Integer(PARTNER_123.id) -> PARTNER_123.data())))
+
+    when(fetcherApi.data(argThat(MatchesResourceType(COURSES_RESOURCE_ID)))).thenReturn(
+      Future.successful(fetcherResponseCourse))
+    when(fetcherApi.data(argThat(MatchesResourceType(PARTNERS_RESOURCE_ID)))).thenReturn(
+      Future.successful(fetcherResponsePartners))
+    when(fetcherApi.data(argThat(MatchesResourceType(INSTRUCTORS_RESOURCE_ID)))).thenReturn(
+      Future.successful(fetcherResponseInstructors))
+
+    val result = engine.execute(request).futureValue
+
+    assert(1 === result.topLevelIds.size, s"Result: $result")
+    assert(result.topLevelIds.contains(request.topLevelRequests.head))
+    assert(2 === result.topLevelIds(request.topLevelRequests.head).size())
+    assert(COURSE_A.id === result.topLevelIds(request.topLevelRequests.head).get(0))
+    assert(COURSE_B.id === result.topLevelIds(request.topLevelRequests.head).get(1))
+
+    assert(result.data.contains(COURSES_RESOURCE_ID))
+    val coursesData = result.data(COURSES_RESOURCE_ID)
+    assert(2 === coursesData.size)
+    assert(coursesData.contains(COURSE_A.id))
+    val courseAResponse = coursesData(COURSE_A.id)
+    assert(COURSE_A.id === courseAResponse.getString("id"))
+    assert(COURSE_A.name === courseAResponse.getString("name"))
+    assert(COURSE_A.slug === courseAResponse.getString("slug"))
+    assert(coursesData.contains(COURSE_B.id))
+    val courseBResponse = coursesData(COURSE_B.id)
+    assert(COURSE_B.id === courseBResponse.getString("id"))
+    assert(COURSE_B.name === courseBResponse.getString("name"))
+    assert(COURSE_B.slug === courseBResponse.getString("slug"))
+
+    assert(result.data.contains(INSTRUCTORS_RESOURCE_ID))
+    val instructorsData = result.data(INSTRUCTORS_RESOURCE_ID)
+    assert(2 === instructorsData.size)
+    assert(instructorsData.contains(INSTRUCTOR_1.id))
+    val instructor1Response = instructorsData(INSTRUCTOR_1.id)
+    assert(INSTRUCTOR_1.id === instructor1Response.getString("id"))
+    assert(INSTRUCTOR_1.name === instructor1Response.getString("name"))
+    assert(INSTRUCTOR_1.title === instructor1Response.getString("title"))
+    assert(instructorsData.contains(INSTRUCTOR_2.id))
+    val instructor2Response = instructorsData(INSTRUCTOR_2.id)
+    assert(INSTRUCTOR_2.id === instructor2Response.getString("id"))
+    assert(INSTRUCTOR_2.name === instructor2Response.getString("name"))
+    assert(INSTRUCTOR_2.title === instructor2Response.getString("title"))
+
+    assert(result.data.contains(PARTNERS_RESOURCE_ID))
+    val partnersData = result.data(PARTNERS_RESOURCE_ID)
+    assert(1 === partnersData.size)
+    assert(partnersData.contains(new Integer(PARTNER_123.id)))
+    val partner123Response = partnersData(new Integer(PARTNER_123.id))
+    assert(PARTNER_123.id === partner123Response.getInteger("id"))
+    assert(PARTNER_123.name === partner123Response.getString("name"))
+    assert(PARTNER_123.slug === partner123Response.getString("slug"))
+    assert(PARTNER_123.geolocation.data() === partner123Response.getDataMap("geolocation"))
+
+    verify(fetcherApi, times(3)).data(any())
+  }
 }
 
 object EngineImplTest {
@@ -573,14 +687,16 @@ object EngineImplTest {
     name = "Professor X",
     title = "Chair",
     bio = "Professor X's bio",
-    courses = List(COURSE_A.id))
+    courses = List(COURSE_A.id),
+    partner = 123)
 
   val INSTRUCTOR_2 = MergedInstructor(
     id = "instructor2Id",
     name = "Professor Y",
     title = "Table",
     bio = "Professor Y's bio",
-    courses = List(COURSE_B.id))
+    courses = List(COURSE_B.id),
+    partner = 123)
 
   val PARTNER_123 = MergedPartner(
     id = 123,
@@ -609,7 +725,7 @@ object EngineImplTest {
     parentClass = None,
     keyType = "string",
     valueType = "org.coursera.naptime.test.Instructor",
-    mergedType = "org.coursera.naptime.test.InstructorsResourceModel",
+    mergedType = MergedInstructor.SCHEMA.getFullName,
     handlers = List.empty,
     className = "org.coursera.naptime.test.InstructorsResource",
     attributes = List.empty)
@@ -622,7 +738,7 @@ object EngineImplTest {
     parentClass = None,
     keyType = "string",
     valueType = "org.coursera.naptime.test.Partner",
-    mergedType = "org.coursera.naptime.test.PartnersResourceModel",
+    mergedType = MergedPartner.SCHEMA.getFullName,
     handlers = List.empty,
     className = "org.coursera.naptime.test.PartnersResource",
     attributes = List.empty)
@@ -633,5 +749,7 @@ object EngineImplTest {
     PARTNERS_RESOURCE)
 
   val TYPE_SCHEMAS = Map(
-    MergedCourse.SCHEMA.getFullName -> MergedCourse.SCHEMA)
+    MergedCourse.SCHEMA.getFullName -> MergedCourse.SCHEMA,
+    MergedInstructor.SCHEMA.getFullName -> MergedInstructor.SCHEMA,
+    MergedPartner.SCHEMA.getFullName -> MergedPartner.SCHEMA)
 }


### PR DESCRIPTION
If Resource A points to Resource B, and Resource B points to Resource C
a single query should be able to link everything up. This commit extends
our engine from supporting only a single hop, to supporting multiple
hops.