### PR TITLE
Add a `q={finderName}` argument to parsed top-level resources

### DIFF
--- a/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/SangriaGraphQlParserTest.scala
+++ b/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/SangriaGraphQlParserTest.scala
@@ -23,6 +23,7 @@ import org.coursera.naptime.ari.TopLevelRequest
 import org.junit.Test
 import org.scalatest.junit.AssertionsForJUnit
 import play.api.libs.json.JsNumber
+import play.api.libs.json.JsString
 import play.api.test.FakeRequest
 
 import scala.collection.immutable
@@ -120,7 +121,7 @@ class SangriaGraphQlParserTest extends AssertionsForJUnit {
       """
         query DeeplyNestedQuery {
           courses: CoursesV1Resource {
-            myCourses {
+            getAll {
               id
               partner {
                 shortUrl: slug
@@ -134,7 +135,7 @@ class SangriaGraphQlParserTest extends AssertionsForJUnit {
       TopLevelRequest(
         ResourceName("courses", 1),
         RequestField(
-          name = "myCourses",
+          name = "getAll",
           alias = None,
           args = Set.empty,
           selections = List(
@@ -159,12 +160,12 @@ class SangriaGraphQlParserTest extends AssertionsForJUnit {
       """
         query EmptyQuery {
           CoursesV1Resource {
-            myCourses {
+            getAll {
               id
             }
           }
           InstructorsV1Resource {
-            favorites {
+            get {
               id
               firstName
             }
@@ -176,7 +177,7 @@ class SangriaGraphQlParserTest extends AssertionsForJUnit {
       TopLevelRequest(
         ResourceName("courses", 1),
         RequestField(
-          name = "myCourses",
+          name = "getAll",
           alias = None,
           args = Set.empty,
           selections = List(
@@ -188,7 +189,7 @@ class SangriaGraphQlParserTest extends AssertionsForJUnit {
       TopLevelRequest(
         ResourceName("instructors", 1),
         RequestField(
-          name = "favorites",
+          name = "get",
           alias = None,
           args = Set.empty,
           selections = List(
@@ -225,6 +226,37 @@ class SangriaGraphQlParserTest extends AssertionsForJUnit {
           name = "getAll",
           alias = None,
           args = Set(("limit", JsNumber(10))),
+          selections = List(
+            RequestField(
+              name = "id",
+              alias = None,
+              args = Set.empty,
+              selections = List.empty))))))
+    assert(response.get === expectedRequest)
+  }
+
+  @Test
+  def augmentFinderArguments(): Unit = {
+    val query =
+      """
+        query EmptyQuery {
+          CoursesV1Resource {
+            slug(slug: "machine-learning") {
+              id
+            }
+          }
+        }
+      """
+    val response = SangriaGraphQlParser.parse(query, requestHeader)
+    val expectedRequest = Request(requestHeader, immutable.Seq(
+      TopLevelRequest(
+        ResourceName("courses", 1),
+        RequestField(
+          name = "slug",
+          alias = None,
+          args = Set(
+            ("slug", JsString("machine-learning")),
+            ("q", JsString("slug"))),
           selections = List(
             RequestField(
               name = "id",

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.3.3"
+version in ThisBuild := "0.3.4"


### PR DESCRIPTION
Finders require an extra `?q=finderName` argument in their requests to specify the correct endpoint. This commit adds that argument in the parsing layer so both the RemoteFetcher and LocalFetcher can make the finder requests properly.

PTAL @saeta . I'm still unsure whether this logic should live in the parser or in the fetchers. I opted to put this in the parser only to avoid having to duplicate the logic across the RemoteFetcher and LocalFetcher (which right now live in two separate codebases). Open to other suggestions though...