### PR TITLE
Add engine metrics collector to the Engine

### DIFF
--- a/examples/src/main/resources/logback.xml
+++ b/examples/src/main/resources/logback.xml
@@ -24,6 +24,7 @@
 
   <logger name="play" level="INFO" />
   <logger name="application" level="DEBUG" />
+  <logger name="org.coursera.naptime" level="DEBUG" />
 
   <!-- Off these ones as they are annoying, and anyway we manage configuration ourselves -->
   <logger name="com.avaje.ebean.config.PropertyMapLoader" level="OFF" />

--- a/examples/src/main/scala/ResourceModule.scala
+++ b/examples/src/main/scala/ResourceModule.scala
@@ -4,6 +4,8 @@ import org.coursera.naptime.ari.FetcherApi
 import org.coursera.naptime.ari.LocalSchemaProvider
 import org.coursera.naptime.ari.SchemaProvider
 import org.coursera.naptime.ari.engine.EngineImpl
+import org.coursera.naptime.ari.engine.EngineMetricsCollector
+import org.coursera.naptime.ari.engine.LoggingEngineMetricsCollector
 import org.coursera.naptime.ari.fetcher.LocalFetcher
 import org.coursera.naptime.ari.graphql.DefaultGraphqlSchemaProvider
 import org.coursera.naptime.ari.graphql.GraphqlSchemaProvider
@@ -24,6 +26,7 @@ class ResourceModule extends NaptimeModule {
     bind[UserStore].to[UserStoreImpl]
     bind[EngineApi].to[EngineImpl]
     bind[FetcherApi].to[LocalFetcher]
+    bind[EngineMetricsCollector].to[LoggingEngineMetricsCollector]
     bind[SchemaProvider].to[LocalSchemaProvider]
     bind[GraphqlSchemaProvider].to[DefaultGraphqlSchemaProvider]
   }

--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/GraphQLController.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/GraphQLController.scala
@@ -106,7 +106,8 @@ class GraphQLController @Inject() (
               context,
               variables = variables,
               exceptionHandler = exceptionHandler)
-              .map(Ok(_))
+              .map(Ok(_).withHeaders(
+                ("X-Naptime-Downstream-Requests", response.metrics.numRequests.toString)))
 
           }.recover {
             case error: QueryAnalysisError =>

--- a/naptime/src/main/scala/org/coursera/naptime/ari/engine/EngineImpl.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/ari/engine/EngineImpl.scala
@@ -29,6 +29,7 @@ import org.coursera.naptime.ari.FetcherApi
 import org.coursera.naptime.ari.Request
 import org.coursera.naptime.ari.RequestField
 import org.coursera.naptime.ari.Response
+import org.coursera.naptime.ari.ResponseMetrics
 import org.coursera.naptime.ari.SchemaProvider
 import org.coursera.naptime.ari.TopLevelRequest
 import play.api.libs.json.JsString
@@ -37,10 +38,12 @@ import play.api.mvc.RequestHeader
 import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
+import scala.concurrent.duration.FiniteDuration
 
 class EngineImpl @Inject() (
     schemaProvider: SchemaProvider,
-    fetcher: FetcherApi)
+    fetcher: FetcherApi,
+    metricsCollector: EngineMetricsCollector)
     (implicit executionContext: ExecutionContext) extends EngineApi with StrictLogging {
 
   private[this] def mergedTypeForResource(resourceName: ResourceName): Option[RecordDataSchema] = {
@@ -52,20 +55,34 @@ class EngineImpl @Inject() (
       executeTopLevelRequest(request.requestHeader, topLevelRequest)
     }
     val futureResponses = Future.sequence(responseFutures)
-    futureResponses.map { responses =>
+    val finalResponseFut = futureResponses.map { responses =>
       responses.foldLeft(Response.empty)(_ ++ _)
     }
+    finalResponseFut.map { finalResponse =>
+      metricsCollector.markExecutionCompletion(finalResponse.metrics)
+    }
+    finalResponseFut.onFailure {
+      case e: Throwable =>
+        metricsCollector.markExecutionFailure()
+    }
+
+    finalResponseFut
   }
 
   private[this] def executeTopLevelRequest(
       requestHeader: RequestHeader,
       topLevelRequest: TopLevelRequest): Future[Response] = {
+    val startTime = System.nanoTime()
     val topLevelResponse = fetcher.data(Request(requestHeader, List(topLevelRequest)))
 
     topLevelResponse.flatMap { topLevelResponse =>
+      val topLevelResponseWithMetrics = topLevelResponse.copy(
+        metrics = ResponseMetrics(
+          numRequests = 1,
+          duration = FiniteDuration(System.nanoTime() - startTime, "nanos")))
       // If we have a schema, we can perform automatic resource inclusion.
       mergedTypeForResource(topLevelRequest.resource).map { mergedType =>
-        val topLevelData = extractDataMaps(topLevelResponse, topLevelRequest)
+        val topLevelData = extractDataMaps(topLevelResponseWithMetrics, topLevelRequest)
 
         // TODO(bryan): Pull out logic about connections in here
         val elementLookups = (for {
@@ -100,15 +117,18 @@ class EngineImpl @Inject() (
               selections = nestedField.selections))
           executeTopLevelRequest(requestHeader, relatedTopLevelRequest).map { response =>
             // Exclude the top level ids in the response.
-            Response(topLevelResponses = Map.empty, data = response.data)
+            Response(
+              topLevelResponses = Map.empty,
+              data = response.data,
+              metrics = response.metrics)
           }
         }
         Future.sequence(additionalResponses).map { additionalResponses =>
-          additionalResponses.foldLeft(topLevelResponse)(_ ++ _)
+          additionalResponses.foldLeft(topLevelResponseWithMetrics)(_ ++ _)
         }
       }.getOrElse {
         logger.error(s"No merged type found for resource ${topLevelRequest.resource}. Skipping automatic inclusions.")
-        Future.successful(topLevelResponse)
+        Future.successful(topLevelResponseWithMetrics)
       }
     }
   }
@@ -153,3 +173,4 @@ class EngineImpl @Inject() (
     }.toSet.map[String, Set[String]](_.toString).mkString(",") // TODO: escape appropriately.
   }
 }
+

--- a/naptime/src/main/scala/org/coursera/naptime/ari/engine/EngineImpl.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/ari/engine/EngineImpl.scala
@@ -57,6 +57,7 @@ class EngineImpl @Inject() (
     futureResponses.map { responses =>
       responses.foldLeft(Response.empty)(_ ++ _)
     }
+  }
 
   private[this] def executeTopLevelRequest(
       requestHeader: RequestHeader,

--- a/naptime/src/main/scala/org/coursera/naptime/ari/engine/EngineMetricsCollector.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/ari/engine/EngineMetricsCollector.scala
@@ -1,0 +1,33 @@
+package org.coursera.naptime.ari.engine
+
+import com.typesafe.scalalogging.StrictLogging
+import org.coursera.naptime.ari.ResponseMetrics
+
+import javax.inject.Singleton
+
+trait EngineMetricsCollector {
+
+  def markExecutionCompletion(responseMetrics: ResponseMetrics): Unit
+
+  def markExecutionFailure(): Unit
+
+}
+
+@Singleton
+class LoggingEngineMetricsCollector extends EngineMetricsCollector with StrictLogging {
+  def markExecutionCompletion(responseMetrics: ResponseMetrics): Unit = {
+    logger.info(s"Completed engine execution in ${responseMetrics.duration.toMillis} ms with ${responseMetrics.numRequests} requests")
+  }
+
+  def markExecutionFailure(): Unit = {
+    logger.info(s"Failed engine execution")
+  }
+}
+
+
+@Singleton
+class NoopEngineMetricsCollector extends EngineMetricsCollector with StrictLogging {
+  def markExecutionCompletion(responseMetrics: ResponseMetrics): Unit = ()
+
+  def markExecutionFailure(): Unit = ()
+}

--- a/naptime/src/main/scala/org/coursera/naptime/ari/models.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/ari/models.scala
@@ -126,7 +126,14 @@ case class RequestField(
 
 case class ResponseMetrics(
   numRequests: Int = 0,
-  duration: FiniteDuration = FiniteDuration(0, "seconds"))
+  duration: FiniteDuration = FiniteDuration(0, "seconds")) {
+
+  def ++(other: ResponseMetrics): ResponseMetrics = {
+    ResponseMetrics(
+      numRequests = numRequests + other.numRequests,
+      duration = duration + other.duration)
+  }
+}
 
 /**
  * All of the data required to assemble a response to an automatic includes query.
@@ -165,9 +172,7 @@ case class Response(
       }.toMap
       resourceName -> mergedMap
     }.toMap
-    val mergedMetrics = ResponseMetrics(
-      numRequests = metrics.numRequests + other.metrics.numRequests,
-      duration = metrics.duration + other.metrics.duration)
+    val mergedMetrics = metrics ++ other.metrics
     Response(mergedTopLevel, mergedData, mergedMetrics)
   }
 }

--- a/naptime/src/test/scala/org/coursera/naptime/ari/engine/EngineImplTest.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/ari/engine/EngineImplTest.scala
@@ -107,8 +107,7 @@ class EngineImplTest extends AssertionsForJUnit with ScalaFutures with MockitoSu
   val injector = mock[Injector]
   val schemaProvider =
     new LocalSchemaProvider(NaptimeRoutes(injector, Set(courseRouterBuilder, instructorRouterBuilder)))
-  val metricsCollector = new NoopEngineMetricsCollector()
-  val engine = new EngineImpl(schemaProvider, fetcherApi, metricsCollector)
+  val engine = new EngineImpl(schemaProvider, fetcherApi)
 
   @Test
   def singleResourceFetch_Courses(): Unit = {

--- a/naptime/src/test/scala/org/coursera/naptime/ari/engine/EngineImplTest.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/ari/engine/EngineImplTest.scala
@@ -107,7 +107,8 @@ class EngineImplTest extends AssertionsForJUnit with ScalaFutures with MockitoSu
   val injector = mock[Injector]
   val schemaProvider =
     new LocalSchemaProvider(NaptimeRoutes(injector, Set(courseRouterBuilder, instructorRouterBuilder)))
-  val engine = new EngineImpl(schemaProvider, fetcherApi)
+  val metricsCollector = new NoopEngineMetricsCollector()
+  val engine = new EngineImpl(schemaProvider, fetcherApi, metricsCollector)
 
   @Test
   def singleResourceFetch_Courses(): Unit = {


### PR DESCRIPTION
- provides a trait that can be overridden by clients to collect and report metrics from the engine into a downstream system (i.e. DataDog)
- Returns the number of downstream requests from the engine as a response header on GraphQL requests (for developer debugging purposes)

@saeta -- thoughts on this approach? I'm working on tests for this now, but want to get your opinion on things before I spend too much time on tests (in case I have to redo some of this)