### PR TITLE
Support recursive models in fixupInferredSchemas

### DIFF
--- a/naptime/src/test/pegasus/org/coursera/naptime/RecursiveChild.courier
+++ b/naptime/src/test/pegasus/org/coursera/naptime/RecursiveChild.courier
@@ -1,0 +1,5 @@
+namespace org.coursera.naptime
+
+record RecursiveChild {
+  newBase: RecursiveModelBase
+}

--- a/naptime/src/test/pegasus/org/coursera/naptime/RecursiveModelBase.courier
+++ b/naptime/src/test/pegasus/org/coursera/naptime/RecursiveModelBase.courier
@@ -1,0 +1,5 @@
+namespace org.coursera.naptime
+
+record RecursiveModelBase {
+  recursiveChild: RecursiveChild
+}

--- a/naptime/src/test/scala/org/coursera/naptime/SchemaUtilsTest.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/SchemaUtilsTest.scala
@@ -1,0 +1,38 @@
+package org.coursera.naptime
+
+import com.linkedin.data.schema.DataSchema
+import com.linkedin.data.schema.DataSchemaUtil
+import org.coursera.naptime.ari.graphql.models.MergedCourse
+import org.junit._
+import org.scalatest.junit.AssertionsForJUnit
+
+import scala.collection.immutable
+
+class SchemaUtilsTest extends AssertionsForJUnit {
+
+  @Test
+  def testFixupSchema_EmptyOverrides(): Unit = {
+    val schemaToFix = MergedCourse.SCHEMA
+    val overrides = immutable.Map[String, DataSchema]()
+    SchemaUtils.fixupInferredSchemas(schemaToFix, overrides)
+    assert(schemaToFix === MergedCourse.SCHEMA)
+  }
+
+  @Test
+  def testFixupSchema_RecursiveSchema_EmptyOverrides(): Unit = {
+    val schemaToFix = RecursiveModelBase.SCHEMA
+    val overrides = Map[String, DataSchema]()
+    SchemaUtils.fixupInferredSchemas(schemaToFix, overrides)
+    assert(schemaToFix === RecursiveModelBase.SCHEMA)
+  }
+
+  @Test
+  def testFixupSchema_RecursiveSchema_WithOverrides(): Unit = {
+    val schemaToFix = RecursiveModelBase.SCHEMA
+    val longDataSchema = DataSchemaUtil.dataSchemaTypeToPrimitiveDataSchema(DataSchema.Type.LONG)
+    val overrides = Map("org.coursera.naptime.RecursiveChild" -> longDataSchema)
+    SchemaUtils.fixupInferredSchemas(schemaToFix, overrides)
+    assert(schemaToFix.getField("recursiveChild").getType === longDataSchema)
+  }
+
+}

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.4.3"
+version in ThisBuild := "0.4.4"


### PR DESCRIPTION
The schema fixup helper recursively traverses through recorddataschemas. However, some schemas are recursive, which would lead to a StackOverthrowException here. To fix it, we’ll keep track of the nodes that we’ve visited to ensure that we don’t get stuck in a loop

PTAL @saeta or @yifan-coursera 