### PR TITLE
Support overrides dataschemas in arrays and maps

### DIFF
--- a/naptime/src/main/scala/org/coursera/naptime/utilities.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/utilities.scala
@@ -221,6 +221,4 @@ object SchemaUtils {
       }
     }
   }
-
-
 }

--- a/naptime/src/test/pegasus/org/coursera/naptime/NestedChild.courier
+++ b/naptime/src/test/pegasus/org/coursera/naptime/NestedChild.courier
@@ -1,0 +1,5 @@
+namespace org.coursera.naptime
+
+record NestedChild {
+  stringLikeField: StringLikeField
+}

--- a/naptime/src/test/pegasus/org/coursera/naptime/RecursiveModelBase.courier
+++ b/naptime/src/test/pegasus/org/coursera/naptime/RecursiveModelBase.courier
@@ -3,5 +3,6 @@ namespace org.coursera.naptime
 record RecursiveModelBase {
   recursiveChild: RecursiveChild
   recursiveChildren: array[RecursiveChild]
+  nestedChild: array[NestedChild]
   recursiveChildMap: map[string, RecursiveChild]
 }

--- a/naptime/src/test/pegasus/org/coursera/naptime/RecursiveModelBase.courier
+++ b/naptime/src/test/pegasus/org/coursera/naptime/RecursiveModelBase.courier
@@ -4,5 +4,6 @@ record RecursiveModelBase {
   recursiveChild: RecursiveChild
   recursiveChildren: array[RecursiveChild]
   nestedChild: array[NestedChild]
+  unionChild: union[NestedChild, RecursiveChild]
   recursiveChildMap: map[string, RecursiveChild]
 }

--- a/naptime/src/test/pegasus/org/coursera/naptime/RecursiveModelBase.courier
+++ b/naptime/src/test/pegasus/org/coursera/naptime/RecursiveModelBase.courier
@@ -2,4 +2,6 @@ namespace org.coursera.naptime
 
 record RecursiveModelBase {
   recursiveChild: RecursiveChild
+  recursiveChildren: array[RecursiveChild]
+  recursiveChildMap: map[string, RecursiveChild]
 }

--- a/naptime/src/test/pegasus/org/coursera/naptime/StringLikeField.courier
+++ b/naptime/src/test/pegasus/org/coursera/naptime/StringLikeField.courier
@@ -1,0 +1,5 @@
+namespace org.coursera.naptime
+
+record StringLikeField {
+  element: string
+}

--- a/naptime/src/test/scala/org/coursera/naptime/SchemaUtilsTest.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/SchemaUtilsTest.scala
@@ -1,7 +1,9 @@
 package org.coursera.naptime
 
+import com.linkedin.data.schema.ArrayDataSchema
 import com.linkedin.data.schema.DataSchema
 import com.linkedin.data.schema.DataSchemaUtil
+import com.linkedin.data.schema.MapDataSchema
 import org.coursera.naptime.ari.graphql.models.MergedCourse
 import org.junit._
 import org.scalatest.junit.AssertionsForJUnit
@@ -33,6 +35,26 @@ class SchemaUtilsTest extends AssertionsForJUnit {
     val overrides = Map("org.coursera.naptime.RecursiveChild" -> longDataSchema)
     SchemaUtils.fixupInferredSchemas(schemaToFix, overrides)
     assert(schemaToFix.getField("recursiveChild").getType === longDataSchema)
+  }
+
+  @Test
+  def testFixupSchema_ListSchema_WithOverrides(): Unit = {
+    val schemaToFix = RecursiveModelBase.SCHEMA
+    val longDataSchema = DataSchemaUtil.dataSchemaTypeToPrimitiveDataSchema(DataSchema.Type.LONG)
+    val overrides = Map("org.coursera.naptime.RecursiveChild" -> longDataSchema)
+    SchemaUtils.fixupInferredSchemas(schemaToFix, overrides)
+    assert(schemaToFix.getField("recursiveChildren").getType ===
+      new ArrayDataSchema(longDataSchema))
+  }
+
+  @Test
+  def testFixupSchema_MapSchema_WithOverrides(): Unit = {
+    val schemaToFix = RecursiveModelBase.SCHEMA
+    val longDataSchema = DataSchemaUtil.dataSchemaTypeToPrimitiveDataSchema(DataSchema.Type.LONG)
+    val overrides = Map("org.coursera.naptime.RecursiveChild" -> longDataSchema)
+    SchemaUtils.fixupInferredSchemas(schemaToFix, overrides)
+    assert(schemaToFix.getField("recursiveChildMap").getType ===
+      new MapDataSchema(longDataSchema))
   }
 
 }

--- a/naptime/src/test/scala/org/coursera/naptime/SchemaUtilsTest.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/SchemaUtilsTest.scala
@@ -5,6 +5,7 @@ import com.linkedin.data.schema.DataSchema
 import com.linkedin.data.schema.DataSchemaUtil
 import com.linkedin.data.schema.MapDataSchema
 import com.linkedin.data.schema.RecordDataSchema
+import com.linkedin.data.schema.UnionDataSchema
 import org.coursera.naptime.ari.graphql.models.MergedCourse
 import org.junit._
 import org.scalatest.junit.AssertionsForJUnit
@@ -67,6 +68,18 @@ class SchemaUtilsTest extends AssertionsForJUnit {
     assert(schemaToFix
       .getField("nestedChild").getType.asInstanceOf[ArrayDataSchema]
       .getItems.asInstanceOf[RecordDataSchema]
+      .getField("stringLikeField").getType === stringDataSchema)
+  }
+
+  @Test
+  def testFixupSchema_RecursiveUnionSchema_WithOverrides(): Unit = {
+    val schemaToFix = RecursiveModelBase.SCHEMA
+    val stringDataSchema = DataSchemaUtil.dataSchemaTypeToPrimitiveDataSchema(DataSchema.Type.STRING)
+    val overrides = Map("org.coursera.naptime.StringLikeField" -> stringDataSchema)
+    SchemaUtils.fixupInferredSchemas(schemaToFix, overrides)
+    assert(schemaToFix
+      .getField("unionChild").getType.asInstanceOf[UnionDataSchema]
+      .getTypeByName("NestedChild").asInstanceOf[RecordDataSchema]
       .getField("stringLikeField").getType === stringDataSchema)
   }
 

--- a/naptime/src/test/scala/org/coursera/naptime/SchemaUtilsTest.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/SchemaUtilsTest.scala
@@ -4,6 +4,7 @@ import com.linkedin.data.schema.ArrayDataSchema
 import com.linkedin.data.schema.DataSchema
 import com.linkedin.data.schema.DataSchemaUtil
 import com.linkedin.data.schema.MapDataSchema
+import com.linkedin.data.schema.RecordDataSchema
 import org.coursera.naptime.ari.graphql.models.MergedCourse
 import org.junit._
 import org.scalatest.junit.AssertionsForJUnit
@@ -55,6 +56,18 @@ class SchemaUtilsTest extends AssertionsForJUnit {
     SchemaUtils.fixupInferredSchemas(schemaToFix, overrides)
     assert(schemaToFix.getField("recursiveChildMap").getType ===
       new MapDataSchema(longDataSchema))
+  }
+
+  @Test
+  def testFixupSchema_RecursiveListSchema_WithOverrides(): Unit = {
+    val schemaToFix = RecursiveModelBase.SCHEMA
+    val stringDataSchema = DataSchemaUtil.dataSchemaTypeToPrimitiveDataSchema(DataSchema.Type.STRING)
+    val overrides = Map("org.coursera.naptime.StringLikeField" -> stringDataSchema)
+    SchemaUtils.fixupInferredSchemas(schemaToFix, overrides)
+    assert(schemaToFix
+      .getField("nestedChild").getType.asInstanceOf[ArrayDataSchema]
+      .getItems.asInstanceOf[RecordDataSchema]
+      .getField("stringLikeField").getType === stringDataSchema)
   }
 
 }


### PR DESCRIPTION
DataSchema overrides only worked for fields in a recorddataschema, but there were some cases where we need to fix up a schema that's a member in a list or map. This now looks at the item types for those, and fixes them up.

PTAL @yifan-coursera
cc @saeta 