### PR TITLE
Add schema inference override registry.

### DIFF
--- a/examples/src/main/scala/ResourceModule.scala
+++ b/examples/src/main/scala/ResourceModule.scala
@@ -10,7 +10,6 @@ import org.coursera.naptime.ari.graphql.GraphqlSchemaProvider
 import resources.UserStore
 import resources.UserStoreImpl
 import resources.UsersResource
-import org.coursera.naptime.model.Keyed
 import resources.CoursesResource
 import resources.InstructorsResource
 import resources.PartnersResource

--- a/examples/src/main/scala/resources/CoursesResource.scala
+++ b/examples/src/main/scala/resources/CoursesResource.scala
@@ -6,7 +6,6 @@ import javax.inject.Singleton
 import org.coursera.example.Course
 import org.coursera.naptime.Fields
 import org.coursera.naptime.Ok
-import org.coursera.naptime.ResourceName
 import org.coursera.naptime.model.Keyed
 import org.coursera.naptime.resources.CourierCollectionResource
 import stores.CourseStore

--- a/naptime-testing/src/test/scala/org/coursera/naptime/NaptimeModuleTest.scala
+++ b/naptime-testing/src/test/scala/org/coursera/naptime/NaptimeModuleTest.scala
@@ -1,0 +1,76 @@
+package org.coursera.naptime
+
+import java.util.Date
+import javax.inject.Inject
+
+import com.google.inject.Guice
+import com.google.inject.Stage
+import com.linkedin.data.schema.DataSchema
+import com.linkedin.data.schema.DataSchemaUtil
+import com.linkedin.data.schema.PrimitiveDataSchema
+import com.linkedin.data.schema.RecordDataSchema
+import org.coursera.naptime.model.KeyFormat
+import org.coursera.naptime.resources.TopLevelCollectionResource
+import org.coursera.naptime.router2.NaptimeRoutes
+import org.junit.Test
+import org.scalatest.junit.AssertionsForJUnit
+import play.api.libs.json.Json
+import play.api.libs.json.OFormat
+
+object NaptimeModuleTest {
+  case class User(name: String, createdAt: Date)
+  object User {
+    implicit val oFormat: OFormat[User] = Json.format[User]
+  }
+  class MyResource extends TopLevelCollectionResource[String, User] {
+    override implicit def resourceFormat: OFormat[User] = User.oFormat
+    override def keyFormat: KeyFormat[KeyType] = KeyFormat.stringKeyFormat
+    override def resourceName: String = "myResource"
+    implicit val fields = Fields
+
+    def get(id: String) = Nap.get(ctx => ???)
+  }
+  object MyFakeModule extends NaptimeModule {
+    override def configure(): Unit = {
+      bindResource[MyResource]
+      bindSchemaType[Date](DataSchemaUtil.dataSchemaTypeToPrimitiveDataSchema(DataSchema.Type.LONG))
+    }
+  }
+
+  class OverrideTypesHelper @Inject() (val schemaOverrideTypes: NaptimeModule.SchemaTypeOverrides)
+}
+
+class NaptimeModuleTest extends AssertionsForJUnit {
+  import NaptimeModuleTest._
+
+  /**
+   * Check to ensure that configured type schema overrides are appropriately set.
+   */
+  @Test
+  def checkInferredOverrides(): Unit = {
+    val injector = Guice.createInjector(Stage.DEVELOPMENT, MyFakeModule, NaptimeModule)
+    val overrides = injector.getInstance(classOf[OverrideTypesHelper])
+    assert(overrides.schemaOverrideTypes.size === 1)
+    assert(overrides.schemaOverrideTypes.contains("java.util.Date"))
+  }
+
+  @Test
+  def checkComputedOverrides(): Unit = {
+    val injector = Guice.createInjector(Stage.DEVELOPMENT, MyFakeModule, NaptimeModule)
+    val overrides = injector.getInstance(classOf[OverrideTypesHelper])
+    val routes = injector.getInstance(classOf[NaptimeRoutes])
+    assert(1 === routes.routerBuilders.size)
+    val routerBuilder = routes.routerBuilders.head
+    val inferredSchemaKeyed = routerBuilder.types.find(
+      _.key == "org.coursera.naptime.NaptimeModuleTest.User").get
+    assert(inferredSchemaKeyed.value.isInstanceOf[RecordDataSchema])
+    val userSchema = inferredSchemaKeyed.value.asInstanceOf[RecordDataSchema]
+    assert(2 === userSchema.getFields.size())
+    val initialCreatedAtSchema = userSchema.getField("createdAt").getType.getDereferencedDataSchema
+    assert(initialCreatedAtSchema.isInstanceOf[RecordDataSchema])
+    assert(initialCreatedAtSchema.asInstanceOf[RecordDataSchema].getDoc.contains("Unable to infer schema"))
+    SchemaUtils.fixupInferredSchemas(userSchema, overrides.schemaOverrideTypes)
+    val fixedCreatedAtSchema = userSchema.getField("createdAt").getType.getDereferencedDataSchema
+    assert(fixedCreatedAtSchema.isInstanceOf[PrimitiveDataSchema])
+  }
+}

--- a/naptime/src/main/scala/org/coursera/naptime/router2/NaptimePlayRouter.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/router2/NaptimePlayRouter.scala
@@ -20,6 +20,7 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 import com.google.inject.Injector
+import com.linkedin.data.schema.DataSchema
 import com.netflix.governator.annotations.WarmUp
 import com.typesafe.scalalogging.StrictLogging
 import org.coursera.naptime.schema.HandlerKind
@@ -35,7 +36,8 @@ import scala.collection.immutable
 
 @Singleton
 private[naptime] case class NaptimeRoutes @Inject() (
-    injector: Injector, routerBuilders: immutable.Set[ResourceRouterBuilder]) {
+    injector: Injector,
+    routerBuilders: immutable.Set[ResourceRouterBuilder]) {
   /**
    * Helper function to filter out those resource router builders that don't provide schemas.
    */


### PR DESCRIPTION
When computing schemas for resources, if the types are neither
courier-based nor primitives, a reflection-based schema-inference
algorithm is run. This works fine for case-classes, but fails miserably
on some of their fields (e.g. if a field is a java.util.Date). This
results in relatively useless schemas (e.g. for GraphQL).

In this commit, I have added a Guice Multi-binding/MapBinding-based
implementation to register these overrides. Additionally, I've added a
utility that can fix up these inferred schemas at runtime based on the
configured overrides. Finally, I've added a test that verifies the
correctness of all of the above.