### PR TITLE
Add ResponsePagination model to TopLevelResponse

### DIFF
--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/SangriaGraphQlSchemaBuilder.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/SangriaGraphQlSchemaBuilder.scala
@@ -289,14 +289,14 @@ class SangriaGraphQlSchemaBuilder(
     (context: Context[SangriaGraphQlContext, DataMap]) => {
 
       val connection = (for {
-        topLevelIds <- context.ctx.response.topLevelIds.find { case (topLevelRequest, _) =>
+        topLevelResponse <- context.ctx.response.topLevelResponses.find { case (topLevelRequest, _) =>
           topLevelRequest.resource == resourceName &&
             topLevelRequest.selection.alias == context.astFields.headOption.flatMap(_.alias)
         }.map(_._2)
         objects <- context.ctx.response.data.get(resourceName)
       } yield {
         objects.collect {
-          case (id, element) if topLevelIds.contains(id) => element
+          case (id, element) if topLevelResponse.ids.contains(id) => element
         }.toSeq
       }).map(objects => Connection.connectionFromSeq(objects, ConnectionArgs(context)))
         .getOrElse(Connection.empty[DataMap])

--- a/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/SangriaGraphQlSchemaExecutionTest.scala
+++ b/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/SangriaGraphQlSchemaExecutionTest.scala
@@ -20,9 +20,11 @@ import com.linkedin.data.DataList
 import com.linkedin.data.DataMap
 import org.coursera.courier.templates.DataTemplates.DataConversion
 import org.coursera.naptime.ResourceName
+import org.coursera.naptime.ResponsePagination
 import org.coursera.naptime.ari.RequestField
 import org.coursera.naptime.ari.Response
 import org.coursera.naptime.ari.TopLevelRequest
+import org.coursera.naptime.ari.TopLevelResponse
 import org.coursera.naptime.ari.graphql.marshaller.NaptimeMarshaller._
 import org.coursera.naptime.ari.graphql.models.AnyData
 import org.coursera.naptime.ari.graphql.models.CoursePlatform
@@ -126,7 +128,8 @@ class SangriaGraphQlSchemaExecutionTest extends AssertionsForJUnit with ScalaFut
               args = Set.empty,
               selections = List.empty))))
     val response = Response(
-      topLevelIds = Map(topLevelRequest -> new DataList(List("1").asJava)),
+      topLevelResponses = Map(topLevelRequest ->
+        TopLevelResponse(new DataList(List("1").asJava), ResponsePagination.empty)),
       data = Map(ResourceName("courses", 1) -> Map("1" -> courseOne.data())))
     val context = SangriaGraphQlContext(response)
     val execution = Executor.execute(schema, queryAst, context).futureValue
@@ -168,7 +171,8 @@ class SangriaGraphQlSchemaExecutionTest extends AssertionsForJUnit with ScalaFut
             selections = List.empty))),
       alias = Some("courseContainer"))
     val response = Response(
-      topLevelIds = Map(topLevelRequest -> new DataList(List("1").asJava)),
+      topLevelResponses = Map(topLevelRequest ->
+        TopLevelResponse(new DataList(List("1").asJava), ResponsePagination.empty)),
       data = Map(ResourceName("courses", 1) -> Map(
         "1" -> courseOne.data(),
         "2" -> courseTwo.data())))
@@ -207,7 +211,8 @@ class SangriaGraphQlSchemaExecutionTest extends AssertionsForJUnit with ScalaFut
             args = Set.empty,
             selections = List.empty))))
     val response = Response(
-      topLevelIds = Map(topLevelRequest -> new DataList(List("1").asJava)),
+      topLevelResponses = Map(topLevelRequest ->
+        TopLevelResponse(new DataList(List("1").asJava), ResponsePagination.empty)),
       data = Map(ResourceName("courses", 1) -> Map("1" -> courseOne.data())))
     val context = SangriaGraphQlContext(response)
     val execution = Executor.execute(schema, queryAst, context).futureValue

--- a/naptime-testing/src/test/scala/org/coursera/naptime/NestedMacroCourierTests.scala
+++ b/naptime-testing/src/test/scala/org/coursera/naptime/NestedMacroCourierTests.scala
@@ -141,7 +141,7 @@ class NestedMacroCourierTests extends AssertionsForJUnit with ScalaFutures {
 
     val response = fetcher.data(request).futureValue
 
-    assert(1 === response.topLevelIds.size)
+    assert(1 === response.topLevelResponses.size)
     assert(1 === response.data.size)
     assert(response.data.contains(CoursesResource.ID))
     val coursesResponse = response.data(CoursesResource.ID)
@@ -175,7 +175,7 @@ class NestedMacroCourierTests extends AssertionsForJUnit with ScalaFutures {
     val response = fetcher.data(request).futureValue
 
 
-    assert(1 === response.topLevelIds.size)
+    assert(1 === response.topLevelResponses.size)
     assert(1 === response.data.size)
     assert(response.data.contains(CoursesResource.ID))
     val coursesResponse = response.data(CoursesResource.ID)
@@ -208,7 +208,7 @@ class NestedMacroCourierTests extends AssertionsForJUnit with ScalaFutures {
 
     val response = fetcher.data(request).futureValue
 
-    assert(1 === response.topLevelIds.size)
+    assert(1 === response.topLevelResponses.size)
     assert(1 === response.data.size)
     assert(response.data.contains(CoursesResource.ID))
     val coursesResponse = response.data(CoursesResource.ID)

--- a/naptime/src/main/scala/org/coursera/naptime/actions/RestActionCategoryEngine2.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/actions/RestActionCategoryEngine2.scala
@@ -53,6 +53,7 @@ import org.coursera.common.stringkey.StringKey
 import org.coursera.naptime.ETag
 import org.coursera.naptime.ResponsePagination
 import org.coursera.naptime.ari.TopLevelRequest
+import org.coursera.naptime.ari.TopLevelResponse
 import org.coursera.naptime.ari.{Response => AriResponse}
 import org.coursera.naptime.model.KeyFormat
 import org.coursera.naptime.model.Keyed
@@ -133,9 +134,10 @@ trait RestActionCategoryEngine2Impls {
         dataMap.get("id") -> dataMap
       }.toMap
       // TODO: serialized related ones too!
-      val topLevelIdMap = Map(topLevelRequest -> topLevelDataList)
+      val topLevelResponseMap = Map(topLevelRequest ->
+        TopLevelResponse(topLevelDataList, ResponsePagination.empty))
       val responseDataMap = Map(resourceName -> resourceMap)
-      Future.successful(AriResponse(topLevelIdMap, responseDataMap))
+      Future.successful(AriResponse(topLevelResponseMap, responseDataMap))
     }.getOrElse {
       Future.failed(new IllegalArgumentException("Could not compute schema for resource value."))
     }

--- a/naptime/src/main/scala/org/coursera/naptime/ari/engine/EngineImpl.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/ari/engine/EngineImpl.scala
@@ -101,7 +101,7 @@ class EngineImpl @Inject() (
               selections = nestedField.selections))
           executeTopLevelRequest(requestHeader, relatedTopLevelRequest).map { response =>
             // Exclude the top level ids in the response.
-            Response(topLevelIds = Map.empty, data = response.data)
+            Response(topLevelResponses = Map.empty, data = response.data)
           }
         }
         Future.sequence(additionalResponses).map { additionalResponses =>

--- a/naptime/src/main/scala/org/coursera/naptime/ari/models.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/ari/models.scala
@@ -21,6 +21,7 @@ import com.linkedin.data.DataMap
 import com.linkedin.data.schema.DataSchema
 import com.linkedin.data.schema.RecordDataSchema
 import org.coursera.naptime.ResourceName
+import org.coursera.naptime.ResponsePagination
 import org.coursera.naptime.schema.Resource
 import play.api.libs.json.JsValue
 import play.api.mvc.RequestHeader
@@ -127,18 +128,18 @@ case class RequestField(
  *
  * TODO: performance test, and determine if mutable collections yield non-trivial performance improvements.
  *
- * @param topLevelIds A map from the top level requests to a DataList containing the ordered list of IDs for the
- *                    top of the response
+ * @param topLevelResponses A map from the top level requests to a TopLevelResponse,
+  *                         containing ids and pagination
  * @param data A map from the resource name to a Map of IDs to DataMaps.
  */
 case class Response(
-  topLevelIds: Map[TopLevelRequest, DataList],
+  topLevelResponses: Map[TopLevelRequest, TopLevelResponse],
   data: Map[ResourceName, Map[AnyRef, DataMap]]) {
 
   // TODO: performance test this implementation, and consider optimizing it.
   // Note: this operation potentially mutates the current response due to interior mutability.
   def ++(other: Response): Response = {
-    val mergedTopLevel = topLevelIds ++ other.topLevelIds
+    val mergedTopLevel = topLevelResponses ++ other.topLevelResponses
     val mergedData = (data.keySet ++ other.data.keySet).map { resourceName =>
       val lhs = data.getOrElse(resourceName, Map.empty)
       val rhs = other.data.getOrElse(resourceName, Map.empty)
@@ -165,3 +166,12 @@ case class Response(
 object Response {
   val empty = Response(Map.empty, Map.empty)
 }
+
+/**
+  * Represents the response data from a TopLevelRequest, including returned ids and pagination
+  *
+  * @param ids a list of IDs returned by the top level request.
+  *            (i.e. ids 5, 6, and 7 were returned by the bySlug finder)
+  * @param pagination pagination info from the top level request, including total and next cursor
+  */
+case class TopLevelResponse(ids: DataList, pagination: ResponsePagination)

--- a/naptime/src/main/scala/org/coursera/naptime/models.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/models.scala
@@ -165,6 +165,7 @@ case class ResponsePagination(
 
 object ResponsePagination {
   implicit val format = Json.format[ResponsePagination]
+  val empty = ResponsePagination(None, None, None)
 }
 
 /**

--- a/naptime/src/test/pegasus/org/coursera/naptime/ari/ResponseTest.scala
+++ b/naptime/src/test/pegasus/org/coursera/naptime/ari/ResponseTest.scala
@@ -3,6 +3,7 @@ package org.coursera.naptime.ari
 import com.linkedin.data.DataList
 import com.linkedin.data.DataMap
 import org.coursera.naptime.ResourceName
+import org.coursera.naptime.ResponsePagination
 import org.junit.Test
 import org.scalatest.junit.AssertionsForJUnit
 import play.api.libs.json.JsNumber
@@ -20,18 +21,19 @@ class ResponseTest extends AssertionsForJUnit {
       args = Set("query" -> JsString("machine learning")),
       selections = List.empty))
     val topLevelDataList = new DataList(List("abc").asJava)
+    val topLevelResponse = TopLevelResponse(topLevelDataList, ResponsePagination.empty)
     val response = Response(
-      topLevelIds = Map(topLevelRequest -> topLevelDataList),
+      topLevelResponses = Map(topLevelRequest -> topLevelResponse),
       data = Map(topLevelRequest.resource -> Map(
         "abc" -> new DataMap(Map("id" -> "abc", "slug" -> "machine-learning").asJava))))
 
     val merged = Response.empty ++ response
 
-    assert(1 === merged.topLevelIds.size)
-    assert(merged.topLevelIds.contains(topLevelRequest))
-    val topLevelResponse = merged.topLevelIds(topLevelRequest)
-    assert(1 === topLevelResponse.size())
-    assert("abc" === topLevelResponse.get(0))
+    assert(1 === merged.topLevelResponses.size)
+    assert(merged.topLevelResponses.contains(topLevelRequest))
+    val mergedTopLevelResponse = merged.topLevelResponses(topLevelRequest)
+    assert(1 === mergedTopLevelResponse.ids.size())
+    assert("abc" === mergedTopLevelResponse.ids.get(0))
 
     assert(1 === merged.data.size)
     assert(merged.data.contains(topLevelRequest.resource))
@@ -55,8 +57,10 @@ class ResponseTest extends AssertionsForJUnit {
       args = Set("query" -> JsString("machine learning")),
       selections = List.empty))
     val topLevelDataListCourses = new DataList(List("abc").asJava)
+    val topLevelResponseCourses = TopLevelResponse(topLevelDataListCourses,
+      ResponsePagination.empty)
     val responseCourses = Response(
-      topLevelIds = Map(topLevelRequestCourses -> topLevelDataListCourses),
+      topLevelResponses = Map(topLevelRequestCourses -> topLevelResponseCourses),
       data = Map(topLevelRequestCourses.resource -> Map(
         "abc" -> new DataMap(Map("id" -> "abc", "slug" -> "machine-learning").asJava))))
 
@@ -66,22 +70,24 @@ class ResponseTest extends AssertionsForJUnit {
       args = Set("id" -> JsNumber(123)),
       selections = List.empty))
     val topLevelDataListInstructors = new DataList(List(new Integer(123)).asJava)
+    val topLevelResponseInstructors = TopLevelResponse(topLevelDataListInstructors,
+      ResponsePagination.empty)
     val responseInstructors = Response(
-      topLevelIds = Map(topLevelRequestInstructors -> topLevelDataListInstructors),
+      topLevelResponses = Map(topLevelRequestInstructors -> topLevelResponseInstructors),
       data = Map(topLevelRequestInstructors.resource -> Map(
         new Integer(123) -> new DataMap(Map("id" -> new Integer(123), "name" -> "Professor X").asJava))))
 
-    val merged = Response.empty ++ responseCourses ++ responseInstructors
+    val merged: Response = Response.empty ++ responseCourses ++ responseInstructors
 
-    assert(2 === merged.topLevelIds.size)
-    assert(merged.topLevelIds.contains(topLevelRequestCourses))
-    assert(merged.topLevelIds.contains(topLevelRequestInstructors))
-    val topLevelResponseCourses = merged.topLevelIds(topLevelRequestCourses)
-    assert(1 === topLevelResponseCourses.size())
-    assert("abc" === topLevelResponseCourses.get(0))
-    val topLevelResponseInstructors = merged.topLevelIds(topLevelRequestInstructors)
-    assert(1 === topLevelResponseInstructors.size())
-    assert(new Integer(123) === topLevelResponseInstructors.get(0))
+    assert(2 === merged.topLevelResponses.size)
+    assert(merged.topLevelResponses.contains(topLevelRequestCourses))
+    assert(merged.topLevelResponses.contains(topLevelRequestInstructors))
+    val mergedTopLevelResponseCourses = merged.topLevelResponses(topLevelRequestCourses)
+    assert(1 === mergedTopLevelResponseCourses.ids.size())
+    assert("abc" === mergedTopLevelResponseCourses.ids.get(0))
+    val mergedTopLevelResponseInstructors = merged.topLevelResponses(topLevelRequestInstructors)
+    assert(1 === mergedTopLevelResponseInstructors.ids.size())
+    assert(new Integer(123) === mergedTopLevelResponseInstructors.ids.get(0))
 
     assert(2 === merged.data.size)
     assert(merged.data.contains(topLevelRequestCourses.resource))
@@ -111,8 +117,9 @@ class ResponseTest extends AssertionsForJUnit {
       args = Set("query" -> JsString("machine learning")),
       selections = List.empty))
     val topLevelDataList1 = new DataList(List("abc").asJava)
+    val topLevelResponse1 = TopLevelResponse(topLevelDataList1, ResponsePagination.empty)
     val response1 = Response(
-      topLevelIds = Map(topLevelRequest1 -> topLevelDataList1),
+      topLevelResponses = Map(topLevelRequest1 -> topLevelResponse1),
       data = Map(topLevelRequest1.resource -> Map(
         "abc" -> new DataMap(Map("id" -> "abc", "slug" -> "machine-learning").asJava))))
 
@@ -122,22 +129,23 @@ class ResponseTest extends AssertionsForJUnit {
       args = Set("id" -> JsString("xyz")),
       selections = List.empty))
     val topLevelDataList2 = new DataList(List("xyz").asJava)
+    val topLevelResponse2 = TopLevelResponse(topLevelDataList2, ResponsePagination.empty)
     val response2 = Response(
-      topLevelIds = Map(topLevelRequest2 -> topLevelDataList2),
+      topLevelResponses = Map(topLevelRequest2 -> topLevelResponse2),
       data = Map(topLevelRequest2.resource -> Map(
         "xyz" -> new DataMap(Map("id" -> "xyz", "slug" -> "pgm").asJava))))
 
-    val merged = response1 ++ response2
+    val merged: Response = response1 ++ response2
 
-    assert(2 === merged.topLevelIds.size)
-    assert(merged.topLevelIds.contains(topLevelRequest1))
-    val topLevelResponse1 = merged.topLevelIds(topLevelRequest1)
-    assert(1 === topLevelResponse1.size())
-    assert("abc" === topLevelResponse1.get(0))
-    assert(merged.topLevelIds.contains(topLevelRequest2))
-    val topLevelResponse2 = merged.topLevelIds(topLevelRequest2)
-    assert(1 === topLevelResponse2.size())
-    assert("xyz" === topLevelResponse2.get(0))
+    assert(2 === merged.topLevelResponses.size)
+    assert(merged.topLevelResponses.contains(topLevelRequest1))
+    val mergedTopLevelResponse1 = merged.topLevelResponses(topLevelRequest1)
+    assert(1 === mergedTopLevelResponse1.ids.size())
+    assert("abc" === mergedTopLevelResponse1.ids.get(0))
+    assert(merged.topLevelResponses.contains(topLevelRequest2))
+    val mergedTopLevelResponse2 = merged.topLevelResponses(topLevelRequest2)
+    assert(1 === mergedTopLevelResponse2.ids.size())
+    assert("xyz" === mergedTopLevelResponse2.ids.get(0))
 
     assert(1 === merged.data.size)
     assert(merged.data.contains(topLevelRequest1.resource))
@@ -164,8 +172,9 @@ class ResponseTest extends AssertionsForJUnit {
       args = Set("query" -> JsString("machine learning")),
       selections = List.empty))
     val topLevelDataList1 = new DataList(List("abc").asJava)
+    val topLevelResponse1 = TopLevelResponse(topLevelDataList1, ResponsePagination.empty)
     val response1 = Response(
-      topLevelIds = Map(topLevelRequest1 -> topLevelDataList1),
+      topLevelResponses = Map(topLevelRequest1 -> topLevelResponse1),
       data = Map(topLevelRequest1.resource -> Map(
         "abc" -> new DataMap(Map("id" -> "abc", "slug" -> "machine-learning").asJava))))
 
@@ -175,22 +184,23 @@ class ResponseTest extends AssertionsForJUnit {
       args = Set("id" -> JsString("abc")),
       selections = List.empty))
     val topLevelDataList2 = new DataList(List("abc").asJava)
+    val topLevelResponse2 = TopLevelResponse(topLevelDataList2, ResponsePagination.empty)
     val response2 = Response(
-      topLevelIds = Map(topLevelRequest2 -> topLevelDataList2),
+      topLevelResponses = Map(topLevelRequest2 -> topLevelResponse2),
       data = Map(topLevelRequest2.resource -> Map(
         "abc" -> new DataMap(Map("id" -> "abc", "slug" -> "machine-learning").asJava))))
 
-    val merged = response1 ++ response2
+    val merged: Response = response1 ++ response2
 
-    assert(2 === merged.topLevelIds.size)
-    assert(merged.topLevelIds.contains(topLevelRequest1))
-    val topLevelResponse1 = merged.topLevelIds(topLevelRequest1)
-    assert(1 === topLevelResponse1.size())
-    assert("abc" === topLevelResponse1.get(0))
-    assert(merged.topLevelIds.contains(topLevelRequest2))
-    val topLevelResponse2 = merged.topLevelIds(topLevelRequest2)
-    assert(1 === topLevelResponse2.size())
-    assert("abc" === topLevelResponse2.get(0))
+    assert(2 === merged.topLevelResponses.size)
+    assert(merged.topLevelResponses.contains(topLevelRequest1))
+    val mergedTopLevelResponse1 = merged.topLevelResponses(topLevelRequest1)
+    assert(1 === mergedTopLevelResponse1.ids.size())
+    assert("abc" === mergedTopLevelResponse1.ids.get(0))
+    assert(merged.topLevelResponses.contains(topLevelRequest2))
+    val mergedTopLevelResponse2 = merged.topLevelResponses(topLevelRequest2)
+    assert(1 === mergedTopLevelResponse2.ids.size())
+    assert("abc" === mergedTopLevelResponse2.ids.get(0))
 
     assert(1 === merged.data.size)
     assert(topLevelRequest1.resource === topLevelRequest2.resource)

--- a/naptime/src/test/scala/org/coursera/naptime/ari/engine/EngineImplTest.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/ari/engine/EngineImplTest.scala
@@ -5,12 +5,14 @@ import com.linkedin.data.DataList
 import com.linkedin.data.DataMap
 import org.coursera.courier.templates.DataTemplates.DataConversion
 import org.coursera.naptime.ResourceName
+import org.coursera.naptime.ResponsePagination
 import org.coursera.naptime.ari.FetcherApi
 import org.coursera.naptime.ari.LocalSchemaProvider
 import org.coursera.naptime.ari.Request
 import org.coursera.naptime.ari.RequestField
 import org.coursera.naptime.ari.Response
 import org.coursera.naptime.ari.TopLevelRequest
+import org.coursera.naptime.ari.TopLevelResponse
 import org.coursera.naptime.ari.graphql.models.AnyData
 import org.coursera.naptime.ari.graphql.models.Coordinates
 import org.coursera.naptime.ari.graphql.models.CoursePlatform
@@ -123,8 +125,9 @@ class EngineImplTest extends AssertionsForJUnit with ScalaFutures with MockitoSu
 
     val topLevelDataList = new DataList()
     topLevelDataList.add(COURSE_A.id)
+    val topLevelResponse = TopLevelResponse(topLevelDataList, ResponsePagination.empty)
     val fetcherResponse = Response(
-      topLevelIds = Map(request.topLevelRequests.head -> topLevelDataList),
+      topLevelResponses = Map(request.topLevelRequests.head -> topLevelResponse),
       data = Map(COURSES_RESOURCE_ID -> Map(
         COURSE_A.id -> COURSE_A.data())))
 
@@ -132,9 +135,9 @@ class EngineImplTest extends AssertionsForJUnit with ScalaFutures with MockitoSu
 
     val result = engine.execute(request).futureValue
 
-    assert(result.topLevelIds.contains(request.topLevelRequests.head))
-    assert(1 === result.topLevelIds(request.topLevelRequests.head).size())
-    assert(COURSE_A.id === result.topLevelIds(request.topLevelRequests.head).get(0))
+    assert(result.topLevelResponses.contains(request.topLevelRequests.head))
+    assert(1 === result.topLevelResponses(request.topLevelRequests.head).ids.size())
+    assert(COURSE_A.id === result.topLevelResponses(request.topLevelRequests.head).ids.get(0))
     assert(result.data.contains(COURSES_RESOURCE_ID))
     val coursesData = result.data(COURSES_RESOURCE_ID)
     assert(1 === coursesData.size)
@@ -162,8 +165,9 @@ class EngineImplTest extends AssertionsForJUnit with ScalaFutures with MockitoSu
 
     val topLevelDataList = new DataList()
     topLevelDataList.add(INSTRUCTOR_1.id)
+    val topLevelResponse = TopLevelResponse(topLevelDataList, ResponsePagination.empty)
     val fetcherResponse = Response(
-      topLevelIds = Map(request.topLevelRequests.head -> topLevelDataList),
+      topLevelResponses = Map(request.topLevelRequests.head -> topLevelResponse),
       data = Map(INSTRUCTORS_RESOURCE_ID -> Map(
         INSTRUCTOR_1.id -> INSTRUCTOR_1.data())))
 
@@ -171,9 +175,9 @@ class EngineImplTest extends AssertionsForJUnit with ScalaFutures with MockitoSu
 
     val result = engine.execute(request).futureValue
 
-    assert(result.topLevelIds.contains(request.topLevelRequests.head))
-    assert(1 === result.topLevelIds(request.topLevelRequests.head).size())
-    assert(INSTRUCTOR_1.id === result.topLevelIds(request.topLevelRequests.head).get(0))
+    assert(result.topLevelResponses.contains(request.topLevelRequests.head))
+    assert(1 === result.topLevelResponses(request.topLevelRequests.head).ids.size())
+    assert(INSTRUCTOR_1.id === result.topLevelResponses(request.topLevelRequests.head).ids.get(0))
     assert(result.data.contains(INSTRUCTORS_RESOURCE_ID))
     val instructorsData = result.data(INSTRUCTORS_RESOURCE_ID)
     assert(1 === instructorsData.size)
@@ -216,13 +220,15 @@ class EngineImplTest extends AssertionsForJUnit with ScalaFutures with MockitoSu
 
     val topLevelDataListCourse = new DataList(List(COURSE_A.id).asJava)
     val fetcherResponseCourse = Response(
-      topLevelIds = Map(request.topLevelRequests.head -> topLevelDataListCourse),
+      topLevelResponses = Map(request.topLevelRequests.head ->
+        TopLevelResponse(topLevelDataListCourse, ResponsePagination.empty)),
       data = Map(COURSES_RESOURCE_ID -> Map(
         COURSE_A.id -> COURSE_A.data())))
     val topLevelDataListInstructor = new DataList()
     topLevelDataListInstructor.add(INSTRUCTOR_1.id)
     val fetcherResponseInstructors = Response(
-      topLevelIds = Map(request.topLevelRequests.tail.head -> topLevelDataListInstructor),
+      topLevelResponses = Map(request.topLevelRequests.tail.head ->
+        TopLevelResponse(topLevelDataListInstructor, ResponsePagination.empty)),
       data = Map(INSTRUCTORS_RESOURCE_ID -> Map(
         INSTRUCTOR_1.id -> INSTRUCTOR_1.data())))
 
@@ -233,9 +239,9 @@ class EngineImplTest extends AssertionsForJUnit with ScalaFutures with MockitoSu
 
     val result = engine.execute(request).futureValue
 
-    assert(result.topLevelIds.contains(request.topLevelRequests.head))
-    assert(1 === result.topLevelIds(request.topLevelRequests.head).size())
-    assert(COURSE_A.id === result.topLevelIds(request.topLevelRequests.head).get(0))
+    assert(result.topLevelResponses.contains(request.topLevelRequests.head))
+    assert(1 === result.topLevelResponses(request.topLevelRequests.head).ids.size())
+    assert(COURSE_A.id === result.topLevelResponses(request.topLevelRequests.head).ids.get(0))
     assert(result.data.contains(COURSES_RESOURCE_ID))
     val coursesData = result.data(COURSES_RESOURCE_ID)
     assert(1 === coursesData.size)
@@ -245,9 +251,9 @@ class EngineImplTest extends AssertionsForJUnit with ScalaFutures with MockitoSu
     assert(COURSE_A.name === courseAResponse.getString("name"))
     assert(COURSE_A.slug === courseAResponse.getString("slug"))
 
-    assert(result.topLevelIds.contains(request.topLevelRequests.head))
-    assert(1 === result.topLevelIds(request.topLevelRequests.head).size())
-    assert(INSTRUCTOR_1.id === result.topLevelIds(request.topLevelRequests.tail.head).get(0))
+    assert(result.topLevelResponses.contains(request.topLevelRequests.head))
+    assert(1 === result.topLevelResponses(request.topLevelRequests.head).ids.size())
+    assert(INSTRUCTOR_1.id === result.topLevelResponses(request.topLevelRequests.tail.head).ids.get(0))
     assert(result.data.contains(INSTRUCTORS_RESOURCE_ID))
     val instructorsData = result.data(INSTRUCTORS_RESOURCE_ID)
     assert(1 === instructorsData.size)
@@ -279,7 +285,8 @@ class EngineImplTest extends AssertionsForJUnit with ScalaFutures with MockitoSu
 
     val topLevelDataList = new DataList(List(new Integer(PARTNER_123.id)).asJava)
     val fetcherResponse = Response(
-      topLevelIds = Map(request.topLevelRequests.head -> topLevelDataList),
+      topLevelResponses = Map(request.topLevelRequests.head ->
+        TopLevelResponse(topLevelDataList, ResponsePagination.empty)),
       data = Map(PARTNERS_RESOURCE_ID -> Map(
         new Integer(PARTNER_123.id) -> PARTNER_123.data())))
     when(fetcherApi.data(argThat(MatchesResourceType(PARTNERS_RESOURCE_ID)))).thenReturn(
@@ -287,9 +294,9 @@ class EngineImplTest extends AssertionsForJUnit with ScalaFutures with MockitoSu
 
     val result = engine.execute(request).futureValue
 
-    assert(result.topLevelIds.contains(request.topLevelRequests.head))
-    assert(1 === result.topLevelIds(request.topLevelRequests.head).size())
-    assert(PARTNER_123.id === result.topLevelIds(request.topLevelRequests.head).get(0))
+    assert(result.topLevelResponses.contains(request.topLevelRequests.head))
+    assert(1 === result.topLevelResponses(request.topLevelRequests.head).ids.size())
+    assert(PARTNER_123.id === result.topLevelResponses(request.topLevelRequests.head).ids.get(0))
     assert(result.data.contains(PARTNERS_RESOURCE_ID))
     val partnersData = result.data(PARTNERS_RESOURCE_ID)
     assert(1 === partnersData.size)
@@ -330,7 +337,8 @@ class EngineImplTest extends AssertionsForJUnit with ScalaFutures with MockitoSu
                         RequestField("title", None, Set.empty, List.empty))))))))))))))))
 
     val fetcherResponseCourse = Response(
-      topLevelIds = Map(request.topLevelRequests.head -> new DataList(List(COURSE_A.id).asJava)),
+      topLevelResponses = Map(request.topLevelRequests.head ->
+        TopLevelResponse(new DataList(List(COURSE_A.id).asJava), ResponsePagination.empty)),
       data = Map(COURSES_RESOURCE_ID -> Map(COURSE_A.id -> COURSE_A.data())))
 
     val expectedInstructorRequest = TopLevelRequest(
@@ -341,7 +349,8 @@ class EngineImplTest extends AssertionsForJUnit with ScalaFutures with MockitoSu
         args = Set("ids" -> JsString("instructor1Id")),
         selections = request.topLevelRequests.head.selection.selections.head.selections.head.selections.drop(3).head.selections))
     val fetcherResponseInstructors = Response(
-      topLevelIds = Map(expectedInstructorRequest -> new DataList(List(INSTRUCTOR_1.id).asJava)),
+      topLevelResponses = Map(expectedInstructorRequest ->
+        TopLevelResponse(new DataList(List(INSTRUCTOR_1.id).asJava), ResponsePagination.empty)),
       data = Map(INSTRUCTORS_RESOURCE_ID -> Map(INSTRUCTOR_1.id -> INSTRUCTOR_1.data())))
 
     when(fetcherApi.data(argThat(MatchesResourceType(COURSES_RESOURCE_ID)))).thenReturn(
@@ -351,10 +360,10 @@ class EngineImplTest extends AssertionsForJUnit with ScalaFutures with MockitoSu
 
     val result = engine.execute(request).futureValue
 
-    assert(1 === result.topLevelIds.size, s"Result: $result")
-    assert(result.topLevelIds.contains(request.topLevelRequests.head))
-    assert(1 === result.topLevelIds(request.topLevelRequests.head).size())
-    assert(COURSE_A.id === result.topLevelIds(request.topLevelRequests.head).get(0))
+    assert(1 === result.topLevelResponses.size, s"Result: $result")
+    assert(result.topLevelResponses.contains(request.topLevelRequests.head))
+    assert(1 === result.topLevelResponses(request.topLevelRequests.head).ids.size())
+    assert(COURSE_A.id === result.topLevelResponses(request.topLevelRequests.head).ids.get(0))
 
     assert(result.data.contains(COURSES_RESOURCE_ID))
     val coursesData = result.data(COURSES_RESOURCE_ID)
@@ -410,7 +419,10 @@ class EngineImplTest extends AssertionsForJUnit with ScalaFutures with MockitoSu
                   instructorField)))))))))
 
     val fetcherResponseCourse = Response(
-      topLevelIds = Map(request.topLevelRequests.head -> new DataList(List(COURSE_A.id, COURSE_B.id).asJava)),
+      topLevelResponses = Map(request.topLevelRequests.head ->
+        TopLevelResponse(
+          new DataList(List(COURSE_A.id, COURSE_B.id).asJava),
+          ResponsePagination.empty)),
       data = Map(COURSES_RESOURCE_ID -> Map(COURSE_A.id -> COURSE_A.data(), COURSE_B.id -> COURSE_B.data())))
 
     val expectedInstructorRequest = TopLevelRequest(
@@ -421,7 +433,10 @@ class EngineImplTest extends AssertionsForJUnit with ScalaFutures with MockitoSu
         args = Set("ids" -> JsString(s"${INSTRUCTOR_1.id},${INSTRUCTOR_2.id}")),
         selections = instructorField.selections))
     val fetcherResponseInstructors = Response(
-      topLevelIds = Map(expectedInstructorRequest -> new DataList(List(INSTRUCTOR_1.id, INSTRUCTOR_2.id).asJava)),
+      topLevelResponses = Map(expectedInstructorRequest ->
+        TopLevelResponse(
+          new DataList(List(INSTRUCTOR_1.id, INSTRUCTOR_2.id).asJava),
+          ResponsePagination.empty)),
       data = Map(INSTRUCTORS_RESOURCE_ID -> Map(
         INSTRUCTOR_1.id -> INSTRUCTOR_1.data(), INSTRUCTOR_2.id -> INSTRUCTOR_2.data())))
 
@@ -433,7 +448,10 @@ class EngineImplTest extends AssertionsForJUnit with ScalaFutures with MockitoSu
         args = Set("ids" -> JsString(s"${PARTNER_123.id}")),
         selections = partnerField.selections))
     val fetcherResponsePartners = Response(
-      topLevelIds = Map(expectedPartnersRequest -> new DataList(List(new Integer(PARTNER_123.id)).asJava)),
+      topLevelResponses = Map(expectedPartnersRequest ->
+        TopLevelResponse(
+          new DataList(List(new Integer(PARTNER_123.id)).asJava),
+          ResponsePagination.empty)),
       data = Map(PARTNERS_RESOURCE_ID -> Map(new Integer(PARTNER_123.id) -> PARTNER_123.data())))
 
     when(fetcherApi.data(argThat(MatchesResourceType(COURSES_RESOURCE_ID)))).thenReturn(
@@ -445,11 +463,11 @@ class EngineImplTest extends AssertionsForJUnit with ScalaFutures with MockitoSu
 
     val result = engine.execute(request).futureValue
 
-    assert(1 === result.topLevelIds.size, s"Result: $result")
-    assert(result.topLevelIds.contains(request.topLevelRequests.head))
-    assert(2 === result.topLevelIds(request.topLevelRequests.head).size())
-    assert(COURSE_A.id === result.topLevelIds(request.topLevelRequests.head).get(0))
-    assert(COURSE_B.id === result.topLevelIds(request.topLevelRequests.head).get(1))
+    assert(1 === result.topLevelResponses.size, s"Result: $result")
+    assert(result.topLevelResponses.contains(request.topLevelRequests.head))
+    assert(2 === result.topLevelResponses(request.topLevelRequests.head).ids.size())
+    assert(COURSE_A.id === result.topLevelResponses(request.topLevelRequests.head).ids.get(0))
+    assert(COURSE_B.id === result.topLevelResponses(request.topLevelRequests.head).ids.get(1))
 
     assert(result.data.contains(COURSES_RESOURCE_ID))
     val coursesData = result.data(COURSES_RESOURCE_ID)
@@ -523,7 +541,8 @@ class EngineImplTest extends AssertionsForJUnit with ScalaFutures with MockitoSu
                       RequestField("longitude", None, Set.empty, List.empty))))))))))))))
 
     val fetcherResponseCourse = Response(
-      topLevelIds = Map(request.topLevelRequests.head -> new DataList(List(COURSE_A.id).asJava)),
+      topLevelResponses = Map(request.topLevelRequests.head ->
+        TopLevelResponse(new DataList(List(COURSE_A.id).asJava), ResponsePagination.empty)),
       data = Map(COURSES_RESOURCE_ID -> Map(COURSE_A.id -> COURSE_A.data())))
 
     val expectedPartnersRequest = TopLevelRequest(
@@ -539,7 +558,8 @@ class EngineImplTest extends AssertionsForJUnit with ScalaFutures with MockitoSu
           .drop(3)
           .head.selections))
     val fetcherResponsePartners = Response(
-      topLevelIds = Map(expectedPartnersRequest -> new DataList(List(new Integer(PARTNER_123.id)).asJava)),
+      topLevelResponses = Map(expectedPartnersRequest ->
+        TopLevelResponse(new DataList(List(new Integer(PARTNER_123.id)).asJava), ResponsePagination.empty)),
       data = Map(PARTNERS_RESOURCE_ID -> Map(new Integer(PARTNER_123.id) -> PARTNER_123.data())))
 
     when(fetcherApi.data(argThat(MatchesResourceType(COURSES_RESOURCE_ID)))).thenReturn(
@@ -549,10 +569,10 @@ class EngineImplTest extends AssertionsForJUnit with ScalaFutures with MockitoSu
 
     val result = engine.execute(request).futureValue
 
-    assert(1 === result.topLevelIds.size, s"Result: $result")
-    assert(result.topLevelIds.contains(request.topLevelRequests.head))
-    assert(1 === result.topLevelIds(request.topLevelRequests.head).size())
-    assert(COURSE_A.id === result.topLevelIds(request.topLevelRequests.head).get(0))
+    assert(1 === result.topLevelResponses.size, s"Result: $result")
+    assert(result.topLevelResponses.contains(request.topLevelRequests.head))
+    assert(1 === result.topLevelResponses(request.topLevelRequests.head).ids.size())
+    assert(COURSE_A.id === result.topLevelResponses(request.topLevelRequests.head).ids.get(0))
 
     assert(result.data.contains(COURSES_RESOURCE_ID))
     val coursesData = result.data(COURSES_RESOURCE_ID)
@@ -612,7 +632,8 @@ class EngineImplTest extends AssertionsForJUnit with ScalaFutures with MockitoSu
                   instructorField)))))))))
 
     val fetcherResponseCourse = Response(
-      topLevelIds = Map(request.topLevelRequests.head -> new DataList(List(COURSE_A.id, COURSE_B.id).asJava)),
+      topLevelResponses = Map(request.topLevelRequests.head ->
+        TopLevelResponse(new DataList(List(COURSE_A.id, COURSE_B.id).asJava), ResponsePagination.empty)),
       data = Map(COURSES_RESOURCE_ID -> Map(COURSE_A.id -> COURSE_A.data(), COURSE_B.id -> COURSE_B.data())))
 
     val expectedInstructorRequest = TopLevelRequest(
@@ -623,7 +644,8 @@ class EngineImplTest extends AssertionsForJUnit with ScalaFutures with MockitoSu
         args = Set("ids" -> JsString(s"${INSTRUCTOR_1.id},${INSTRUCTOR_2.id}")),
         selections = instructorField.selections))
     val fetcherResponseInstructors = Response(
-      topLevelIds = Map(expectedInstructorRequest -> new DataList(List(INSTRUCTOR_1.id, INSTRUCTOR_2.id).asJava)),
+      topLevelResponses = Map(expectedInstructorRequest ->
+        TopLevelResponse(new DataList(List(INSTRUCTOR_1.id, INSTRUCTOR_2.id).asJava), ResponsePagination.empty)),
       data = Map(INSTRUCTORS_RESOURCE_ID -> Map(
         INSTRUCTOR_1.id -> INSTRUCTOR_1.data(), INSTRUCTOR_2.id -> INSTRUCTOR_2.data())))
 
@@ -635,7 +657,8 @@ class EngineImplTest extends AssertionsForJUnit with ScalaFutures with MockitoSu
         args = Set("ids" -> JsString(s"${PARTNER_123.id}")),
         selections = partnerField.selections))
     val fetcherResponsePartners = Response(
-      topLevelIds = Map(expectedPartnersRequest -> new DataList(List(new Integer(PARTNER_123.id)).asJava)),
+      topLevelResponses = Map(expectedPartnersRequest ->
+        TopLevelResponse(new DataList(List(new Integer(PARTNER_123.id)).asJava), ResponsePagination.empty)),
       data = Map(PARTNERS_RESOURCE_ID -> Map(new Integer(PARTNER_123.id) -> PARTNER_123.data())))
 
     when(fetcherApi.data(argThat(MatchesResourceType(COURSES_RESOURCE_ID)))).thenReturn(
@@ -647,11 +670,11 @@ class EngineImplTest extends AssertionsForJUnit with ScalaFutures with MockitoSu
 
     val result = engine.execute(request).futureValue
 
-    assert(1 === result.topLevelIds.size, s"Result: $result")
-    assert(result.topLevelIds.contains(request.topLevelRequests.head))
-    assert(2 === result.topLevelIds(request.topLevelRequests.head).size())
-    assert(COURSE_A.id === result.topLevelIds(request.topLevelRequests.head).get(0))
-    assert(COURSE_B.id === result.topLevelIds(request.topLevelRequests.head).get(1))
+    assert(1 === result.topLevelResponses.size, s"Result: $result")
+    assert(result.topLevelResponses.contains(request.topLevelRequests.head))
+    assert(2 === result.topLevelResponses(request.topLevelRequests.head).ids.size())
+    assert(COURSE_A.id === result.topLevelResponses(request.topLevelRequests.head).ids.get(0))
+    assert(COURSE_B.id === result.topLevelResponses(request.topLevelRequests.head).ids.get(1))
 
     assert(result.data.contains(COURSES_RESOURCE_ID))
     val coursesData = result.data(COURSES_RESOURCE_ID)


### PR DESCRIPTION
Adds a pagination model to the TopLevelResponse, allowing us to pass pagination data from a response throughout the parsing and serialization flows.

PTAL @saeta 