### PR TITLE
Convert naptime defaults to use ArbitraryValue courier type

### DIFF
--- a/naptime-testing/src/test/scala/org/coursera/naptime/NestedMacroCourierTests.scala
+++ b/naptime-testing/src/test/scala/org/coursera/naptime/NestedMacroCourierTests.scala
@@ -7,6 +7,7 @@ import org.coursera.naptime.model.Keyed
 import org.coursera.naptime.resources.CourierCollectionResource
 import org.coursera.naptime.router2.Router
 import org.junit.Test
+import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.junit.AssertionsForJUnit
 
 /**
@@ -14,8 +15,11 @@ import org.scalatest.junit.AssertionsForJUnit
  */
 object NestedMacroCourierTests {
 
+  object CoursesResource {
+    val ID = ResourceName("courses", 1)
+  }
   class CoursesResource extends CourierCollectionResource[String, Course] {
-    override def resourceName: String = "courses"
+    override def resourceName: String = CoursesResource.ID.topLevelName
 
     override implicit lazy val Fields: Fields[Course] = BaseFields.withRelated("instructors" -> ResourceName("instructors", 1))
 
@@ -76,7 +80,7 @@ object NestedMacroCourierTests {
   val instructorRouter = Router.build[InstructorsResource]
 }
 
-class NestedMacroCourierTests extends AssertionsForJUnit {
+class NestedMacroCourierTests extends AssertionsForJUnit with ScalaFutures {
 
   @Test
   def checkCoursesMergedType(): Unit = {

--- a/naptime-testing/src/test/scala/org/coursera/naptime/NestedMacroTests.scala
+++ b/naptime-testing/src/test/scala/org/coursera/naptime/NestedMacroTests.scala
@@ -16,6 +16,7 @@
 
 package org.coursera.naptime
 
+import com.linkedin.data.DataMap
 import com.linkedin.data.schema.DataSchema
 import com.linkedin.data.schema.RecordDataSchema
 import org.coursera.naptime.actions.NaptimeSerializer.AnyWrites._
@@ -33,6 +34,7 @@ import org.coursera.naptime.path.RootParsedPathKey
 import org.coursera.naptime.resources.CollectionResource
 import org.coursera.naptime.resources.TopLevelCollectionResource
 import org.coursera.naptime.router2.Router
+import org.coursera.naptime.schema.ArbitraryValue.StringMember
 import org.joda.time.DateTime
 import org.junit.Test
 import org.mockito.Mockito._
@@ -47,6 +49,7 @@ import play.api.mvc.AnyContentAsEmpty
 import play.api.mvc.BodyParsers
 import play.api.mvc.RequestHeader
 import play.api.test.FakeRequest
+
 import scala.collection.JavaConversions._
 
 /**
@@ -666,7 +669,7 @@ class NestedMacroTests extends AssertionsForJUnit with MockitoSugar {
     assert(withDefaultsSchema.parameters.map(_.name).toSet ===
       Set("ancestorKeys", "userName", "domain"))
     val domainSchema = withDefaultsSchema.parameters.find(_.name == "domain").get
-    assert(domainSchema.data.get("default") === "defaultDomain")
+    assert(StringMember(domainSchema.data.get("default").asInstanceOf[DataMap]).value === "defaultDomain")
 
     assert(schema.parentClass === Some(peopleInstanceImpl.getClass.getName))
 

--- a/naptime/src/main/pegasus/org/coursera/naptime/schema/ArbitraryRecord.courier
+++ b/naptime/src/main/pegasus/org/coursera/naptime/schema/ArbitraryRecord.courier
@@ -1,0 +1,11 @@
+namespace org.coursera.naptime.schema
+
+/**
+ * An empty record that allows us to package arbitrary Javascript data in a structured manner.
+ *
+ * Note: this is entirely an escape hatch from the Schema type system. Use judiciously!
+ */
+@passthroughExempt
+record ArbitraryRecord {
+  // Intentionally empty!
+}

--- a/naptime/src/main/pegasus/org/coursera/naptime/schema/ArbitraryValue.courier
+++ b/naptime/src/main/pegasus/org/coursera/naptime/schema/ArbitraryValue.courier
@@ -1,0 +1,12 @@
+namespace org.coursera.naptime.schema
+
+typeref ArbitraryValue = union[
+  ArbitraryRecord
+  int
+  string
+  long
+  float
+  double
+  bytes
+  boolean
+]

--- a/naptime/src/main/pegasus/org/coursera/naptime/schema/Parameter.courier
+++ b/naptime/src/main/pegasus/org/coursera/naptime/schema/Parameter.courier
@@ -19,5 +19,5 @@ record Parameter {
    * Note: this is computed on a best-effort basis and should be used only for documentation
    * purposes.
    */
-  default: JsValue?
+  default: ArbitraryValue?
 }

--- a/naptime/src/main/scala/org/coursera/naptime/router2/MacroImpls.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/router2/MacroImpls.scala
@@ -318,37 +318,57 @@ class MacroImpls(val c: blackbox.Context) {
         // TODO(saeta): handle path keys appropriately!
         val parameterModelName = TermName(c.freshName())
         // TODO(saeta): Handle attributes!
-        val baseTree = q"""
-          val $parameterModelName = org.coursera.naptime.schema.Parameter(
-            name = ${param.name.toString},
-            `type` = ${param.typeSignature.toString},
-            attributes = List.empty,
-            default = None
-          )
-        """
         if (param.asTerm.isParamWithDefault) {
           val defaultFnName = TermName(s"${method.name}$$default$$" + (i + 1))
           val defaultValue = if (param.typeSignature <:< DATA_TEMPLATE) {
-            q"stubInstance.$defaultFnName.data()"
+            q"""org.coursera.naptime.schema.ArbitraryValue.ArbitraryRecordMember(
+                  org.coursera.naptime.schema.ArbitraryRecord(
+                    stubInstance.$defaultFnName.data(),
+                    org.coursera.courier.templates.DataTemplates.DataConversion.SetReadOnly))"""
           } else if (param.typeSignature <:< ANY_VAL || param.typeSignature =:= STRING) {
             // TODO(saeta): Note: this does not handle case class Foo(val: Int) extends AnyVal!
-            q"stubInstance.$defaultFnName.asInstanceOf[AnyRef]"
+            q"""stubInstance.$defaultFnName.asInstanceOf[Any] match {
+                  case i: Int =>
+                    org.coursera.naptime.schema.ArbitraryValue.IntMember(i.asInstanceOf[Int])
+                  case s: String =>
+                    org.coursera.naptime.schema.ArbitraryValue.StringMember(s.asInstanceOf[String])
+                  case l: Long =>
+                    org.coursera.naptime.schema.ArbitraryValue.LongMember(l.asInstanceOf[Long])
+                  case f: Float =>
+                    org.coursera.naptime.schema.ArbitraryValue.FloatMember(f.asInstanceOf[Float])
+                  case d: Double =>
+                    org.coursera.naptime.schema.ArbitraryValue.DoubleMember(d.asInstanceOf[Double])
+                  case b: com.linkedin.data.ByteString =>
+                    org.coursera.naptime.schema.ArbitraryValue.ByteStringMember(b.asInstanceOf[com.linkedin.data.ByteString])
+                  case b: Boolean =>
+                    org.coursera.naptime.schema.ArbitraryValue.BooleanMember(b.asInstanceOf[Boolean])
+                  case _ =>
+                    org.coursera.naptime.schema.ArbitraryValue.StringMember("unknown default")
+               }"""
           } else {
             // TODO: handle extends scala.Map and scala.Traversable: Construct a data list / map
             // TODO: Try and infer an implicit json.OFormat, and convert to JsValue and then into
             //       a DataMap.
-            q""""unknown default""""
+            q"""org.coursera.naptime.schema.ArbitraryValue.StringMember("unknown default")"""
           }
-          val copiedMapName = TermName(c.freshName())
           q"""
-            $baseTree
-            val $copiedMapName = $parameterModelName.data().clone()
-            $copiedMapName.put("default", $defaultValue)
-            org.coursera.naptime.schema.Parameter($copiedMapName,
-              org.coursera.courier.templates.DataTemplates.DataConversion.SetReadOnly)
+            val defaultValue: org.coursera.naptime.schema.ArbitraryValue = $defaultValue
+            org.coursera.naptime.schema.Parameter(
+              name = ${param.name.toString},
+              `type` = ${param.typeSignature.toString},
+              attributes = List.empty,
+              default = Some(defaultValue)
+            )
           """
         } else {
-          q"$baseTree; $parameterModelName"
+          q"""
+            org.coursera.naptime.schema.Parameter(
+              name = ${param.name.toString},
+              `type` = ${param.typeSignature.toString},
+              attributes = List.empty,
+              default = None
+            )
+          """
         }
       }
       // TODO: handle input, custom output bodies, and attributes


### PR DESCRIPTION
This augments the "default" value for parameters in a REST action to include additional information about types. Currently, the default value is just the string representation of the value. However, because external clients don't have information about the resource schema, its impossible to know what type the default value is.

By using a Courier union type, we can include "metadata" about the default value's type, which can then be parsed by other servers more easily.

PTAL @saeta and @yifan-coursera 