### PR TITLE
upgrade naptime to play 2.5

### DIFF
--- a/naptime/src/main/scala/org/coursera/naptime/errors.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/errors.scala
@@ -18,9 +18,11 @@ package org.coursera.naptime
 
 import java.nio.charset.StandardCharsets
 
+import akka.util.ByteString
 import org.coursera.common.jsonformat.JsonFormats
 import org.coursera.common.jsonformat.JsonFormats.Implicits.optionalReads
 import play.api.http.HeaderNames
+import play.api.http.HttpEntity
 import play.api.http.MimeTypes
 import play.api.libs.iteratee.Enumerator
 import play.api.libs.json.JsValue
@@ -42,10 +44,10 @@ case class NaptimeActionException(
 
   def result: Result = {
     val bodyJson = Json.toJson(NaptimeActionException.Body(errorCode, message, details))
-    val bodyBytes = Json.stringify(bodyJson).getBytes(StandardCharsets.UTF_8)
+    val bodyString = Json.stringify(bodyJson)
     Result(
       ResponseHeader(httpCode, Map(HeaderNames.CONTENT_TYPE -> MimeTypes.JSON)),
-      Enumerator(bodyBytes))
+      HttpEntity.Strict(ByteString(bodyString), Some(MimeTypes.JSON)))
   }
 
 }

--- a/naptime/src/test/scala/org/coursera/naptime/actions/util/Validators.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/actions/util/Validators.scala
@@ -18,6 +18,7 @@ package org.coursera.naptime.actions.util
 
 import org.scalatest.junit.AssertionsForJUnit
 import play.api.http.HeaderNames
+import play.api.http.HttpEntity
 import play.api.http.Status
 import play.api.libs.json.JsArray
 import play.api.libs.json.JsObject
@@ -93,9 +94,10 @@ object Validators extends AssertionsForJUnit {
    */
   def hasBody(result: Result): Boolean = {
     val headers = result.header.headers
-    headers.contains(HeaderNames.CONTENT_LENGTH) ||
-      headers.contains(HeaderNames.CONTENT_TYPE) ||
-      headers.contains(HeaderNames.CONTENT_ENCODING)
+    result.body match {
+      case HttpEntity.Strict(data, contentType) => contentType.isDefined
+      case _ => false // doesn't support matching other types right now
+    }
   }
 
   /**
@@ -104,7 +106,7 @@ object Validators extends AssertionsForJUnit {
    * @return body as a JsValue
    */
   def assertBodyIsJson(result: Result): JsValue = {
-    val contentType = result.header.headers.get(HeaderNames.CONTENT_TYPE)
+    val contentType = result.body.contentType
     assert(contentType.isDefined)
     assert(contentType.get.startsWith(MimeTypes.JSON),
       s"Content-Type must be json. Found ${contentType.get}")

--- a/naptime/src/test/scala/org/coursera/naptime/router2/NaptimePlayRouterTest.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/router2/NaptimePlayRouterTest.scala
@@ -16,6 +16,7 @@
 
 package org.coursera.naptime.router2
 
+import akka.util.ByteString
 import com.google.inject.Injector
 import org.coursera.naptime.resources.RootResource
 import org.coursera.naptime.schema.Handler
@@ -28,7 +29,7 @@ import org.mockito.Mockito.when
 import org.mockito.Matchers.any
 import org.scalatest.junit.AssertionsForJUnit
 import org.scalatest.mock.MockitoSugar
-import play.api.libs.iteratee.Iteratee
+import play.api.libs.streams.Accumulator
 import play.api.mvc.EssentialAction
 import play.api.mvc.RequestHeader
 import play.api.mvc.RequestTaggingHandler
@@ -39,7 +40,7 @@ class NaptimePlayRouterTest extends AssertionsForJUnit with MockitoSugar {
   object FakeHandler extends /* RouteAction */ EssentialAction with RequestTaggingHandler {
     override def tagRequest(request: RequestHeader): RequestHeader = request
 
-    override def apply(v1: RequestHeader): Iteratee[Array[Byte], Result] = ???
+    override def apply(v1: RequestHeader): Accumulator[ByteString, Result] = ???
   }
 
   val resourceSchema = Resource(

--- a/project/NaptimeBuild.scala
+++ b/project/NaptimeBuild.scala
@@ -22,8 +22,8 @@ import de.heikoseeberger.sbtheader.license.Apache2_0
 
 object NaptimeBuild extends Build with NamedDependencies with PluginVersionProvider {
 
-  def playVersion = "2.4.4" // Play version is defined here, and in project/plugins.sbt
-  def akkaVersion = "2.3.13" // Akka version must match the one Play is built with.
+  def playVersion = "2.5.8" // Play version is defined here, and in project/plugins.sbt
+  def akkaVersion = "2.4.10" // Akka version must match the one Play is built with.
   def courierVersion = "2.0.2"
 
   lazy val root = project

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.4.4")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.8")
 
 // Courier binding generator plugin
 addSbtPlugin("org.coursera.courier" % "courier-sbt-plugin" % "2.0.2")


### PR DESCRIPTION
I want to build a version of play 2.5 of naptime, otherwise, i can't boot service in infra-services.

Reviewers: saeta

CC:

Test Plan: unit test passing, will test it in infra-services

Auditors: