### PR TITLE
Implement handling for typerefs in Types.scala

### DIFF
--- a/naptime/src/main/scala/org/coursera/naptime/Types.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/Types.scala
@@ -79,7 +79,14 @@ object Types extends StrictLogging {
       case record: RecordDataSchema =>
         computeAsymTypeWithRecordKey(typeName, record, valueType)
       case typeref: TyperefDataSchema =>
-        ??? // TODO(saeta): handle typeref schemas
+        typeref.getDereferencedDataSchema match {
+          case primitive: PrimitiveDataSchema =>
+            computeAsymTypeWithPrimitiveKey(typeName, primitive, valueType)
+          case record: RecordDataSchema =>
+            computeAsymTypeWithRecordKey(typeName, record, valueType)
+          case unknown: DataSchema =>
+            throw new RuntimeException(s"Cannot compute asymmetric type for key type: $unknown")
+        }
       case unknown: DataSchema =>
         throw new RuntimeException(s"Cannot compute asymmetric type for key type: $unknown")
     }


### PR DESCRIPTION
Note: I'm not sure that this code path will ever be hit in reality,
due to the constraints placed on schemas in other parts of the
framework.
