### PR TITLE
Infer additional key type schemas

### DIFF
--- a/naptime-testing/src/test/scala/org/coursera/naptime/IdInferenceMacroTests.scala
+++ b/naptime-testing/src/test/scala/org/coursera/naptime/IdInferenceMacroTests.scala
@@ -1,0 +1,126 @@
+
+package org.coursera.naptime
+
+import com.linkedin.data.schema.DataSchema
+import com.linkedin.data.schema.RecordDataSchema
+import org.coursera.common.stringkey.StringKeyFormat
+import org.coursera.naptime.model.KeyFormat
+import org.coursera.naptime.resources.CourierCollectionResource
+import org.coursera.naptime.resources.TopLevelCollectionResource
+import org.coursera.naptime.router2.Router
+import org.joda.time.DateTime
+import org.junit.Test
+import org.scalatest.junit.AssertionsForJUnit
+import play.api.libs.json.Json
+import play.api.libs.json.OFormat
+import play.api.libs.json.OWrites
+
+import scala.util.Try
+
+object IdInferenceMacroTests {
+  sealed trait CourseId
+  object CourseId {
+    implicit val stringKeyFormat = StringKeyFormat.unimplementedFormat[CourseId]
+    implicit val keyFormat = KeyFormat.idAsStringOnly
+
+    def apply(idString: String): CourseId = {
+      Try(idString.toInt).map(LegacyCourseId).getOrElse(NewCourseId(idString))
+    }
+  }
+  case class LegacyCourseId(id: Int) extends CourseId
+  case class NewCourseId(id: String) extends CourseId
+
+  class CourseResource extends CourierCollectionResource[CourseId, Course] {
+    override def resourceName: String = "courses"
+    def getAll = Nap.getAll(ctx => ???)
+  }
+
+  object CourseResource {
+    val routerBuilder = Router.build[CourseResource]
+  }
+
+  case class UserId(id: Int)
+  object UserId {
+    implicit val stringKeyFormat: StringKeyFormat[UserId] = StringKeyFormat.caseClassFormat(apply, unapply)
+    implicit val keyFormat: KeyFormat[UserId] = KeyFormat.idAsPrimitive(apply, unapply)
+  }
+
+  sealed trait MembershipId {
+    def userId: UserId
+    def courseId: CourseId
+  }
+
+  object MembershipId {
+    implicit val stringKeyFormat = StringKeyFormat.unimplementedFormat[MembershipId]
+    implicit val keyFormat: KeyFormat[MembershipId] = {
+      val writes = OWrites[MembershipId] { membershipId =>
+        Json.obj(
+          "userId" -> membershipId.userId,
+          "courseId" -> membershipId.courseId)
+      }
+      KeyFormat.idAsStringWithFields(writes)
+    }
+    def apply(userId: UserId, courseId: CourseId): MembershipId = ???
+  }
+
+  case class CourseGrade(score: Double, issued: DateTime)
+
+  object CourseGrade {
+    implicit val jsonFormat = Json.format[CourseGrade]
+  }
+
+  case class Membership(
+    enrolledTimestamp: Option[DateTime],
+    grade: Option[CourseGrade])
+
+  object Membership {
+    implicit val jsonFormat = Json.format[Membership]
+  }
+
+  class MembershipResource extends TopLevelCollectionResource[MembershipId, Membership] {
+    override def keyFormat: KeyFormat[KeyType] = MembershipId.keyFormat
+    override implicit def resourceFormat: OFormat[Membership] = Membership.jsonFormat
+    override def resourceName: String = "memberships"
+    implicit val fields = Fields
+
+    def getAll = Nap.getAll(ctx => ???)
+  }
+  object MembershipResource {
+    val routerBuilder = Router.build[MembershipResource]
+  }
+}
+
+class IdInferenceMacroTests extends AssertionsForJUnit {
+
+  @Test
+  def coursesTypesGeneration(): Unit = {
+    val types = IdInferenceMacroTests.CourseResource.routerBuilder.types
+    assert(3 === types.size, s"$types")
+    val resourceType = types.find(
+      _.key == "org.coursera.naptime.IdInferenceMacroTests.CourseResource.Model").getOrElse {
+        assert(false, s"Could not find merged type in types list $types")
+        ???
+      }
+    assert(!resourceType.value.hasError)
+    assert(resourceType.value.isComplex)
+    assert(resourceType.value.getType === DataSchema.Type.RECORD)
+    assert(resourceType.value.isInstanceOf[RecordDataSchema])
+    assert(resourceType.value.asInstanceOf[RecordDataSchema].getFields.size() === 4)
+  }
+
+  @Test
+  def membershipsTypesGeneration(): Unit = {
+    val types = IdInferenceMacroTests.MembershipResource.routerBuilder.types
+    assert(3 === types.size, s"$types")
+    val resourceType = types.find(
+      _.key == "org.coursera.naptime.IdInferenceMacroTests.MembershipResource.Model").getOrElse {
+        assert(false, s"Could not find merged type in types list $types")
+        ???
+      }
+    assert(!resourceType.value.hasError)
+    assert(resourceType.value.isComplex)
+    assert(resourceType.value.getType === DataSchema.Type.RECORD)
+    assert(resourceType.value.isInstanceOf[RecordDataSchema])
+    assert(resourceType.value.asInstanceOf[RecordDataSchema].getFields.size() === 5)
+  }
+}

--- a/naptime-testing/src/test/scala/org/coursera/naptime/NestedMacroTests.scala
+++ b/naptime-testing/src/test/scala/org/coursera/naptime/NestedMacroTests.scala
@@ -638,7 +638,7 @@ class NestedMacroTests extends AssertionsForJUnit with MockitoSugar {
   def typesTest(): Unit = {
     val types = PersonResource.routerBuilder.types
     assert(types.size === 3)
-    val resourceType = types.find(_.key === "org.coursera.naptime.PersonResource.Model").getOrElse {
+    val resourceType = types.find(_.key == "org.coursera.naptime.PersonResource.Model").getOrElse {
       assert(false, "Could not find merged type in types list.")
       ???
     }

--- a/naptime/src/main/scala/org/coursera/naptime/router2/MacroImpls.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/router2/MacroImpls.scala
@@ -243,13 +243,8 @@ class MacroImpls(val c: blackbox.Context) {
       }
     }
 
-    private[this] def computeTypes(resourceType: c.Type): c.Tree = {
-      val collectionTypeView = resourceType.baseType(COLLECTION_RESOURCE_TYPE.typeSymbol)
-      val keyType = collectionTypeView.typeArgs(1)
-      val bodyType = collectionTypeView.typeArgs(2)
-
-      // Add additional types here
-      val keySchemaOption = keyType match {
+    private[this] def computeKeyType(keyType: c.Type): c.Tree = {
+      keyType match {
         case _ if keyType =:= typeOf[Int] =>
           q"Some(new com.linkedin.data.schema.IntegerDataSchema)"
         case _ if keyType =:= typeOf[String] =>
@@ -257,8 +252,61 @@ class MacroImpls(val c: blackbox.Context) {
         case _ if keyType =:= typeOf[Long] =>
           q"Some(new com.linkedin.data.schema.LongDataSchema)"
         case _ =>
-          getRecordSchemaForType(keyType)
+          // Search for an apply method, and attempt to do something with that.
+          val companion = keyType.companion
+          // Note: if the apply method is overloaded, isMethod will be false (will be OverloadedTerm instead)
+          val applyMethod = companion.member(TermName("apply"))
+          if (!(keyType <:< SCALA_RECORD_TEMPLATE)
+              && applyMethod.isMethod
+              && applyMethod.asMethod.returnType =:= keyType
+              && applyMethod.asMethod.paramLists.size == 1) {
+
+            // If there is a single-argument apply method, infer the id type from the parameter type.
+            if (applyMethod.asMethod.paramLists.head.size == 1) {
+              val idTerm = applyMethod.asMethod.paramLists.head.head.asTerm
+              assert(idTerm.isParameter, s"Id type $idTerm was not a parameter?!?!?")
+              val idType = idTerm.infoIn(keyType)
+              // TODO: preserve & serialize the "typeref" nature of the schema.
+              // Note: doing so may break other parts of the system that assume the only schemas are
+              // record data schemas.
+              computeKeyType(idType)
+            } else {
+              val params = applyMethod.asMethod.paramLists.head
+              val fields = params.map { param =>
+                q"""
+                  ${computeKeyType(param.infoIn(keyType))}.map { paramType =>
+                    val paramField = new com.linkedin.data.schema.RecordDataSchema.Field(paramType)
+                    paramField.setName(${param.name.encodedName.toString}, null)
+                    paramField.setRecord(keyRecord)
+                    paramField
+                  }
+                 """
+              }
+              val recordSchema =
+                q"""
+                  val keyRecord = new com.linkedin.data.schema.RecordDataSchema(
+                    new com.linkedin.data.schema.Name(${keyType.toString}),
+                    com.linkedin.data.schema.RecordDataSchema.RecordType.RECORD)
+                  val fields = $fields.flatten
+                  val fieldsJava = scala.collection.convert.WrapAsJava.seqAsJavaList(fields)
+                  keyRecord.setFields(fieldsJava, null)
+                  Some(keyRecord)
+                 """
+              recordSchema
+            }
+          } else {
+            getRecordSchemaForType(keyType)
+          }
       }
+    }
+
+    private[this] def computeTypes(resourceType: c.Type): c.Tree = {
+      val collectionTypeView = resourceType.baseType(COLLECTION_RESOURCE_TYPE.typeSymbol)
+      val keyType = collectionTypeView.typeArgs(1)
+      val bodyType = collectionTypeView.typeArgs(2)
+
+      // Add additional types here
+      val keySchemaOption = computeKeyType(keyType)
       val bodySchemaOption = getRecordSchemaForType(bodyType)
 
       q"""{


### PR DESCRIPTION
It is quite common to use a more sophisticated key type. Often, these key types
have a single apply method in the companion object that corresopnds to the
fields of the serialized form of the type. This commit extends the macro to
automatically infer the schema for these more sophisticated key types.

Additionally, we capture the changes in some unit tests to verify the correct
operation of the macro.