### PR TITLE
Parse all `get` lookups as multigets

### DIFF
--- a/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/SangriaGraphQlParserTest.scala
+++ b/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/SangriaGraphQlParserTest.scala
@@ -22,6 +22,7 @@ import org.coursera.naptime.ari.RequestField
 import org.coursera.naptime.ari.TopLevelRequest
 import org.junit.Test
 import org.scalatest.junit.AssertionsForJUnit
+import play.api.libs.json.JsArray
 import play.api.libs.json.JsNumber
 import play.api.libs.json.JsString
 import play.api.test.FakeRequest
@@ -165,7 +166,7 @@ class SangriaGraphQlParserTest extends AssertionsForJUnit {
             }
           }
           InstructorsV1Resource {
-            get {
+            multiGet {
               id
               firstName
             }
@@ -189,7 +190,7 @@ class SangriaGraphQlParserTest extends AssertionsForJUnit {
       TopLevelRequest(
         ResourceName("instructors", 1),
         RequestField(
-          name = "get",
+          name = "multiGet",
           alias = None,
           args = Set.empty,
           selections = List(
@@ -226,6 +227,35 @@ class SangriaGraphQlParserTest extends AssertionsForJUnit {
           name = "getAll",
           alias = None,
           args = Set(("limit", JsNumber(10))),
+          selections = List(
+            RequestField(
+              name = "id",
+              alias = None,
+              args = Set.empty,
+              selections = List.empty))))))
+    assert(response.get === expectedRequest)
+  }
+
+  @Test
+  def augmentGetArguments(): Unit = {
+    val query =
+      """
+        query EmptyQuery {
+          CoursesV1Resource {
+            get(id: "abc123") {
+              id
+            }
+          }
+        }
+      """
+    val response = SangriaGraphQlParser.parse(query, requestHeader)
+    val expectedRequest = Request(requestHeader, immutable.Seq(
+      TopLevelRequest(
+        ResourceName("courses", 1),
+        RequestField(
+          name = "get",
+          alias = None,
+          args = Set(("ids", JsArray(List(JsString("abc123"))))),
           selections = List(
             RequestField(
               name = "id",

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.3.5"
+version in ThisBuild := "0.3.6"


### PR DESCRIPTION
This modifies all `get` top-level requests to instead be multigets. This allows us to remove a special case from our url construction libraries, and also fixes a bug where finders that have an `id` argument were being parsed as gets instead.

PTAL @saeta 
cc @lewisf 