### PR TITLE
Add DataSchemas for parameter types on naptime handlers

### DIFF
--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/SangriaGraphQlSchemaBuilder.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/SangriaGraphQlSchemaBuilder.scala
@@ -128,7 +128,13 @@ class SangriaGraphQlSchemaBuilder(
     val arguments = SangriaGraphQlSchemaBuilder.generateHandlerArguments(handler)
     val resourceName = ResourceName(resource.name, resource.version.getOrElse(0L).toInt)
 
-    val idExtractor = (context: Context[SangriaGraphQlContext, DataMap]) => context.arg[AnyRef]("id")
+    val idExtractor = (context: Context[SangriaGraphQlContext, DataMap]) => {
+      val id = context.arg[AnyRef]("id")
+      id match {
+        case idOpt: Option[Any] => idOpt.orNull
+        case _ => id
+      }
+    }
 
     NaptimeResourceField.build(
       schemaMetadata = schemaMetadata,

--- a/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/models.scala
+++ b/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/models.scala
@@ -67,7 +67,22 @@ object Models {
     keyType = "",
     valueType = "",
     mergedType = "org.coursera.naptime.ari.graphql.models.MergedPartner",
-    handlers = List.empty,
+    handlers = List(
+      Handler(
+        kind = HandlerKind.GET,
+        name = "get",
+        parameters = List(Parameter(name = "id", `type` = "Int", attributes = List.empty)),
+        attributes = List.empty),
+      Handler(
+        kind = HandlerKind.MULTI_GET,
+        name = "multiGet",
+        parameters = List(Parameter(name = "ids", `type` = "List[Int]", attributes = List.empty)),
+        attributes = List.empty),
+      Handler(
+        kind = HandlerKind.GET_ALL,
+        name = "getAll",
+        parameters = List.empty,
+        attributes = List.empty)),
     className = "",
     attributes = List.empty)
 

--- a/naptime-models/src/main/scala/org/coursera/naptime/courier/SchemaInference.scala
+++ b/naptime-models/src/main/scala/org/coursera/naptime/courier/SchemaInference.scala
@@ -48,6 +48,9 @@ object SchemaInference {
    */
   def inferSchema[T: ru.TypeTag]: JsObject = inferSchema(ru.typeOf[T])
 
+  def inferSchemaFromWeakTypeTag[T: ru.WeakTypeTag]: JsObject = inferSchema(ru.weakTypeOf[T])
+
+
   /**
    * Extracts schemas from Courier generated bindings.
    * Infers schemas from Play! JSON style classes that use `Format` and `OFormat`.

--- a/naptime-testing/src/test/scala/org/coursera/naptime/NestedMacroTests.scala
+++ b/naptime-testing/src/test/scala/org/coursera/naptime/NestedMacroTests.scala
@@ -629,6 +629,8 @@ class NestedMacroTests extends AssertionsForJUnit with MockitoSugar {
     val multiGetSetParameter = multiGetSchema.parameters.head
     assert(multiGetSetParameter.name === "ids")
     assert(multiGetSetParameter.`type` === "Set[String]") // TODO(saeta): Use a courier type.
+    assert(multiGetSetParameter.typeSchema.get.data().getString("type") === "array")
+    assert(multiGetSetParameter.typeSchema.get.data().getString("items") === "string")
     assert(multiGetSetParameter.default === None)
 
     // TODO(saeta): verify more things (i.e. more handlers)

--- a/naptime/src/main/pegasus/org/coursera/naptime/schema/Parameter.courier
+++ b/naptime/src/main/pegasus/org/coursera/naptime/schema/Parameter.courier
@@ -22,4 +22,10 @@ record Parameter {
    * purposes.
    */
   default: ArbitraryValue?
+
+  /**
+   * Flag whether the parameter is optional,
+   * either because it is an Option or provides a default value.
+   */
+  required: boolean = false
 }

--- a/naptime/src/main/pegasus/org/coursera/naptime/schema/Parameter.courier
+++ b/naptime/src/main/pegasus/org/coursera/naptime/schema/Parameter.courier
@@ -11,6 +11,8 @@ record Parameter {
 
   type: TypeName
 
+  typeSchema: ParameterDataSchema?
+
   attributes: array[Attribute]
 
   /**

--- a/naptime/src/main/pegasus/org/coursera/naptime/schema/ParameterDataSchema.courier
+++ b/naptime/src/main/pegasus/org/coursera/naptime/schema/ParameterDataSchema.courier
@@ -1,0 +1,13 @@
+namespace org.coursera.naptime.schema
+
+/**
+ * Marker type identifying a Pegasus data schema.
+ *
+ * Because Pegasus data schemas are not self describing, they are represented in Courier with this
+ * record. Instances of this record will, however, be non-empty-- their underlying DataMap will
+ * contain the JSON representation of a Pegasus data schema.
+ */
+@passthroughExempt
+record ParameterDataSchema {
+  // Intentionally empty!
+}

--- a/naptime/src/main/scala/org/coursera/naptime/router2/MacroImpls.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/router2/MacroImpls.scala
@@ -451,7 +451,7 @@ class MacroImpls(val c: blackbox.Context) {
           val typeSchema: Option[com.linkedin.data.DataMap] = ${getDataSchemaDataMapForType(param.typeSignature)}
           val updatedDataMap = parameterWithoutTypeSchema.data().clone()
           typeSchema.foreach(t => updatedDataMap.put("typeSchema", t))
-          org.coursera.naptime.schema.Parameter(
+          org.coursera.naptime.schema.Parameter.build(
             updatedDataMap,
             org.coursera.courier.templates.DataTemplates.DataConversion.SetReadOnly)
         """

--- a/naptime/src/test/scala/org/coursera/naptime/actions/RecordTemplateNaptimeSerializerTest.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/actions/RecordTemplateNaptimeSerializerTest.scala
@@ -30,7 +30,7 @@ class RecordTemplateNaptimeSerializerTest extends AssertionsForJUnit {
 
   @Test
   def simpleTest(): Unit = {
-    val parameter = Parameter("parameterName", "fakeType", List.empty)
+    val parameter = Parameter("parameterName", "fakeType", None, List.empty)
 
     val expected = new DataMap()
     expected.put("name", "parameterName")

--- a/naptime/src/test/scala/org/coursera/naptime/actions/RecordTemplateNaptimeSerializerTest.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/actions/RecordTemplateNaptimeSerializerTest.scala
@@ -36,6 +36,7 @@ class RecordTemplateNaptimeSerializerTest extends AssertionsForJUnit {
     expected.put("name", "parameterName")
     expected.put("type", "fakeType")
     expected.put("attributes", new DataList())
+    expected.put("required", Boolean.box(false))
 
     assert(expected === helper(parameter))
   }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.5.2"
+version in ThisBuild := "0.5.3"


### PR DESCRIPTION
This change adds a new `typeSchema` field to the Parameter, which contains a DataSchema (serialized as a DataMap) that defines the parameter type. This allows the type of a parameter to be serialized in a better way than a string, so it can be parsed by the GraphQL assembler and used in schema generation. (Presently, the scala typename is being parsed with a regex, but that’s terrible)

Once this is landed, the schema store will be updated to parse the correct parameter types, and then the GraphQL schema builder can use that type to generate the graphql parameters.

PTAL @saeta and @yifan-coursera 