### PR TITLE
Set `gets` as nullable to handle 404s

### DIFF
--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/NaptimePaginatedResourceField.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/NaptimePaginatedResourceField.scala
@@ -59,7 +59,7 @@ object NaptimePaginatedResourceField {
       resourceName: String,
       fieldName: String): Context[SangriaGraphQlContext, ParentContext] => Value[SangriaGraphQlContext, Any] = {
     (context: Context[SangriaGraphQlContext, ParentContext]) => {
-      // TODO(bryan): Figure out pagination here
+
       val parsedResourceName = ResourceName.parse(resourceName).getOrElse {
         throw new SchemaExecutionException(s"Cannot parse resource name from $resourceName")
       }
@@ -97,7 +97,5 @@ object NaptimePaginatedResourceField {
   private[this] def formatPaginatedResourceName(resource: Resource): String = {
     s"${resource.name.capitalize}V${resource.version.getOrElse(0)}Connection"
   }
-
-  case class ParentContext(parentContext: Context[SangriaGraphQlContext, DataMap])
 
 }

--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/NaptimePaginationField.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/NaptimePaginationField.scala
@@ -1,12 +1,10 @@
 package org.coursera.naptime.ari.graphql.schema
 
-import com.linkedin.data.DataMap
 import com.typesafe.scalalogging.StrictLogging
 import org.coursera.naptime.PaginationConfiguration
 import org.coursera.naptime.ResourceName
 import org.coursera.naptime.ResponsePagination
 import org.coursera.naptime.ari.graphql.SangriaGraphQlContext
-import org.coursera.naptime.ari.graphql.schema.NaptimePaginatedResourceField.ParentContext
 import sangria.schema.Argument
 import sangria.schema.Context
 import sangria.schema.Field

--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/exceptions.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/exceptions.scala
@@ -1,6 +1,9 @@
 package org.coursera.naptime.ari.graphql.schema
 
+import sangria.execution.UserFacingError
+
 case class SchemaGenerationException(msg: String) extends Exception(msg)
 case class SchemaExecutionException(msg: String) extends Exception(msg)
 
-case class ResponseFormatException(msg: String) extends Exception(msg)
+case class ResponseFormatException(msg: String) extends Exception(msg) with UserFacingError
+case class NotFoundException(msg: String) extends Exception(msg) with UserFacingError

--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/models.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/models.scala
@@ -1,0 +1,7 @@
+package org.coursera.naptime.ari.graphql.schema
+
+import com.linkedin.data.DataMap
+import org.coursera.naptime.ari.graphql.SangriaGraphQlContext
+import sangria.schema.Context
+
+case class ParentContext(parentContext: Context[SangriaGraphQlContext, DataMap])

--- a/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/schema/NaptimePaginationFieldTest.scala
+++ b/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/schema/NaptimePaginationFieldTest.scala
@@ -25,7 +25,6 @@ import org.coursera.naptime.ari.Response
 import org.coursera.naptime.ari.TopLevelRequest
 import org.coursera.naptime.ari.TopLevelResponse
 import org.coursera.naptime.ari.graphql.SangriaGraphQlContext
-import org.coursera.naptime.ari.graphql.schema.NaptimePaginatedResourceField.ParentContext
 import org.junit.Test
 import org.scalatest.junit.AssertionsForJUnit
 import sangria.schema.Args

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.4.0"
+version in ThisBuild := "0.4.1"


### PR DESCRIPTION
Also pulls ParentContext out to its own file just to make things nicer, and creates a new exception class to use.

PTAL @saeta 