### PR TITLE
Add DataMap support to JSON serializer and schemas

### DIFF
--- a/examples/build.sbt
+++ b/examples/build.sbt
@@ -5,11 +5,8 @@ routesGenerator := InjectedRoutesGenerator
 libraryDependencies ++= Seq(
   courierRuntime,
   cache,
-  sangria,
-  sangriaPlayJson
+  sangria
 )
-
-dependencyOverrides += playJson
 
 org.coursera.courier.sbt.CourierPlugin.courierSettings
 

--- a/examples/src/main/pegasus/org/coursera/example/AnyData.courier
+++ b/examples/src/main/pegasus/org/coursera/example/AnyData.courier
@@ -1,0 +1,13 @@
+namespace org.coursera.example
+
+/**
+ * Marker type for arbitrary JSON data.
+ *
+ * WARN: Provided for compatibility with existing data models only. Please define schemas for all
+ * data.
+ *
+ * This will be deprecated once `AnyRecord` is available.
+ */
+@passthroughExempt
+  record AnyData {
+}

--- a/examples/src/main/pegasus/org/coursera/example/AnyData.courier
+++ b/examples/src/main/pegasus/org/coursera/example/AnyData.courier
@@ -9,5 +9,5 @@ namespace org.coursera.example
  * This will be deprecated once `AnyRecord` is available.
  */
 @passthroughExempt
-  record AnyData {
+record AnyData {
 }

--- a/examples/src/main/pegasus/org/coursera/example/Course.courier
+++ b/examples/src/main/pegasus/org/coursera/example/Course.courier
@@ -11,4 +11,6 @@ record Course {
   slug: string
   name: string
   description: string
+
+  extraData: AnyData
 }

--- a/examples/src/main/scala/stores/CourseStore.scala
+++ b/examples/src/main/scala/stores/CourseStore.scala
@@ -3,8 +3,13 @@ package stores
 import java.util.concurrent.atomic.AtomicInteger
 import javax.inject.Singleton
 
+import com.linkedin.data.DataMap
+import org.coursera.courier.templates.DataTemplates.DataConversion
+import org.coursera.example.AnyData
 import org.coursera.example.Course
 import org.coursera.naptime.model.Keyed
+
+import scala.collection.JavaConverters._
 
 @Singleton
 class CourseStore {
@@ -18,13 +23,19 @@ class CourseStore {
       partner = "stanford",
       slug = "machine-learning",
       name = "Machine Learning",
-      description = ""),
+      description = "",
+      extraData = AnyData(new DataMap(
+        Map("firstModuleId" -> "wrh7vtpj").asJava),
+        DataConversion.SetReadOnly)),
     "lhtl" -> Course(
       instructors = List("barb-oakley"),
       partner = "ucsd",
       slug = "learning-how-to-learn",
       name = "Learning How to Learn",
-      description = ""))
+      description = "",
+      extraData = AnyData(new DataMap(
+        Map("recentEnrollments" -> new Integer(1000)).asJava),
+        DataConversion.SetReadOnly)))
 
   def get(id: String) = courseStore.get(id)
 

--- a/naptime-graphql/build.sbt
+++ b/naptime-graphql/build.sbt
@@ -4,7 +4,6 @@ libraryDependencies ++= Seq(
   courierRuntime,
   playJson,
   sangria,
-  sangriaPlayJson,
   sangriaRelay,
   scalaLogging,
   junit,
@@ -12,7 +11,5 @@ libraryDependencies ++= Seq(
   scalatest,
   mockito
 )
-
-dependencyOverrides += playJson
 
 org.coursera.courier.sbt.CourierPlugin.courierSettings

--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/GraphQLController.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/GraphQLController.scala
@@ -21,6 +21,7 @@ import javax.inject._
 import com.typesafe.scalalogging.StrictLogging
 import org.coursera.naptime.ari.EngineApi
 import org.coursera.naptime.ari.Response
+import org.coursera.naptime.ari.graphql.marshaller.NaptimeMarshaller._
 import play.api.libs.json.JsObject
 import play.api.libs.json.JsString
 import play.api.libs.json.Json
@@ -31,7 +32,6 @@ import sangria.execution.HandledException
 import sangria.execution.QueryAnalysisError
 import sangria.parser.QueryParser
 import sangria.renderer.SchemaRenderer
-import sangria.marshalling.playJson._
 import sangria.parser.SyntaxError
 
 import scala.concurrent.ExecutionContext

--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/SangriaGraphQlSchemaBuilder.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/SangriaGraphQlSchemaBuilder.scala
@@ -36,6 +36,7 @@ import com.typesafe.scalalogging.StrictLogging
 import org.coursera.naptime.PaginationConfiguration
 import org.coursera.naptime.ResourceName
 import org.coursera.naptime.ari.TopLevelRequest
+import org.coursera.naptime.ari.graphql.types.NaptimeTypes
 import org.coursera.naptime.schema.Handler
 import org.coursera.naptime.schema.HandlerKind
 import org.coursera.naptime.schema.Resource
@@ -486,6 +487,9 @@ class SangriaGraphQlSchemaBuilder(
       case nullDataSchema: NullDataSchema =>
         // TODO(bryan): Figure out nulls
         StringType
+      case recordDataSchema: RecordDataSchema
+        if recordDataSchema.getProperties.asScala.get("passthroughExempt").contains(true) =>
+        NaptimeTypes.DataMapType
       case recordDataSchema: RecordDataSchema =>
         buildRecordType(recordDataSchema, namespace)
       case unionDataSchema: UnionDataSchema =>

--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/marshaller/NaptimeMarshaller.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/marshaller/NaptimeMarshaller.scala
@@ -1,0 +1,151 @@
+package org.coursera.naptime.ari.graphql.marshaller
+
+import com.linkedin.data.DataMap
+import org.coursera.naptime.actions.NaptimeSerializer
+import play.api.libs.json.JsArray
+import play.api.libs.json.JsBoolean
+import play.api.libs.json.JsError
+import play.api.libs.json.JsNull
+import play.api.libs.json.JsNumber
+import play.api.libs.json.JsObject
+import play.api.libs.json.JsPath
+import play.api.libs.json.JsString
+import play.api.libs.json.JsSuccess
+import play.api.libs.json.JsValue
+import play.api.libs.json.Json
+import play.api.libs.json.Reads
+import play.api.libs.json.Writes
+import sangria.marshalling.ArrayMapBuilder
+import sangria.marshalling.FromInput
+import sangria.marshalling.InputParser
+import sangria.marshalling.InputParsingError
+import sangria.marshalling.InputUnmarshaller
+import sangria.marshalling.ResultMarshaller
+import sangria.marshalling.ResultMarshallerForType
+import sangria.marshalling.ScalarValueInfo
+import sangria.marshalling.ToInput
+
+import scala.util.Try
+
+/**
+  * Modified from https://github.com/sangria-graphql/sangria-play-json,
+  * with added support for DataMaps
+  */
+object NaptimeMarshaller extends PlayJsonSupportLowPrioImplicits {
+  implicit object PlayJsonResultMarshaller extends ResultMarshaller {
+    type Node = JsValue
+    type MapBuilder = ArrayMapBuilder[Node]
+
+    def emptyMapNode(keys: Seq[String]) = new ArrayMapBuilder[Node](keys)
+    def addMapNodeElem(builder: MapBuilder, key: String, value: Node, optional: Boolean) = builder.add(key, value)
+
+    def mapNode(builder: MapBuilder) = JsObject(builder.toSeq)
+    def mapNode(keyValues: Seq[(String, JsValue)]) = JsObject(keyValues)
+
+    def arrayNode(values: Vector[JsValue]) = JsArray(values)
+
+    def optionalArrayNodeValue(value: Option[JsValue]) = value match {
+      case Some(v) => v
+      case None => nullNode
+    }
+
+    def scalarNode(value: Any, typeName: String, info: Set[ScalarValueInfo]) = value match {
+      case v: String => JsString(v)
+      case v: Boolean => JsBoolean(v)
+      case v: Int => JsNumber(v)
+      case v: Long => JsNumber(v)
+      case v: Double => JsNumber(v)
+      case v: BigInt => JsNumber(BigDecimal(v))
+      case v: BigDecimal => JsNumber(v)
+      case v: DataMap => NaptimeSerializer.PlayJson.deserialize(v)
+      case v => throw new IllegalArgumentException("Unsupported scalar value: " + v)
+    }
+
+    def enumNode(value: String, typeName: String) = JsString(value)
+
+    def nullNode = JsNull
+
+    def renderCompact(node: JsValue) = Json.stringify(node)
+    def renderPretty(node: JsValue) = Json.prettyPrint(node)
+  }
+
+  implicit object PlayJsonMarshallerForType extends ResultMarshallerForType[JsValue] {
+    val marshaller = PlayJsonResultMarshaller
+  }
+
+  implicit object PlayJsonInputUnmarshaller extends InputUnmarshaller[JsValue] {
+    def getRootMapValue(node: JsValue, key: String) = node.asInstanceOf[JsObject].value get key
+
+    def isListNode(node: JsValue) = node.isInstanceOf[JsArray]
+    def getListValue(node: JsValue) = node.asInstanceOf[JsArray].value
+
+    def isMapNode(node: JsValue) = node.isInstanceOf[JsObject]
+    def getMapValue(node: JsValue, key: String) = node.asInstanceOf[JsObject].value get key
+    def getMapKeys(node: JsValue) = node.asInstanceOf[JsObject].keys
+
+    def isDefined(node: JsValue) = node != JsNull
+    def getScalarValue(node: JsValue) = node match {
+      case JsBoolean(b) => b
+      case JsNumber(d) => d.toBigIntExact getOrElse d
+      case JsString(s) => s
+      case _ => throw new IllegalStateException(s"$node is not a scalar value")
+    }
+
+    def getScalaScalarValue(node: JsValue) = getScalarValue(node)
+
+    def isEnumNode(node: JsValue) = node.isInstanceOf[JsString]
+
+    def isScalarNode(node: JsValue) = node match {
+      case _: JsBoolean | _: JsNumber | _: JsString => true
+      case _ => false
+    }
+
+    def isVariableNode(node: JsValue) = false
+    def getVariableName(node: JsValue) = throw new IllegalArgumentException("variables are not supported")
+
+    def render(node: JsValue) = Json.stringify(node)
+  }
+
+  private object PlayJsonToInput extends ToInput[JsValue, JsValue] {
+    def toInput(value: JsValue) = (value, PlayJsonInputUnmarshaller)
+  }
+
+  implicit def playJsonToInput[T <: JsValue]: ToInput[T, JsValue] =
+    PlayJsonToInput.asInstanceOf[ToInput[T, JsValue]]
+
+  implicit def playJsonWriterToInput[T : Writes]: ToInput[T, JsValue] =
+    new ToInput[T, JsValue] {
+      def toInput(value: T) = implicitly[Writes[T]].writes(value) → PlayJsonInputUnmarshaller
+    }
+
+  private object PlayJsonFromInput extends FromInput[JsValue] {
+    val marshaller = PlayJsonResultMarshaller
+    def fromResult(node: marshaller.Node) = node
+  }
+
+  implicit def playJsonFromInput[T <: JsValue]: FromInput[T] =
+    PlayJsonFromInput.asInstanceOf[FromInput[T]]
+
+  implicit def playJsonReaderFromInput[T : Reads]: FromInput[T] =
+    new FromInput[T] {
+      val marshaller = PlayJsonResultMarshaller
+      def fromResult(node: marshaller.Node) = implicitly[Reads[T]].reads(node) match {
+        case JsSuccess(v, _) => v
+        case JsError(errors) =>
+          val formattedErrors = errors.toVector.flatMap {
+            case (JsPath(nodes), es) => es.map(e => s"At path '${nodes.mkString(".")}': ${e.message}")
+          }
+
+          throw InputParsingError(formattedErrors)
+      }
+    }
+
+  implicit object PlayJsonInputParser extends InputParser[JsValue] {
+    def parse(str: String) = Try(Json.parse(str))
+  }
+}
+
+trait PlayJsonSupportLowPrioImplicits {
+  implicit val PlayJsonInputUnmarshallerJObject =
+    NaptimeMarshaller.PlayJsonInputUnmarshaller.asInstanceOf[InputUnmarshaller[JsObject]]
+}

--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/types/NaptimeTypes.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/types/NaptimeTypes.scala
@@ -1,0 +1,36 @@
+package org.coursera.naptime.ari.graphql.types
+
+import com.linkedin.data.DataMap
+import com.linkedin.data.codec.JacksonDataCodec
+import sangria.ast.StringValue
+import sangria.schema.ScalarType
+import sangria.validation.ValueCoercionViolation
+import sangria.validation.Violation
+
+import scala.util.Try
+
+object NaptimeTypes {
+  case object DataMapCoercionViolation extends ValueCoercionViolation("DataMap value expected")
+
+  private[this] val dataCodec = new JacksonDataCodec()
+
+  private[this] def stringToDataMapEither(string: String): Either[Violation, DataMap] = {
+    Try(dataCodec.stringToMap(string))
+      .toOption
+      .map(Right(_))
+      .getOrElse(Left(DataMapCoercionViolation))
+  }
+
+
+  val DataMapType = ScalarType[DataMap]("DataMap",
+    description = Some("Pegasus DataMap, with an arbitrary JSON-like value"),
+    coerceOutput = (value, _) ⇒ value,
+    coerceUserInput = {
+      case string: String => stringToDataMapEither(string)
+      case _ => Left(DataMapCoercionViolation)
+    },
+    coerceInput = {
+      case StringValue(string, _, _) => stringToDataMapEither(string)
+      case _ => Left(DataMapCoercionViolation)
+    })
+}

--- a/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/DefaultGraphqlSchemaProviderTest.scala
+++ b/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/DefaultGraphqlSchemaProviderTest.scala
@@ -69,7 +69,16 @@ class DefaultGraphqlSchemaProviderTest extends AssertionsForJUnit {
 object DefaultGraphqlSchemaProviderTest extends MockitoSugar {
   import org.coursera.naptime.ari.engine.EngineImplTest._
 
-  val DEFAULT_TYPES = Set("ID", "root", "Boolean", "Long", "Float", "Int", "BigInt", "String", "BigDecimal")
+  val DEFAULT_TYPES = Set(
+    "ID",
+    "root",
+    "Boolean",
+    "Long",
+    "Float",
+    "Int",
+    "BigInt",
+    "String",
+    "BigDecimal")
 
   val COMPUTED_TYPES = Set(
     "CoursesV1",
@@ -84,7 +93,8 @@ object DefaultGraphqlSchemaProviderTest extends MockitoSugar {
     "org_coursera_naptime_ari_graphql_models_CoursePlatform",
     "org_coursera_naptime_ari_graphql_models_originalId",
     "PageInfo",
-    "stringMember")
+    "stringMember",
+    "DataMap")
 
   val extraTypes = TYPE_SCHEMAS.map { case (key, value) => Keyed(key, value) }.toList
 

--- a/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/SangriaGraphQlSchemaBuilderTest.scala
+++ b/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/SangriaGraphQlSchemaBuilderTest.scala
@@ -89,7 +89,8 @@ class SangriaGraphQlSchemaBuilderTest extends AssertionsForJUnit {
       "instructors",
       "originalId",
       "partner",
-      "coursePlatform")
+      "coursePlatform",
+      "arbitraryData")
     assert(fieldNames === expectedFieldNames)
   }
 

--- a/naptime/src/test/pegasus/org/coursera/naptime/ari/graphql/models/AnyData.courier
+++ b/naptime/src/test/pegasus/org/coursera/naptime/ari/graphql/models/AnyData.courier
@@ -1,0 +1,13 @@
+namespace org.coursera.naptime.ari.graphql.models
+
+/**
+ * Marker type for arbitrary JSON data.
+ *
+ * WARN: Provided for compatibility with existing data models only. Please define schemas for all
+ * data.
+ *
+ * This will be deprecated once `AnyRecord` is available.
+ */
+@passthroughExempt
+  record AnyData {
+}

--- a/naptime/src/test/pegasus/org/coursera/naptime/ari/graphql/models/AnyData.courier
+++ b/naptime/src/test/pegasus/org/coursera/naptime/ari/graphql/models/AnyData.courier
@@ -9,5 +9,5 @@ namespace org.coursera.naptime.ari.graphql.models
  * This will be deprecated once `AnyRecord` is available.
  */
 @passthroughExempt
-  record AnyData {
+record AnyData {
 }

--- a/naptime/src/test/pegasus/org/coursera/naptime/ari/graphql/models/MergedCourse.courier
+++ b/naptime/src/test/pegasus/org/coursera/naptime/ari/graphql/models/MergedCourse.courier
@@ -18,4 +18,6 @@ record MergedCourse {
   originalId: union[int, string]
 
   coursePlatform: array[enum CoursePlatform {OldPlatform NewPlatform}]
+
+  arbitraryData: AnyData
 }

--- a/naptime/src/test/scala/org/coursera/naptime/ari/engine/EngineImplTest.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/ari/engine/EngineImplTest.scala
@@ -2,6 +2,8 @@ package org.coursera.naptime.ari.engine
 
 import com.google.inject.Injector
 import com.linkedin.data.DataList
+import com.linkedin.data.DataMap
+import org.coursera.courier.templates.DataTemplates.DataConversion
 import org.coursera.naptime.ResourceName
 import org.coursera.naptime.ari.FetcherApi
 import org.coursera.naptime.ari.LocalSchemaProvider
@@ -9,6 +11,7 @@ import org.coursera.naptime.ari.Request
 import org.coursera.naptime.ari.RequestField
 import org.coursera.naptime.ari.Response
 import org.coursera.naptime.ari.TopLevelRequest
+import org.coursera.naptime.ari.graphql.models.AnyData
 import org.coursera.naptime.ari.graphql.models.Coordinates
 import org.coursera.naptime.ari.graphql.models.CoursePlatform
 import org.coursera.naptime.ari.graphql.models.MergedCourse
@@ -701,7 +704,8 @@ object EngineImplTest {
     instructors = List("instructor1Id"),
     partner = 123,
     originalId = "",
-    coursePlatform = List(CoursePlatform.NewPlatform))
+    coursePlatform = List(CoursePlatform.NewPlatform),
+    arbitraryData = AnyData(new DataMap(), DataConversion.SetReadOnly))
   val COURSE_B = MergedCourse(
     id = "courseBId",
     name = "Probabalistic Graphical Models",
@@ -710,7 +714,8 @@ object EngineImplTest {
     instructors = List("instructor2Id"),
     partner = 123,
     originalId = "",
-    coursePlatform = List(CoursePlatform.NewPlatform))
+    coursePlatform = List(CoursePlatform.NewPlatform),
+    arbitraryData = AnyData(new DataMap(), DataConversion.SetReadOnly))
 
   val INSTRUCTOR_1 = MergedInstructor(
     id = "instructor1Id",

--- a/project/NamedDependencies.scala
+++ b/project/NamedDependencies.scala
@@ -36,7 +36,6 @@ trait NamedDependencies { this: PluginVersionProvider =>
   val playTestCompile = ("com.typesafe.play" %% "play-test" % playVersion)
     .excludeAll(new ExclusionRule(organization="org.specs2"))
   val sangria = "org.sangria-graphql" %% "sangria" % "0.7.1"
-  val sangriaPlayJson = "org.sangria-graphql" %% "sangria-play-json" % "0.3.2"
   val sangriaRelay = "org.sangria-graphql" %% "sangria-relay" % "0.7.1"
   val scalaGuice = "net.codingwell" %% "scala-guice" % "4.0.0"
   val scalaLogging = "com.typesafe.scala-logging" %% "scala-logging" % "3.1.0"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.3.6"
+version in ThisBuild := "0.3.7"


### PR DESCRIPTION
Some of our Courier models support a `passthroughExempt` flag, which lets the model support an arbitrary, untyped DataMap as a field. GraphQL/Sangria was freaking out when seeing this though, as there were no fields defined (which is not allowed according to GraphQL’s spec). This takes a lot of inspiration from both https://github.com/taion/graphql-type-json and https://gist.github.com/OlegIlyenko/5b96f4b54f656aac226d3c4bc33fd2a6 to add a `DataMapType` to the GraphQL schema we support.

TODO: add tests for this :). But initial thoughts would be nice, in case I have to end up refactoring any of this.

PTAL @saeta , and cc @lewisf as you need this for Nostos support to work properly.