### PR TITLE
Adds a naive approach to calculating complexity

### DIFF
--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/GraphQLController.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/GraphQLController.scala
@@ -26,10 +26,12 @@ import play.api.libs.json.JsObject
 import play.api.libs.json.JsString
 import play.api.libs.json.Json
 import play.api.mvc._
+import sangria.ast.Document
 import sangria.execution.ErrorWithResolver
 import sangria.execution.Executor
 import sangria.execution.HandledException
 import sangria.execution.QueryAnalysisError
+import sangria.execution.QueryReducer
 import sangria.parser.QueryParser
 import sangria.renderer.SchemaRenderer
 import sangria.parser.SyntaxError
@@ -82,6 +84,8 @@ class GraphQLController @Inject() (
       HandledException(e.getMessage)
   }
 
+  val MAX_COMPLEXITY = 10000 // TODO(bryan): pull this out to config?
+
   private def executeQuery(
       query: String,
       requestHeader: RequestHeader,
@@ -91,30 +95,38 @@ class GraphQLController @Inject() (
     QueryParser.parse(query) match {
       case Success(queryAst) =>
         SangriaGraphQlParser.parse(query, variables, requestHeader).map { request =>
-          val fetcherExecution: Future[Option[Response]] =
-            if (query.contains("IntrospectionQuery")) {
-              Future.successful(None)
-            } else {
-              engine.execute(request).map(Some(_))
-            }
-          fetcherExecution.flatMap { responseOpt =>
-            val response = responseOpt.getOrElse(Response.empty)
-            val context = SangriaGraphQlContext(response)
-            Executor.execute(
-              graphqlSchemaProvider.schema,
-              queryAst,
-              context,
-              variables = variables,
-              exceptionHandler = exceptionHandler)
-              .map(Ok(_))
 
-          }.recover {
-            case error: QueryAnalysisError =>
-              BadRequest(Json.obj("error" -> error.resolveError))
-            case error: ErrorWithResolver =>
-              InternalServerError(Json.obj("error" -> error.resolveError))
-            case error: Exception =>
-              InternalServerError(Json.obj("error" -> error.getMessage))
+          val complexity = computeComplexity(queryAst, variables)
+          if (complexity > MAX_COMPLEXITY) {
+            Future.successful(BadRequest(Json.obj(
+              "error" -> "Query is too complex.",
+              "complexity" -> complexity)))
+          } else {
+            val fetcherExecution: Future[Option[Response]] =
+              if (query.contains("IntrospectionQuery")) {
+                Future.successful(None)
+              } else {
+                engine.execute(request).map(Some(_))
+              }
+            fetcherExecution.flatMap { responseOpt =>
+              val response = responseOpt.getOrElse(Response.empty)
+              val context = SangriaGraphQlContext(response)
+              Executor.execute(
+                graphqlSchemaProvider.schema,
+                queryAst,
+                context,
+                variables = variables,
+                exceptionHandler = exceptionHandler)
+                .map(Ok(_))
+
+            }.recover {
+              case error: QueryAnalysisError =>
+                BadRequest(Json.obj("error" -> error.resolveError))
+              case error: ErrorWithResolver =>
+                InternalServerError(Json.obj("error" -> error.resolveError))
+              case error: Exception =>
+                InternalServerError(Json.obj("error" -> error.getMessage))
+            }
           }
         }.getOrElse {
           Future.successful(
@@ -135,5 +147,22 @@ class GraphQLController @Inject() (
       case Failure(error) =>
         throw error
     }
+  }
+  private def computeComplexity(queryAst: Document, variables: JsObject): Double = {
+    // TODO(bryan): is there a way around this var?
+    var complexity = 0D
+    val complReducer = QueryReducer.measureComplexity[SangriaGraphQlContext] { (c, ctx) ⇒
+      complexity = c
+      ctx
+    }
+    Executor.execute(
+      graphqlSchemaProvider.schema,
+      queryAst,
+      SangriaGraphQlContext(Response.empty),
+      variables = variables,
+      exceptionHandler = exceptionHandler,
+      queryReducers = List(complReducer))
+
+    complexity
   }
 }

--- a/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/models.scala
+++ b/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/models.scala
@@ -25,6 +25,11 @@ object Models {
         kind = HandlerKind.MULTI_GET,
         name = "multiGet",
         parameters = List(Parameter(name = "ids", `type` = "List[Integer]", attributes = List.empty)),
+        attributes = List.empty),
+      Handler(
+        kind = HandlerKind.GET_ALL,
+        name = "getAll",
+        parameters = List.empty,
         attributes = List.empty)),
     className = "",
     attributes = List.empty)

--- a/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/schema/NaptimePaginatedResourceFieldTest.scala
+++ b/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/schema/NaptimePaginatedResourceFieldTest.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2016 Coursera Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.coursera.naptime.ari.graphql.schema
+
+import org.coursera.naptime.ari.Response
+import org.coursera.naptime.ari.graphql.Models
+import org.coursera.naptime.ari.graphql.SangriaGraphQlContext
+import org.junit.Test
+import org.mockito.Mockito.when
+import org.scalatest.junit.AssertionsForJUnit
+import org.scalatest.mock.MockitoSugar
+import sangria.schema.Args
+
+class NaptimePaginatedResourceFieldTest extends AssertionsForJUnit with MockitoSugar {
+
+  val fieldName = "relatedIds"
+  val resourceName = "courses.v1"
+  val context = SangriaGraphQlContext(Response.empty)
+
+  val schemaMetadata = mock[SchemaMetadata]
+  val resource = Models.courseResource
+  when(schemaMetadata.getResource(resourceName)).thenReturn(resource)
+  when(schemaMetadata.getSchema(resource)).thenReturn(Some(null))
+
+  @Test
+  def computeComplexity(): Unit = {
+    val field = NaptimePaginatedResourceField.build(schemaMetadata, resourceName, fieldName)
+
+    val limitTen = field.complexity.get.apply(context, Args(Map("limit" -> 10)), 1)
+    assert(limitTen === 1 * NaptimePaginatedResourceField.COMPLEXITY_COST * 1)
+
+    val limitFifty = field.complexity.get.apply(context, Args(Map("limit" -> 50)), 1)
+    assert(limitFifty === 5 * NaptimePaginatedResourceField.COMPLEXITY_COST * 1)
+
+    val limitZero = field.complexity.get.apply(context, Args(Map("limit" -> 0)), 1)
+    assert(limitZero === 1 * NaptimePaginatedResourceField.COMPLEXITY_COST * 1)
+
+    val childScoreFive = field.complexity.get.apply(context, Args(Map("limit" -> 1)), 5)
+    assert(childScoreFive === 1 * NaptimePaginatedResourceField.COMPLEXITY_COST * 5)
+
+  }
+
+}


### PR DESCRIPTION
Basic approach is that each field selection counts as 1, remote `get` requests count as 10, and paginated remote requests count as 10 * (limit / 10). I imagine we’ll be tweaking this _a lot_ as we go, but this will at least prevent against a lot of basic attacks possible on the graphql endpoint.

Thoughts, @saeta ? and maybe @jnwng and @lewisf have thoughts too