### PR TITLE
Allow overriding of max complexity score

### DIFF
--- a/examples/src/main/scala/ResourceModule.scala
+++ b/examples/src/main/scala/ResourceModule.scala
@@ -9,6 +9,7 @@ import org.coursera.naptime.ari.engine.LoggingEngineMetricsCollector
 import org.coursera.naptime.ari.fetcher.LocalFetcher
 import org.coursera.naptime.ari.graphql.DefaultGraphqlSchemaProvider
 import org.coursera.naptime.ari.graphql.GraphqlSchemaProvider
+import org.coursera.naptime.ari.graphql.controllers.filters.ComplexityFilterConfiguration
 import org.coursera.naptime.ari.graphql.controllers.filters.DefaultFilters
 import org.coursera.naptime.ari.graphql.controllers.filters.FilterList
 import resources.UserStore
@@ -32,5 +33,6 @@ class ResourceModule extends NaptimeModule {
     bind[SchemaProvider].to[LocalSchemaProvider]
     bind[GraphqlSchemaProvider].to[DefaultGraphqlSchemaProvider]
     bind[FilterList].to[DefaultFilters]
+    bind[ComplexityFilterConfiguration].toInstance(ComplexityFilterConfiguration.DEFAULT)
   }
 }

--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/controllers/filters/QueryComplexityFilter.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/controllers/filters/QueryComplexityFilter.scala
@@ -23,13 +23,14 @@ import scala.concurrent.Future
 
 @Singleton
 class QueryComplexityFilter @Inject() (
-    graphqlSchemaProvider: GraphqlSchemaProvider)
+    graphqlSchemaProvider: GraphqlSchemaProvider,
+    configuration: ComplexityFilterConfiguration)
     (implicit executionContext: ExecutionContext)
   extends Filter
   with Results
   with StrictLogging {
 
-  val MAX_COMPLEXITY = 10000 // TODO(bryan): pull this out to config?
+  val MAX_COMPLEXITY = configuration.maxComplexity
 
   def apply(nextFilter: FilterFn): FilterFn = { incoming =>
     computeComplexity(incoming.document, incoming.variables).flatMap { complexity =>
@@ -75,4 +76,10 @@ class QueryComplexityFilter @Inject() (
     }
 
   }
+}
+
+case class ComplexityFilterConfiguration(maxComplexity: Int)
+
+object ComplexityFilterConfiguration {
+  val DEFAULT = ComplexityFilterConfiguration(10000)
 }

--- a/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/controllers/filters/QueryComplexityFilterTest.scala
+++ b/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/controllers/filters/QueryComplexityFilterTest.scala
@@ -6,7 +6,8 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 class QueryComplexityFilterTest extends FilterTest {
 
-  val filter = new QueryComplexityFilter(graphqlSchemaProvider)
+  val config = ComplexityFilterConfiguration.DEFAULT
+  val filter = new QueryComplexityFilter(graphqlSchemaProvider, config)
 
   @Test
   def emptyQuery(): Unit = {


### PR DESCRIPTION
We were hitting the limits of the complexity filter with some normal queries, so this pulls the max complexity score out to a config that we can override. This is still a somewhat naive approach, but we can modify it more later on once we better understand what we need.

We also have metrics / monitoring on the number of downstream requests we make, so we'll keep a close eye on that and make sure it doesn't go too crazy.

PTAL @yifan-coursera