### PR TITLE
Fix fragment parsing and __id generation

### DIFF
--- a/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/SangriaGraphQlParserTest.scala
+++ b/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/SangriaGraphQlParserTest.scala
@@ -235,6 +235,103 @@ class SangriaGraphQlParserTest extends AssertionsForJUnit {
   }
 
   @Test
+  def parseFragments(): Unit = {
+    val query =
+      """
+        query EmptyQuery {
+          CoursesV1Resource {
+            ...getAllFragment
+          }
+        }
+
+        fragment getAllFragment on CoursesV1Resource {
+          getAll(limit: 10) {
+            id
+          }
+        }
+      """
+    val response = SangriaGraphQlParser.parse(query, requestHeader)
+    val expectedRequest = Request(requestHeader, immutable.Seq(
+      TopLevelRequest(
+        ResourceName("courses", 1),
+        RequestField(
+          name = "getAll",
+          alias = None,
+          args = Set(("limit", JsNumber(10))),
+          selections = List(
+            RequestField(
+              name = "id",
+              alias = None,
+              args = Set.empty,
+              selections = List.empty))))))
+    assert(response.get === expectedRequest)
+  }
+
+  @Test
+  def parseFragmentOnRoot(): Unit = {
+    val query =
+      """
+        query EmptyQuery {
+          ...CoursesV1GetAllFragment
+        }
+
+        fragment CoursesV1GetAllFragment on root {
+          CoursesV1Resource {
+            getAll(limit: 10) {
+              id
+            }
+          }
+        }
+      """
+    val response = SangriaGraphQlParser.parse(query, requestHeader)
+    val expectedRequest = Request(requestHeader, immutable.Seq(
+      TopLevelRequest(
+        ResourceName("courses", 1),
+        RequestField(
+          name = "getAll",
+          alias = None,
+          args = Set(("limit", JsNumber(10))),
+          selections = List(
+            RequestField(
+              name = "id",
+              alias = None,
+              args = Set.empty,
+              selections = List.empty))))))
+    assert(response.get === expectedRequest)
+  }
+
+  @Test
+  def parseInlineFragmentOnRoot(): Unit = {
+    val query =
+      """
+        query EmptyQuery {
+          ... on root {
+            CoursesV1Resource {
+              getAll(limit: 10) {
+                id
+              }
+            }
+          }
+        }
+      """
+    val response = SangriaGraphQlParser.parse(query, requestHeader)
+    val expectedRequest = Request(requestHeader, immutable.Seq(
+      TopLevelRequest(
+        ResourceName("courses", 1),
+        RequestField(
+          name = "getAll",
+          alias = None,
+          args = Set(("limit", JsNumber(10))),
+          selections = List(
+            RequestField(
+              name = "id",
+              alias = None,
+              args = Set.empty,
+              selections = List.empty))))))
+    assert(response.get === expectedRequest)
+  }
+
+  @Test
   def resourceNameParse(): Unit = {
     assert(SangriaGraphQlParser.fieldNameToNaptimeResource("CoursesV0Resource") ===
       Some(ResourceName("courses", 0)))

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.3.1"
+version in ThisBuild := "0.3.2"


### PR DESCRIPTION
- Fragments on top-level resources weren’t being parsed correctly. Now they are
- global id generation for non-string ids was also broken. now its fixed

PTAL @saeta 