### PR TITLE
Add relay schema support

### DIFF
--- a/examples/src/main/pegasus/org/coursera/example/Course.courier
+++ b/examples/src/main/pegasus/org/coursera/example/Course.courier
@@ -2,7 +2,7 @@ namespace org.coursera.example
 
 record Course {
   instructors: array[InstructorId]
-  partners: array[PartnerId]
+  partner: PartnerId
   slug: string
   name: string
   description: string

--- a/examples/src/main/pegasus/org/coursera/example/Course.courier
+++ b/examples/src/main/pegasus/org/coursera/example/Course.courier
@@ -1,8 +1,13 @@
 namespace org.coursera.example
 
 record Course {
+
+  @related = "instructors.v1"
   instructors: array[InstructorId]
+
+  @related = "partners.v1"
   partner: PartnerId
+
   slug: string
   name: string
   description: string

--- a/examples/src/main/pegasus/org/coursera/example/Instructor.courier
+++ b/examples/src/main/pegasus/org/coursera/example/Instructor.courier
@@ -1,8 +1,12 @@
 namespace org.coursera.example
 
 record Instructor {
+  @related = "courses.v1"
   courses: array[CourseId]
+
+  @related = "partners.v1"
   partner: PartnerId
+
   name: string
   photoUrl: string
 }

--- a/examples/src/main/resources/routes
+++ b/examples/src/main/resources/routes
@@ -6,6 +6,7 @@
 GET     /                           @controllers.HomeController.index
 POST    /graphql                    @org.coursera.naptime.ari.graphql.GraphQLController.graphqlBody
 GET     /graphiql                   @controllers.HomeController.graphiql
+GET     /graphql-schema             @org.coursera.naptime.ari.graphql.GraphQLController.renderSchema
 
 # Hook in Naptime to the URL space
 ->      /api                        org.coursera.naptime.router2.NaptimePlayRouter

--- a/examples/src/main/scala/resources/CoursesResource.scala
+++ b/examples/src/main/scala/resources/CoursesResource.scala
@@ -18,9 +18,7 @@ class CoursesResource @Inject() (
 
   override def resourceName = "courses"
   override def resourceVersion = 1
-  override implicit lazy val Fields: Fields[Course] = BaseFields.withRelated(
-    "instructors" -> ResourceName("instructors", 1),
-    "partner" -> ResourceName("partners", 1))
+  override implicit lazy val Fields: Fields[Course] = BaseFields
 
   def get(id: String = "v1-123") = Nap.get { context =>
     OkIfPresent(id, courseStore.get(id))

--- a/examples/src/main/scala/resources/CoursesResource.scala
+++ b/examples/src/main/scala/resources/CoursesResource.scala
@@ -20,7 +20,7 @@ class CoursesResource @Inject() (
   override def resourceVersion = 1
   override implicit lazy val Fields: Fields[Course] = BaseFields.withRelated(
     "instructors" -> ResourceName("instructors", 1),
-    "partners" -> ResourceName("partners", 1))
+    "partner" -> ResourceName("partners", 1))
 
   def get(id: String = "v1-123") = Nap.get { context =>
     OkIfPresent(id, courseStore.get(id))

--- a/examples/src/main/scala/resources/InstructorsResource.scala
+++ b/examples/src/main/scala/resources/InstructorsResource.scala
@@ -20,7 +20,7 @@ class InstructorsResource @Inject() (
   override def resourceVersion = 1
   override implicit lazy val Fields: Fields[Instructor] = BaseFields.withRelated(
     "courses" -> ResourceName("courses", 1),
-    "partners" -> ResourceName("partners", 1))
+    "partner" -> ResourceName("partners", 1))
 
   def get(id: String) = Nap.get { context =>
     OkIfPresent(id, instructorStore.get(id))

--- a/examples/src/main/scala/resources/InstructorsResource.scala
+++ b/examples/src/main/scala/resources/InstructorsResource.scala
@@ -18,9 +18,7 @@ class InstructorsResource @Inject() (
 
   override def resourceName = "instructors"
   override def resourceVersion = 1
-  override implicit lazy val Fields: Fields[Instructor] = BaseFields.withRelated(
-    "courses" -> ResourceName("courses", 1),
-    "partner" -> ResourceName("partners", 1))
+  override implicit lazy val Fields: Fields[Instructor] = BaseFields
 
   def get(id: String) = Nap.get { context =>
     OkIfPresent(id, instructorStore.get(id))

--- a/examples/src/main/scala/stores/CourseStore.scala
+++ b/examples/src/main/scala/stores/CourseStore.scala
@@ -15,13 +15,13 @@ class CourseStore {
   courseStore = courseStore + (
     "ml" -> Course(
       instructors = List("andrew-ng"),
-      partners = List("stanford"),
+      partner = "stanford",
       slug = "machine-learning",
       name = "Machine Learning",
       description = ""),
     "pgm" -> Course(
       instructors = List("barb-oakley"),
-      partners = List("ucsd"),
+      partner = "ucsd",
       slug = "learning-how-to-learn",
       name = "Learning How to Learn",
       description = ""))

--- a/examples/src/main/scala/stores/CourseStore.scala
+++ b/examples/src/main/scala/stores/CourseStore.scala
@@ -19,7 +19,7 @@ class CourseStore {
       slug = "machine-learning",
       name = "Machine Learning",
       description = ""),
-    "pgm" -> Course(
+    "lhtl" -> Course(
       instructors = List("barb-oakley"),
       partner = "ucsd",
       slug = "learning-how-to-learn",

--- a/examples/src/main/scala/stores/PartnerStore.scala
+++ b/examples/src/main/scala/stores/PartnerStore.scala
@@ -20,7 +20,7 @@ class PartnerStore {
       name = "Stanford University",
       homepage = ""),
     "ucsd" -> Partner(
-      courses = List("learning-how-to-learn"),
+      courses = List("lhtl"),
       instructors = List("barb-oakley"),
       name = "UCSD",
       homepage = ""))

--- a/naptime-graphql/build.sbt
+++ b/naptime-graphql/build.sbt
@@ -5,6 +5,7 @@ libraryDependencies ++= Seq(
   playJson,
   sangria,
   sangriaPlayJson,
+  sangriaRelay,
   scalaLogging,
   junit,
   junitInterface,

--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/GraphqlSchemaProvider.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/GraphqlSchemaProvider.scala
@@ -18,14 +18,13 @@ package org.coursera.naptime.ari.graphql
 
 import javax.inject.Inject
 
-import com.linkedin.data.schema.DataSchema
 import com.linkedin.data.schema.RecordDataSchema
 import com.typesafe.scalalogging.StrictLogging
 import org.coursera.naptime.ari.FullSchema
 import org.coursera.naptime.ari.SchemaProvider
-import org.coursera.naptime.schema.Resource
 import sangria.schema.ObjectType
 import sangria.schema.Schema
+import sangria.schema.SchemaValidationException
 
 import scala.util.control.NonFatal
 
@@ -79,7 +78,7 @@ class DefaultGraphqlSchemaProvider @Inject() (schemaProvider: SchemaProvider)
       cachedSchema = graphQlSchema
     } catch {
       case NonFatal(e) =>
-        logger.error(s"Could not build schema.", e)
+        logger.error(s"Could not build schema.", e.getMessage)
         fullSchema = latestSchema
         // Note: we do not update cachedSchema, but instead retain the existing schema.
     }

--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/SangriaGraphQlContext.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/SangriaGraphQlContext.scala
@@ -16,6 +16,6 @@
 
 package org.coursera.naptime.ari.graphql
 
-import com.linkedin.data.DataMap
+import org.coursera.naptime.ari.Response
 
-case class SangriaGraphQlContext(data: Map[String, List[DataMap]])
+case class SangriaGraphQlContext(response: Response)

--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/SangriaGraphQlParser.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/SangriaGraphQlParser.scala
@@ -84,7 +84,7 @@ object SangriaGraphQlParser extends GraphQlParser {
     Some(Request(requestHeader, topLevelRequests))
   }
 
-  private[this] def parseField(field: Field): RequestField = {
+  def parseField(field: Field): RequestField = {
     val subfields = field.selections.flatMap {
       case subfield: Field => Some(parseField(subfield))
       case _ => None

--- a/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/DefaultGraphqlSchemaProviderTest.scala
+++ b/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/DefaultGraphqlSchemaProviderTest.scala
@@ -34,7 +34,7 @@ class DefaultGraphqlSchemaProviderTest extends AssertionsForJUnit {
     val simpleSchema = new DefaultGraphqlSchemaProvider(simpleSchemaProvider())
 
     val nonMetadataTypes = simpleSchema.schema.allTypes.filterNot(_._1.startsWith("__"))
-    assert(nonMetadataTypes.keySet === DEFAULT_TYPES ++ Set("CoursesV1Resource", "InstructorsV1Resource"),
+    assert(nonMetadataTypes.keySet === DEFAULT_TYPES ++ COMPUTED_TYPES,
       s"${nonMetadataTypes.keySet}")
   }
 
@@ -59,7 +59,7 @@ class DefaultGraphqlSchemaProviderTest extends AssertionsForJUnit {
     val regenerating = new DefaultGraphqlSchemaProvider(regeneratingProvider)
 
     val nonMetadataTypes = regenerating.schema.allTypes.filterNot(_._1.startsWith("__"))
-    assert(nonMetadataTypes.keySet === DEFAULT_TYPES ++ Set("CoursesV1Resource", "InstructorsV1Resource"),
+    assert(nonMetadataTypes.keySet === DEFAULT_TYPES ++ COMPUTED_TYPES,
       s"${nonMetadataTypes.keySet}")
   }
 
@@ -70,6 +70,21 @@ object DefaultGraphqlSchemaProviderTest extends MockitoSugar {
   import org.coursera.naptime.ari.engine.EngineImplTest._
 
   val DEFAULT_TYPES = Set("ID", "root", "Boolean", "Long", "Float", "Int", "BigInt", "String", "BigDecimal")
+
+  val COMPUTED_TYPES = Set(
+    "CoursesV1",
+    "CoursesV1Connection",
+    "CoursesV1Edge",
+    "CoursesV1Resource",
+    "InstructorsV1",
+    "InstructorsV1Connection",
+    "InstructorsV1Edge",
+    "InstructorsV1Resource",
+    "intMember",
+    "org_coursera_naptime_ari_graphql_models_CoursePlatform",
+    "org_coursera_naptime_ari_graphql_models_originalId",
+    "PageInfo",
+    "stringMember")
 
   val extraTypes = TYPE_SCHEMAS.map { case (key, value) => Keyed(key, value) }.toList
 

--- a/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/SangriaGraphQlSchemaBuilderTest.scala
+++ b/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/SangriaGraphQlSchemaBuilderTest.scala
@@ -75,18 +75,27 @@ class SangriaGraphQlSchemaBuilderTest extends AssertionsForJUnit {
 
   @Test
   def parseTopLevelFields(): Unit = {
-    val schema = Schema(builder.generateObjectTypeForResource("courses.v1"))
+    val schema = Schema(builder.generateObjectTypeForResource("courses.v1").get)
     val (_, courseResourceType) = schema.types.get("CoursesV1").get
     val courseResourceObjectType =
       courseResourceType.asInstanceOf[ObjectType[Unit, ScalaRecordTemplate]]
     val fieldNames = courseResourceObjectType.fieldsByName.keySet
-    val expectedFieldNames = Set("name", "description", "slug", "instructors", "id", "originalId", "partner", "coursePlatform")
+    val expectedFieldNames = Set(
+      "__id",
+      "id",
+      "name",
+      "description",
+      "slug",
+      "instructors",
+      "originalId",
+      "partner",
+      "coursePlatform")
     assert(fieldNames === expectedFieldNames)
   }
 
   @Test
   def parseUnionFields(): Unit = {
-    val schema = Schema(builder.generateObjectTypeForResource("courses.v1"))
+    val schema = Schema(builder.generateObjectTypeForResource("courses.v1").get)
     val courseUnionType =
       schema.unionTypes.get("org_coursera_naptime_ari_graphql_models_originalId").get
     val courseUnionUnionType = courseUnionType.asInstanceOf[UnionType[Unit]]
@@ -97,7 +106,7 @@ class SangriaGraphQlSchemaBuilderTest extends AssertionsForJUnit {
 
   @Test
   def parseUnionMemberFields(): Unit = {
-    val schema = Schema(builder.generateObjectTypeForResource("courses.v1"))
+    val schema = Schema(builder.generateObjectTypeForResource("courses.v1").get)
     val (_, coursePlatformMemberType) = schema.types.get("intMember").get
     val coursePlatformMemberObjectType =
       coursePlatformMemberType.asInstanceOf[ObjectType[Unit, ScalaRecordTemplate]]

--- a/naptime/src/main/scala/org/coursera/naptime/ari/LocalSchemaProvider.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/ari/LocalSchemaProvider.scala
@@ -33,9 +33,14 @@ import org.coursera.naptime.schema.Resource
 class LocalSchemaProvider @Inject() (naptimeRoutes: NaptimeRoutes) extends SchemaProvider with StrictLogging {
 
   private[this] val resourceSchemaMap: Map[ResourceName, Resource] = naptimeRoutes.schemaMap.flatMap {
-    case (_, schema) if schema.parentClass.isEmpty => // TODO: handle sub resources
-      val resourceName = ResourceName(schema.name, version = schema.version.getOrElse(0L).toInt)
+    // TODO: handle sub resources
+    case (_, schema)
+      if schema.parentClass.isEmpty ||
+        schema.parentClass.contains("org.coursera.naptime.resources.RootResource") =>
+
+    val resourceName = ResourceName(schema.name, version = schema.version.getOrElse(0L).toInt)
       Some(resourceName -> schema)
+
     case (_, schema) =>
       logger.warn(s"Cannot handle nested resource $schema")
       None

--- a/naptime/src/main/scala/org/coursera/naptime/ari/engine/EngineImpl.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/ari/engine/EngineImpl.scala
@@ -66,7 +66,16 @@ class EngineImpl @Inject() (
       // If we have a schema, we can perform automatic resource inclusion.
       mergedTypeForResource(topLevelRequest.resource).map { mergedType =>
         val topLevelData = extractDataMaps(topLevelResponse, topLevelRequest)
-        val nestedLookups = topLevelRequest.selection.selections.filter(_.selections.nonEmpty)
+
+        // TODO(bryan): Pull out logic about connections in here
+        val nestedLookups = (for {
+          node <- topLevelRequest.selection.selections.find(_.name == "node")
+        } yield {
+          node.selections.filter(_.selections.nonEmpty)
+        }).getOrElse {
+          List.empty
+        }
+
         val additionalResponses = nestedLookups.map { nestedField =>
           val field = Option(mergedType.getField(nestedField.name)).getOrElse {
             logger.warn(s"Could not find field $nestedField on model $mergedType")

--- a/naptime/src/main/scala/org/coursera/naptime/ari/engine/EngineImpl.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/ari/engine/EngineImpl.scala
@@ -68,40 +68,43 @@ class EngineImpl @Inject() (
         val topLevelData = extractDataMaps(topLevelResponse, topLevelRequest)
 
         // TODO(bryan): Pull out logic about connections in here
-        val nestedLookups = (for {
-          node <- topLevelRequest.selection.selections.find(_.name == "node")
+        val edgeLookups = (for {
+          edges <- topLevelRequest.selection.selections.find(_.name == "edges")
+          node <- edges.selections.find(_.name == "node")
         } yield {
           node.selections.filter(_.selections.nonEmpty)
         }).getOrElse {
           List.empty
         }
 
-        val additionalResponses = nestedLookups.map { nestedField =>
-          val field = Option(mergedType.getField(nestedField.name)).getOrElse {
-            logger.warn(s"Could not find field $nestedField on model $mergedType")
-            throw new IllegalStateException("Could not find field on model")
-          }
-          relatedResourceForField(field, mergedType).map { relatedResource =>
-            val multiGetIds = computeMultiGetIds(topLevelData, nestedField, field)
+        val singularLookups = topLevelRequest.selection.selections.filter { selection =>
+          selection.selections.nonEmpty && selection.name != "edges"
+        }
 
-            val relatedTopLevelRequest = TopLevelRequest(
-              resource = relatedResource,
-              selection = RequestField(
-                name = "multiGet",
-                alias = None,
-                args = Set(
-                  "ids" ->
-                    JsString(multiGetIds)), // TODO: pass through original request fields for pagination
-                selections = nestedField.selections))
-            Some(executeTopLevelRequest(requestHeader, relatedTopLevelRequest).map { response =>
-              // Exclude the top level ids in the response.
-              Response(topLevelIds = Map.empty, data = response.data)
-            })
-          }.getOrElse {
-            None
+        val nestedLookups = edgeLookups ++ singularLookups
+
+        val additionalResponses = for {
+          nestedField <- nestedLookups
+          field <- Option(mergedType.getField(nestedField.name)).toList
+          relatedResource <- relatedResourceForField(field, mergedType).toList
+        } yield {
+          val multiGetIds = computeMultiGetIds(topLevelData, nestedField, field)
+
+          val relatedTopLevelRequest = TopLevelRequest(
+            resource = relatedResource,
+            selection = RequestField(
+              name = "multiGet",
+              alias = None,
+              args = Set(
+                "ids" ->
+                  JsString(multiGetIds)), // TODO: pass through original request fields for pagination
+              selections = nestedField.selections))
+          executeTopLevelRequest(requestHeader, relatedTopLevelRequest).map { response =>
+            // Exclude the top level ids in the response.
+            Response(topLevelIds = Map.empty, data = response.data)
           }
         }
-        Future.sequence(additionalResponses.flatten).map { additionalResponses =>
+        Future.sequence(additionalResponses).map { additionalResponses =>
           additionalResponses.foldLeft(topLevelResponse)(_ ++ _)
         }
       }.getOrElse {

--- a/naptime/src/test/scala/org/coursera/naptime/ari/engine/EngineImplTest.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/ari/engine/EngineImplTest.scala
@@ -17,6 +17,9 @@ import org.coursera.naptime.ari.graphql.models.MergedPartner
 import org.coursera.naptime.model.Keyed
 import org.coursera.naptime.router2.NaptimeRoutes
 import org.coursera.naptime.router2.ResourceRouterBuilder
+import org.coursera.naptime.schema.Handler
+import org.coursera.naptime.schema.HandlerKind
+import org.coursera.naptime.schema.Parameter
 import org.coursera.naptime.schema.Resource
 import org.coursera.naptime.schema.ResourceKind
 import org.hamcrest.Matcher
@@ -30,6 +33,7 @@ import org.mockito.Mockito.when
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.junit.AssertionsForJUnit
 import org.scalatest.mock.MockitoSugar
+import org.scalatest.time.Span
 import play.api.libs.json.JsNumber
 import play.api.libs.json.JsString
 import play.api.test.FakeRequest
@@ -74,6 +78,8 @@ class EngineImplTest extends AssertionsForJUnit with ScalaFutures with MockitoSu
       }
     }
   }
+
+  override implicit val patienceConfig = PatienceConfig(timeout = Span.Max)
 
   val fetcherApi = mock[FetcherApi]
 
@@ -308,13 +314,17 @@ class EngineImplTest extends AssertionsForJUnit with ScalaFutures with MockitoSu
             alias = None,
             args = Set("id" -> JsString(COURSE_A.id)),
             selections = List(
-              RequestField("id", None, Set.empty, List.empty),
-              RequestField("slug", None, Set.empty, List.empty),
-              RequestField("name", None, Set.empty, List.empty),
-              RequestField("instructors", None, Set.empty, List(
-                RequestField("id", None, Set.empty, List.empty),
-                RequestField("name", None, Set.empty, List.empty),
-                RequestField("title", None, Set.empty, List.empty))))))))
+              RequestField("edges", None, Set.empty, List(
+                RequestField("node", None, Set.empty, List(
+                  RequestField("id", None, Set.empty, List.empty),
+                  RequestField("slug", None, Set.empty, List.empty),
+                  RequestField("name", None, Set.empty, List.empty),
+                  RequestField("instructors", None, Set.empty, List(
+                    RequestField("edges", None, Set.empty, List(
+                      RequestField("node", None, Set.empty, List(
+                        RequestField("id", None, Set.empty, List.empty),
+                        RequestField("name", None, Set.empty, List.empty),
+                        RequestField("title", None, Set.empty, List.empty))))))))))))))))
 
     val fetcherResponseCourse = Response(
       topLevelIds = Map(request.topLevelRequests.head -> new DataList(List(COURSE_A.id).asJava)),
@@ -326,7 +336,7 @@ class EngineImplTest extends AssertionsForJUnit with ScalaFutures with MockitoSu
         name = "multiGet",
         alias = None,
         args = Set("ids" -> JsString("instructor1Id")),
-        selections = request.topLevelRequests.head.selection.selections.drop(3).head.selections))
+        selections = request.topLevelRequests.head.selection.selections.head.selections.head.selections.drop(3).head.selections))
     val fetcherResponseInstructors = Response(
       topLevelIds = Map(expectedInstructorRequest -> new DataList(List(INSTRUCTOR_1.id).asJava)),
       data = Map(INSTRUCTORS_RESOURCE_ID -> Map(INSTRUCTOR_1.id -> INSTRUCTOR_1.data())))
@@ -374,8 +384,10 @@ class EngineImplTest extends AssertionsForJUnit with ScalaFutures with MockitoSu
           RequestField("longitude", None, Set.empty, List.empty)))))
     val instructorField =
       RequestField("instructors", None, Set.empty, List(
-        RequestField("id", None, Set.empty, List.empty),
-        RequestField("name", None, Set.empty, List.empty)))
+        RequestField("edges", None, Set.empty, List(
+          RequestField("node", None, Set.empty, List(
+            RequestField("id", None, Set.empty, List.empty),
+            RequestField("name", None, Set.empty, List.empty)))))))
     val request = Request(
       requestHeader = FakeRequest(),
       topLevelRequests = List(
@@ -386,11 +398,13 @@ class EngineImplTest extends AssertionsForJUnit with ScalaFutures with MockitoSu
             alias = None,
             args = Set("query" -> JsString("ai classes")),
             selections = List(
-              RequestField("id", None, Set.empty, List.empty),
-              RequestField("slug", None, Set.empty, List.empty),
-              RequestField("name", None, Set.empty, List.empty),
-              partnerField,
-              instructorField)))))
+              RequestField("edges", None, Set.empty, List(
+                RequestField("node", None, Set.empty, List(
+                  RequestField("id", None, Set.empty, List.empty),
+                  RequestField("slug", None, Set.empty, List.empty),
+                  RequestField("name", None, Set.empty, List.empty),
+                  partnerField,
+                  instructorField)))))))))
 
     val fetcherResponseCourse = Response(
       topLevelIds = Map(request.topLevelRequests.head -> new DataList(List(COURSE_A.id, COURSE_B.id).asJava)),
@@ -492,16 +506,18 @@ class EngineImplTest extends AssertionsForJUnit with ScalaFutures with MockitoSu
             alias = None,
             args = Set("id" -> JsString(COURSE_A.id)),
             selections = List(
-              RequestField("id", None, Set.empty, List.empty),
-              RequestField("slug", None, Set.empty, List.empty),
-              RequestField("name", None, Set.empty, List.empty),
-              RequestField("partner", None, Set.empty, List(
-                RequestField("id", None, Set.empty, List.empty),
-                RequestField("slug", None, Set.empty, List.empty),
-                RequestField("name", None, Set.empty, List.empty),
-                RequestField("geolocation", None, Set.empty, List(
-                  RequestField("latitude", None, Set.empty, List.empty),
-                  RequestField("longitude", None, Set.empty, List.empty))))))))))
+              RequestField("edges", None, Set.empty, List(
+                RequestField("node", None, Set.empty, List(
+                  RequestField("id", None, Set.empty, List.empty),
+                  RequestField("slug", None, Set.empty, List.empty),
+                  RequestField("name", None, Set.empty, List.empty),
+                  RequestField("partner", None, Set.empty, List(
+                    RequestField("id", None, Set.empty, List.empty),
+                    RequestField("slug", None, Set.empty, List.empty),
+                    RequestField("name", None, Set.empty, List.empty),
+                    RequestField("geolocation", None, Set.empty, List(
+                      RequestField("latitude", None, Set.empty, List.empty),
+                      RequestField("longitude", None, Set.empty, List.empty))))))))))))))
 
     val fetcherResponseCourse = Response(
       topLevelIds = Map(request.topLevelRequests.head -> new DataList(List(COURSE_A.id).asJava)),
@@ -513,7 +529,12 @@ class EngineImplTest extends AssertionsForJUnit with ScalaFutures with MockitoSu
         name = "multiGet",
         alias = None,
         args = Set("ids" -> JsString(s"${PARTNER_123.id}")),
-        selections = request.topLevelRequests.head.selection.selections.drop(3).head.selections))
+        selections = request.topLevelRequests
+          .head.selection.selections
+          .head.selections
+          .head.selections
+          .drop(3)
+          .head.selections))
     val fetcherResponsePartners = Response(
       topLevelIds = Map(expectedPartnersRequest -> new DataList(List(new Integer(PARTNER_123.id)).asJava)),
       data = Map(PARTNERS_RESOURCE_ID -> Map(new Integer(PARTNER_123.id) -> PARTNER_123.data())))
@@ -565,9 +586,11 @@ class EngineImplTest extends AssertionsForJUnit with ScalaFutures with MockitoSu
           RequestField("longitude", None, Set.empty, List.empty)))))
     val instructorField =
       RequestField("instructors", None, Set.empty, List(
-        RequestField("id", None, Set.empty, List.empty),
-        RequestField("name", None, Set.empty, List.empty),
-        partnerField))
+        RequestField("edges", None, Set.empty, List(
+          RequestField("node", None, Set.empty, List(
+            RequestField("id", None, Set.empty, List.empty),
+            RequestField("name", None, Set.empty, List.empty),
+            partnerField))))))
     val request = Request(
       requestHeader = FakeRequest(),
       topLevelRequests = List(
@@ -578,10 +601,12 @@ class EngineImplTest extends AssertionsForJUnit with ScalaFutures with MockitoSu
             alias = None,
             args = Set("query" -> JsString("ai classes")),
             selections = List(
-              RequestField("id", None, Set.empty, List.empty),
-              RequestField("slug", None, Set.empty, List.empty),
-              RequestField("name", None, Set.empty, List.empty),
-              instructorField)))))
+              RequestField("edges", None, Set.empty, List(
+                RequestField("node", None, Set.empty, List(
+                  RequestField("id", None, Set.empty, List.empty),
+                  RequestField("slug", None, Set.empty, List.empty),
+                  RequestField("name", None, Set.empty, List.empty),
+                  instructorField)))))))))
 
     val fetcherResponseCourse = Response(
       topLevelIds = Map(request.topLevelRequests.head -> new DataList(List(COURSE_A.id, COURSE_B.id).asJava)),
@@ -709,6 +734,18 @@ object EngineImplTest {
     slug = "x-university",
     geolocation = Coordinates(37.386824, -122.061005))
 
+  val GET_HANDLER = Handler(
+    kind = HandlerKind.GET,
+    name = "get",
+    parameters = List(Parameter(
+      name = "id",
+      `type` = "int",
+      attributes = List.empty,
+      default = None)),
+    inputBody = None,
+    customOutputBody = None,
+    attributes = List.empty)
+
   val COURSES_RESOURCE_ID = ResourceName("courses", 1)
   val COURSES_RESOURCE = Resource(
     kind = ResourceKind.COLLECTION,
@@ -718,7 +755,7 @@ object EngineImplTest {
     keyType = "string",
     valueType = "org.coursera.naptime.test.Course",
     mergedType = MergedCourse.SCHEMA.getFullName,
-    handlers = List.empty,
+    handlers = List(GET_HANDLER),
     className = "org.coursera.naptime.test.CoursesResource",
     attributes = List.empty)
 
@@ -731,7 +768,7 @@ object EngineImplTest {
     keyType = "string",
     valueType = "org.coursera.naptime.test.Instructor",
     mergedType = MergedInstructor.SCHEMA.getFullName,
-    handlers = List.empty,
+    handlers = List(GET_HANDLER),
     className = "org.coursera.naptime.test.InstructorsResource",
     attributes = List.empty)
 

--- a/project/NamedDependencies.scala
+++ b/project/NamedDependencies.scala
@@ -37,6 +37,7 @@ trait NamedDependencies { this: PluginVersionProvider =>
     .excludeAll(new ExclusionRule(organization="org.specs2"))
   val sangria = "org.sangria-graphql" %% "sangria" % "0.7.1"
   val sangriaPlayJson = "org.sangria-graphql" %% "sangria-play-json" % "0.3.2"
+  val sangriaRelay = "org.sangria-graphql" %% "sangria-relay" % "0.7.1"
   val scalaGuice = "net.codingwell" %% "scala-guice" % "4.0.0"
   val scalaLogging = "com.typesafe.scala-logging" %% "scala-logging" % "3.1.0"
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.3.0"
+version in ThisBuild := "0.3.1"


### PR DESCRIPTION
- Adds connection and edge / node support to schemas
- Update resolvers to parse through edges + nodes
- Modify SangriaGraphQlContext to take in a full response object
- Use response information when pulling lists of models from a request
- Completely omit resources from a schema that don’t have valid handlers or models
- Reduce many errors to warnings
- Fix a couple of problems with the example app
- Bump version number


PTAL @saeta 