### PR TITLE
Fix bug with aliases on top-level resources

### DIFF
--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/SangriaGraphQlSchemaBuilder.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/SangriaGraphQlSchemaBuilder.scala
@@ -290,7 +290,7 @@ class SangriaGraphQlSchemaBuilder(
       val connection = (for {
         topLevelIds <- context.ctx.response.topLevelIds.find { case (topLevelRequest, _) =>
           topLevelRequest.resource == resourceName &&
-            topLevelRequest.alias == context.astFields.headOption.flatMap(_.alias)
+            topLevelRequest.selection.alias == context.astFields.headOption.flatMap(_.alias)
         }.map(_._2)
         objects <- context.ctx.response.data.get(resourceName)
       } yield {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.3.2"
+version in ThisBuild := "0.3.3"


### PR DESCRIPTION
This moves alias matching from the resource itself to the selection in the resource, so data can now actually be returned.

Wrote a unit test to verify that this works (and before the change, the unit test fails)

PTAL @saeta 