### PR TITLE
Default the type for a key field to string

### DIFF
--- a/naptime/src/main/scala/org/coursera/naptime/router2/MacroImpls.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/router2/MacroImpls.scala
@@ -312,9 +312,10 @@ class MacroImpls(val c: blackbox.Context) {
       q"""{
         val mergedType: String = ${mergedType(resourceType)}
         val keySchemaOption: Option[com.linkedin.data.schema.DataSchema] = $keySchemaOption
+        val keySchema: com.linkedin.data.schema.DataSchema = keySchemaOption
+          .getOrElse(new com.linkedin.data.schema.StringDataSchema)
         val bodySchemaOption: Option[com.linkedin.data.schema.RecordDataSchema] = $bodySchemaOption
         (for {
-          keySchema <- keySchemaOption
           bodySchema <- bodySchemaOption
         } yield {
           org.coursera.naptime.model.Keyed(


### PR DESCRIPTION
There are some key types that are non-courier’d that can’t have their types inferred through reflection. This can occur when the type is or includes a Java class inside of it (i.e. java.util.UUID). In these cases, we can assume that there is a StringKeyFormat available to convert the key type to a string, so it is safe to assume that the ID in the response will be of type string.

In these cases, when the key type cannot be inferred, it will fall back to a string. By falling back, we can ensure that the merged type can be generated correctly, and add graphql support to these resources.

PTAL @saeta and @yifan-coursera 