### PR TITLE
Support query batching in the naptime controller

### DIFF
--- a/examples/src/main/resources/routes
+++ b/examples/src/main/resources/routes
@@ -5,6 +5,7 @@
 # An example controller showing a sample home page
 GET     /                           @controllers.HomeController.index
 POST    /graphql                    @org.coursera.naptime.ari.graphql.controllers.GraphQLController.graphqlBody
+POST    /graphqlBatch               @org.coursera.naptime.ari.graphql.controllers.GraphQLController.graphqlBatch
 GET     /graphiql                   @controllers.HomeController.graphiql
 GET     /graphql-schema             @org.coursera.naptime.ari.graphql.controllers.GraphQLController.renderSchema
 

--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/controllers/filters/QueryComplexityFilter.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/controllers/filters/QueryComplexityFilter.scala
@@ -36,21 +36,20 @@ class QueryComplexityFilter @Inject() (
       if (complexity > MAX_COMPLEXITY) {
         Future.successful(
           OutgoingQuery(
-            result = BadRequest(
-              Json.obj(
+            response = Json.obj(
                 "error" -> "Query is too complex.",
-                "complexity" -> complexity)),
+                "complexity" -> complexity),
             ariResponse = None))
       } else {
         nextFilter.apply(incoming)
       }
     }.recover {
       case error: QueryAnalysisError =>
-        OutgoingQuery(BadRequest(Json.obj("error" -> error.resolveError)), None)
+        OutgoingQuery(Json.obj("error" -> error.resolveError), None)
       case error: ErrorWithResolver =>
-        OutgoingQuery(InternalServerError(Json.obj("error" -> error.resolveError)), None)
+        OutgoingQuery(Json.obj("error" -> error.resolveError), None)
       case error: Exception =>
-        OutgoingQuery(InternalServerError(Json.obj("error" -> error.getMessage)), None)
+        OutgoingQuery(Json.obj("error" -> error.getMessage), None)
     }
   }
 

--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/controllers/filters/models.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/controllers/filters/models.scala
@@ -3,7 +3,6 @@ package org.coursera.naptime.ari.graphql.controllers.filters
 import org.coursera.naptime.ari.Response
 import play.api.libs.json.JsObject
 import play.api.mvc.RequestHeader
-import play.api.mvc.Result
 import sangria.ast.Document
 
 import scala.collection.immutable
@@ -14,6 +13,6 @@ case class IncomingQuery(
     variables: JsObject,
     operation: Option[String])
 
-case class OutgoingQuery(result: Result, ariResponse: Option[Response])
+case class OutgoingQuery(response: JsObject, ariResponse: Option[Response])
 
 case class FilterList(filters: immutable.Seq[Filter])

--- a/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/controllers/filters/FilterTest.scala
+++ b/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/controllers/filters/FilterTest.scala
@@ -1,0 +1,81 @@
+package org.coursera.naptime.ari.graphql.controllers.filters
+
+import org.coursera.naptime.ari.graphql.GraphqlSchemaProvider
+import org.coursera.naptime.ari.graphql.Models
+import org.coursera.naptime.ari.graphql.SangriaGraphQlContext
+import org.coursera.naptime.ari.graphql.SangriaGraphQlSchemaBuilder
+import org.coursera.naptime.ari.graphql.models.MergedCourse
+import org.coursera.naptime.ari.graphql.models.MergedInstructor
+import org.coursera.naptime.ari.graphql.models.MergedPartner
+import org.mockito.Mockito.when
+import org.scalatest.concurrent.IntegrationPatience
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.junit.AssertionsForJUnit
+import org.scalatest.mock.MockitoSugar
+import play.api.libs.json.Json
+import play.api.test.FakeRequest
+import sangria.parser.QueryParser
+import sangria.schema.Schema
+
+import scala.concurrent.Future
+
+trait FilterTest
+  extends AssertionsForJUnit
+  with MockitoSugar
+  with ScalaFutures
+  with IntegrationPatience {
+
+  val baseOutgoingQuery = OutgoingQuery(Json.obj(), None)
+
+  def noopFilter(incomingQuery: IncomingQuery) = {
+    Future.successful(baseOutgoingQuery)
+  }
+
+  def exceptionThrowingFilter(incomingQuery: IncomingQuery): Future[OutgoingQuery] = {
+    assert(false, "This filter should not be run")
+    Future.successful(baseOutgoingQuery)
+  }
+
+  val filter: Filter
+
+  val defaultQuery =
+    """
+      |query {
+      |  __schema {
+      |    queryType {
+      |      name
+      |    }
+      |  }
+      |}
+    """.stripMargin
+
+  val graphqlSchemaProvider = mock[GraphqlSchemaProvider]
+
+  val allResources = Set(Models.courseResource, Models.instructorResource, Models.partnersResource)
+
+  val schemaTypes = Map(
+    "org.coursera.naptime.ari.graphql.models.MergedCourse" -> MergedCourse.SCHEMA,
+    "org.coursera.naptime.ari.graphql.models.MergedPartner" -> MergedPartner.SCHEMA,
+    "org.coursera.naptime.ari.graphql.models.MergedInstructor" -> MergedInstructor.SCHEMA)
+  val builder = new SangriaGraphQlSchemaBuilder(allResources, schemaTypes)
+
+
+  val schema = builder.generateSchema().asInstanceOf[Schema[SangriaGraphQlContext, Any]]
+  when(graphqlSchemaProvider.schema).thenReturn(schema)
+
+  def generateIncomingQuery(query: String = defaultQuery) = {
+    val document = QueryParser.parse(query).get
+    val header = FakeRequest("POST", s"/graphql").withBody(query)
+    val variables = Json.obj()
+    val operation = None
+    IncomingQuery(document, header, variables, operation)
+  }
+
+  def run(incomingQuery: IncomingQuery): Future[OutgoingQuery] = {
+    filter.apply(noopFilter)(incomingQuery)
+  }
+
+  def ensureNotPropagated(incomingQuery: IncomingQuery): Future[OutgoingQuery] = {
+    filter.apply(exceptionThrowingFilter)(incomingQuery)
+  }
+}

--- a/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/controllers/filters/QueryComplexityFilterTest.scala
+++ b/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/controllers/filters/QueryComplexityFilterTest.scala
@@ -1,0 +1,38 @@
+package org.coursera.naptime.ari.graphql.controllers.filters
+
+import org.junit.Test
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class QueryComplexityFilterTest extends FilterTest {
+
+  val filter = new QueryComplexityFilter(graphqlSchemaProvider)
+
+  @Test
+  def emptyQuery(): Unit = {
+    val incomingQuery = generateIncomingQuery()
+    val outgoingQuery = run(incomingQuery).futureValue
+    assert(outgoingQuery === baseOutgoingQuery)
+  }
+
+  @Test
+  def complexQuery(): Unit = {
+    val query =
+      """
+        |query {
+        |  CoursesV1Resource {
+        |    getAll(limit: 100000) {
+        |      elements {
+        |        id
+        |      }
+        |    }
+        |  }
+        |}
+      """.stripMargin
+    val incomingQuery = generateIncomingQuery(query)
+    val outgoingQuery = ensureNotPropagated(incomingQuery).futureValue
+
+    assert(outgoingQuery.response.value("error").as[String] === "Query is too complex.")
+    assert(outgoingQuery.response.value("complexity").as[Int] === 200001)
+  }
+}

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.4.6"
+version in ThisBuild := "0.4.7"


### PR DESCRIPTION
Note: this changes the way that the filters work to instead pass around JsObjects instead of a response. This means that filters / the GraphQL engine cannot alter the response at all (including response codes + headers), but instead must put all data on the response body and _always_ return a 200 access code. This is acceptable with the way that GraphQL works, but is a change to keep in mind

PTAL @yifan-coursera and cc @jnwng 