### PR TITLE
Handle Key types that define their own id field

### DIFF
--- a/naptime/src/test/pegasus/org/coursera/naptime/IdWithIdField.courier
+++ b/naptime/src/test/pegasus/org/coursera/naptime/IdWithIdField.courier
@@ -1,0 +1,13 @@
+namespace org.coursera.naptime
+
+record IdWithIdField {
+  /**
+   * An auto-incremented ID (e.g. from MySQL) that forms the primary key.
+   */
+  id: int
+
+  /**
+   * A secondary unique index for an alternate lookup. Only one of the two is required.
+   */
+  alias: string
+}

--- a/naptime/src/test/scala/org/coursera/naptime/TypesTest.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/TypesTest.scala
@@ -69,4 +69,27 @@ class TypesTest extends AssertionsForJUnit {
     assert(resultingType.getField("description") != null)
     assert(resultingType.getField("description").getRecord == Course.SCHEMA)
   }
+
+  @Test
+  def idWithIdField(): Unit = {
+    val resultingType = Types.computeAsymType(
+      "org.coursera.naptime.IdWithIdTestResource.Model",
+      IdWithIdField.SCHEMA,
+      Course.SCHEMA,
+      Fields.FAKE_FIELDS)
+
+    assert(!resultingType.isErrorRecord)
+    assert(resultingType.getFields().size() == 4)
+    assert(resultingType.getField("id") != null)
+    assert(resultingType.getField("id").getRecord == IdWithIdField.SCHEMA)
+    assert(resultingType.getField("id").getType == new IntegerDataSchema)
+    assert(resultingType.getField("alias") != null)
+    assert(resultingType.getField("alias").getRecord == IdWithIdField.SCHEMA)
+    assert(resultingType.getField("alias").getType == new StringDataSchema)
+    assert(resultingType.getField("name") != null)
+    assert(resultingType.getField("name").getRecord == Course.SCHEMA)
+    assert(resultingType.getField("description") != null)
+    assert(resultingType.getField("description").getRecord == Course.SCHEMA)
+
+  }
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.2.7"
+version in ThisBuild := "0.2.8"


### PR DESCRIPTION
In some cases, a key courier type might define its own id field (e.g.
only a single part of the key is required to uniquely identify the
record). This commit makes the Types computation a little bit smarter.

Note that relying on this behavior is a potential code smell.