### PR TITLE
Abstract NaptimeRoutes behind SchemaProvider trait.

### DIFF
--- a/naptime/src/main/scala/org/coursera/naptime/ari/LocalSchemaProvider.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/ari/LocalSchemaProvider.scala
@@ -1,0 +1,33 @@
+package org.coursera.naptime.ari
+
+import javax.inject.Inject
+
+import com.linkedin.data.schema.RecordDataSchema
+import com.typesafe.scalalogging.StrictLogging
+import org.coursera.naptime.ResourceName
+import org.coursera.naptime.router2.NaptimeRoutes
+import org.coursera.naptime.schema.Resource
+
+/**
+ * Implements a default schema provider for local-only ARI operation.
+ *
+ * @param naptimeRoutes The locally available naptime routes.
+ */
+class LocalSchemaProvider @Inject() (naptimeRoutes: NaptimeRoutes) extends SchemaProvider with StrictLogging {
+  private[this] val resourceSchemas: Map[ResourceName, Resource] = naptimeRoutes.schemaMap.flatMap {
+    case (_, schema) if schema.parentClass.isEmpty => // TODO: handle sub resources
+      val resourceName = ResourceName(schema.name, version = schema.version.getOrElse(0L).toInt)
+      Some(resourceName -> schema)
+    case (_, schema) =>
+      logger.warn(s"Cannot handle nested resource $schema")
+      None
+  }
+
+  private[this] val mergedTypes = naptimeRoutes.routerBuilders.flatMap(_.types.map(_.tuple))
+    .filter(_._2.isInstanceOf[RecordDataSchema])
+    .map(tuple => tuple._1 -> tuple._2.asInstanceOf[RecordDataSchema]).toMap
+
+  override def resourceSchema(resourceName: ResourceName): Option[Resource] = resourceSchemas.get(resourceName)
+
+  override def mergedType(typeName: String): Option[RecordDataSchema] = mergedTypes.get(typeName)
+}

--- a/naptime/src/main/scala/org/coursera/naptime/ari/models.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/ari/models.scala
@@ -2,7 +2,9 @@ package org.coursera.naptime.ari
 
 import com.linkedin.data.DataList
 import com.linkedin.data.DataMap
+import com.linkedin.data.schema.RecordDataSchema
 import org.coursera.naptime.ResourceName
+import org.coursera.naptime.schema.Resource
 import play.api.libs.json.JsValue
 import play.api.mvc.RequestHeader
 
@@ -32,6 +34,26 @@ trait EngineApi {
  */
 trait FetcherApi {
   def data(request: Request): Future[Response]
+}
+
+/**
+ * Provides the metadata required to power the engine.
+ *
+ * For local-only operation, a LocalSchemaProvider implements this interface. For distributed
+ * operations, a more sophisticated SchemaProvider must be implemented.
+ */
+trait SchemaProvider {
+  /**
+   * A mapping from a given resource name to the resource's schema.
+   * @return The resource's schema.
+   */
+  def resourceSchema(resourceName: ResourceName): Option[Resource]
+
+  /**
+   * A mapping from type name to a record data schema.
+   * @return The merged type schema corresponding to the merged type name.
+   */
+  def mergedType(typeName: String): Option[RecordDataSchema]
 }
 
 /**

--- a/naptime/src/test/scala/org/coursera/naptime/ari/engine/EngineImplTest.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/ari/engine/EngineImplTest.scala
@@ -4,6 +4,7 @@ import com.google.inject.Injector
 import com.linkedin.data.DataList
 import org.coursera.naptime.ResourceName
 import org.coursera.naptime.ari.FetcherApi
+import org.coursera.naptime.ari.LocalSchemaProvider
 import org.coursera.naptime.ari.Request
 import org.coursera.naptime.ari.RequestField
 import org.coursera.naptime.ari.Response
@@ -91,8 +92,9 @@ class EngineImplTest extends AssertionsForJUnit with ScalaFutures with MockitoSu
     classOf[InstructorsResource].asInstanceOf[Class[instructorRouterBuilder.ResourceClass]])
 
   val injector = mock[Injector]
-  val naptimeRoutes = NaptimeRoutes(injector, Set(courseRouterBuilder, instructorRouterBuilder))
-  val engine = new EngineImpl(naptimeRoutes, fetcherApi)
+  val schemaProvider =
+    new LocalSchemaProvider(NaptimeRoutes(injector, Set(courseRouterBuilder, instructorRouterBuilder)))
+  val engine = new EngineImpl(schemaProvider, fetcherApi)
 
   @Test
   def singleResourceFetch_Courses(): Unit = {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.3.0-rc4"
+version in ThisBuild := "0.3.0-rc5"


### PR DESCRIPTION
Previously, the EngineImpl directly pulled from the local naptime resources.
However, this does not work in distributed mode. Instead, we must add a layer
of indirection to allow for custom distributed / remote SchemaProviders.