### PR TITLE
Fix parsing of complex child types in lists

### DIFF
--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/SangriaGraphQlSchemaBuilder.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/SangriaGraphQlSchemaBuilder.scala
@@ -321,6 +321,7 @@ class SangriaGraphQlSchemaBuilder(
     * Provides the resolver for a schema type, which implements how to retrieve a value from the raw
     * data type. For instance, for the Integer type, it pulls an integer out of a DataMap and
     * converts the types as appropriate.
+    *
     * @param schemaType Pegasus data schema type for the field
     * @param fieldName name of the field (to pull the value out of the data map)
     * @return Sangria `Value` with the value and Sangria context on it
@@ -347,7 +348,8 @@ class SangriaGraphQlSchemaBuilder(
             case nullField: NullDataSchema => context => null
             case enumField: EnumDataSchema => context => context.value.getString(fieldName)
             case unionField: UnionDataSchema => context => context.value.getDataMap(fieldName)
-            case arrayField: ArrayDataSchema => context => context.value.getDataList(fieldName)
+            case arrayField: ArrayDataSchema => context =>
+              context.value.getDataList(fieldName).asScala
             case recordField: RecordDataSchema => context => context.value.getDataMap(fieldName)
             case _ =>
               logger.error(s"Could not match schema type $schemaType")
@@ -406,6 +408,7 @@ class SangriaGraphQlSchemaBuilder(
 
   /**
     * Builds a Sangria enum from a Pegasus enum schema
+    *
     * @param pegasusEnumSchema Pegasus representation of the enum schema
     * @return Sangria EnumType schema
     */
@@ -421,6 +424,7 @@ class SangriaGraphQlSchemaBuilder(
 
   /**
     * Builds a Sangria record from a Pegasus record schema
+    *
     * @param pegasusRecordSchema Pegasus representation of the record schema
     * @param namespace namespace for the record (potentially used for child types)
     * @return Sangria ObjectType schema
@@ -444,6 +448,7 @@ class SangriaGraphQlSchemaBuilder(
 
   /**
     * Builds a Sangria union from a Pegasus union schema
+    *
     * @param pegasusUnionSchema Pegasus representation of the union schema
     * @param fieldName field name for the union (used for creating member type names)
     * @param namespace namespace for the union (used for creating member type names)
@@ -480,6 +485,7 @@ class SangriaGraphQlSchemaBuilder(
   /**
     * Finds a resource with a given name from the provided list of resources, or throws an exception
     * if the resource cannot be found.
+    *
     * @param resourceName string name, in the format courses.v1 or CoursesV1
     * @return Resource object
     */

--- a/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/SangriaGraphQlSchemaBuilderTest.scala
+++ b/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/SangriaGraphQlSchemaBuilderTest.scala
@@ -24,6 +24,7 @@ import org.coursera.naptime.schema.Resource
 import org.coursera.naptime.schema.ResourceKind
 import org.junit.Test
 import org.scalatest.junit.AssertionsForJUnit
+import sangria.schema.EnumType
 import sangria.schema.ObjectType
 import sangria.schema.Schema
 import sangria.schema.UnionType
@@ -79,7 +80,7 @@ class SangriaGraphQlSchemaBuilderTest extends AssertionsForJUnit {
     val courseResourceObjectType =
       courseResourceType.asInstanceOf[ObjectType[Unit, ScalaRecordTemplate]]
     val fieldNames = courseResourceObjectType.fieldsByName.keySet
-    val expectedFieldNames = Set("name", "description", "slug", "instructors", "id", "originalId", "partner")
+    val expectedFieldNames = Set("name", "description", "slug", "instructors", "id", "originalId", "partner", "coursePlatform")
     assert(fieldNames === expectedFieldNames)
   }
 

--- a/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/SangriaGraphQlSchemaExecutionTest.scala
+++ b/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/SangriaGraphQlSchemaExecutionTest.scala
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2016 Coursera Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.coursera.naptime.ari.graphql
+
+import org.coursera.naptime.ari.graphql.models.CoursePlatform
+import org.coursera.naptime.ari.graphql.models.MergedCourse
+import org.coursera.naptime.ari.graphql.models.MergedInstructor
+import org.coursera.naptime.ari.graphql.models.MergedPartner
+import org.coursera.naptime.schema.Handler
+import org.coursera.naptime.schema.HandlerKind
+import org.coursera.naptime.schema.Parameter
+import org.coursera.naptime.schema.Resource
+import org.coursera.naptime.schema.ResourceKind
+import org.junit.Test
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.junit.AssertionsForJUnit
+import sangria.execution.Executor
+import sangria.parser.QueryParser
+import sangria.schema.Schema
+import sangria.marshalling.playJson._
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class SangriaGraphQlSchemaExecutionTest extends AssertionsForJUnit with ScalaFutures {
+
+  val courseResource = Resource(
+    kind = ResourceKind.COLLECTION,
+    name = "courses",
+    version = Some(1),
+    keyType = "",
+    valueType = "",
+    mergedType = "org.coursera.naptime.ari.graphql.models.MergedCourse",
+    handlers = List(Handler(
+      kind = HandlerKind.GET,
+      name = "get",
+      parameters = List(Parameter(name = "id", `type` = "Integer", attributes = List.empty)),
+      attributes = List.empty)),
+    className = "",
+    attributes = List.empty)
+
+  val allResources = Set(courseResource)
+
+  val schemaTypes = Map(
+    "org.coursera.naptime.ari.graphql.models.MergedCourse" -> MergedCourse.SCHEMA)
+
+  val builder = new SangriaGraphQlSchemaBuilder(allResources, schemaTypes)
+
+  @Test
+  def parseComplexLists(): Unit = {
+    val schema = builder.generateSchema().asInstanceOf[Schema[SangriaGraphQlContext, Any]]
+    val query =
+      """
+      query {
+        CoursesV1Resource {
+          get(id: "1") {
+            coursePlatform
+          }
+        }
+      }
+      """.stripMargin
+    val queryAst = QueryParser.parse(query).get
+    val course = MergedCourse(
+      id = "1",
+      name = "Test Course",
+      slug = "test-course",
+      instructors = List.empty,
+      partner = 1,
+      originalId = "",
+      coursePlatform = List(CoursePlatform.NewPlatform))
+    val context = SangriaGraphQlContext(data = Map("courses.v1" -> List(course.data())))
+    val execution = Executor.execute(schema, queryAst, context).futureValue
+    assert(
+      (execution \ "data" \ "CoursesV1Resource" \ "get" \ "coursePlatform").get.as[List[String]]
+        === List("NewPlatform"))
+  }
+
+
+}

--- a/naptime/src/test/pegasus/org/coursera/naptime/ari/graphql/models/MergedCourse.courier
+++ b/naptime/src/test/pegasus/org/coursera/naptime/ari/graphql/models/MergedCourse.courier
@@ -16,4 +16,6 @@ record MergedCourse {
   partner: PartnerId
 
   originalId: union[int, string]
+
+  coursePlatform: array[enum CoursePlatform {OldPlatform NewPlatform}]
 }

--- a/naptime/src/test/scala/org/coursera/naptime/ari/engine/EngineImplTest.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/ari/engine/EngineImplTest.scala
@@ -10,6 +10,7 @@ import org.coursera.naptime.ari.RequestField
 import org.coursera.naptime.ari.Response
 import org.coursera.naptime.ari.TopLevelRequest
 import org.coursera.naptime.ari.graphql.models.Coordinates
+import org.coursera.naptime.ari.graphql.models.CoursePlatform
 import org.coursera.naptime.ari.graphql.models.MergedCourse
 import org.coursera.naptime.ari.graphql.models.MergedInstructor
 import org.coursera.naptime.ari.graphql.models.MergedPartner
@@ -674,7 +675,8 @@ object EngineImplTest {
     description = Some("An awesome course on machine learning."),
     instructors = List("instructor1Id"),
     partner = 123,
-    originalId = "")
+    originalId = "",
+    coursePlatform = List(CoursePlatform.NewPlatform))
   val COURSE_B = MergedCourse(
     id = "courseBId",
     name = "Probabalistic Graphical Models",
@@ -682,7 +684,8 @@ object EngineImplTest {
     description = Some("An awesome course on pgm's."),
     instructors = List("instructor2Id"),
     partner = 123,
-    originalId = "")
+    originalId = "",
+    coursePlatform = List(CoursePlatform.NewPlatform))
 
   val INSTRUCTOR_1 = MergedInstructor(
     id = "instructor1Id",


### PR DESCRIPTION
List types weren't being parsed correctly (due to the missing `.asScala`), causing a parsing exception and the entire query for any field that was a list to fail. This fixes that issue, and adds a simple test.

PTAL @saeta 