### PR TITLE
Add support for reverse relations to the ARI engine

### DIFF
--- a/examples/src/main/pegasus/org/coursera/example/Course.courier
+++ b/examples/src/main/pegasus/org/coursera/example/Course.courier
@@ -13,4 +13,6 @@ record Course {
   description: string?
 
   extraData: AnyData
+
+  courseMetadata: union[CourseMetadata]
 }

--- a/examples/src/main/pegasus/org/coursera/example/CourseMetadata.courier
+++ b/examples/src/main/pegasus/org/coursera/example/CourseMetadata.courier
@@ -1,0 +1,8 @@
+namespace org.coursera.example
+
+record CourseMetadata {
+
+  @related = "instructors.v1"
+  certificateInstructor: InstructorId
+
+}

--- a/examples/src/main/pegasus/org/coursera/example/Instructor.courier
+++ b/examples/src/main/pegasus/org/coursera/example/Instructor.courier
@@ -1,9 +1,6 @@
 namespace org.coursera.example
 
 record Instructor {
-  @related = "courses.v1"
-  courses: array[CourseId]
-
   @related = "partners.v1"
   partner: PartnerId
 

--- a/examples/src/main/scala/resources/CoursesResource.scala
+++ b/examples/src/main/scala/resources/CoursesResource.scala
@@ -44,4 +44,10 @@ class CoursesResource @Inject() (
       .withPagination(next, Some(courses.size.toLong))
   }
 
+  def byInstructor(instructorId: String) = Nap.finder { context =>
+    val courses = courseStore.all()
+      .filter(course => course._2.instructors.contains(instructorId))
+    Ok(courses.toList.map { case (id, course) => Keyed(id, course) })
+  }
+
 }

--- a/examples/src/main/scala/resources/InstructorsResource.scala
+++ b/examples/src/main/scala/resources/InstructorsResource.scala
@@ -5,9 +5,9 @@ import javax.inject.Singleton
 
 import org.coursera.example.Instructor
 import org.coursera.naptime.Fields
+import org.coursera.naptime.FinderReverseRelation
 import org.coursera.naptime.Ok
 import org.coursera.naptime.ResourceName
-import org.coursera.naptime.ReverseRelation
 import org.coursera.naptime.model.Keyed
 import org.coursera.naptime.resources.CourierCollectionResource
 import stores.InstructorStore
@@ -21,11 +21,10 @@ class InstructorsResource @Inject() (
   override def resourceVersion = 1
   override implicit lazy val Fields: Fields[Instructor] = BaseFields
     .withReverseRelations(
-      "courses" -> ReverseRelation[String](
+      "courses" -> FinderReverseRelation[String](
         resourceName = ResourceName("courses", 1),
-        arguments = Map(
-          "q" -> "byInstructor",
-          "instructorId" -> "$id")))
+        finderName = "byInstructor",
+        arguments = Map("instructorId" -> "$id")))
 
   def get(id: String) = Nap.get { context =>
     OkIfPresent(id, instructorStore.get(id))

--- a/examples/src/main/scala/resources/InstructorsResource.scala
+++ b/examples/src/main/scala/resources/InstructorsResource.scala
@@ -7,6 +7,7 @@ import org.coursera.example.Instructor
 import org.coursera.naptime.Fields
 import org.coursera.naptime.Ok
 import org.coursera.naptime.ResourceName
+import org.coursera.naptime.ReverseRelation
 import org.coursera.naptime.model.Keyed
 import org.coursera.naptime.resources.CourierCollectionResource
 import stores.InstructorStore
@@ -19,6 +20,12 @@ class InstructorsResource @Inject() (
   override def resourceName = "instructors"
   override def resourceVersion = 1
   override implicit lazy val Fields: Fields[Instructor] = BaseFields
+    .withReverseRelations(
+      "courses" -> ReverseRelation[String](
+        resourceName = ResourceName("courses", 1),
+        arguments = Map(
+          "q" -> "byInstructor",
+          "instructorId" -> "$id")))
 
   def get(id: String) = Nap.get { context =>
     OkIfPresent(id, instructorStore.get(id))

--- a/examples/src/main/scala/stores/CourseStore.scala
+++ b/examples/src/main/scala/stores/CourseStore.scala
@@ -7,6 +7,7 @@ import com.linkedin.data.DataMap
 import org.coursera.courier.templates.DataTemplates.DataConversion
 import org.coursera.example.AnyData
 import org.coursera.example.Course
+import org.coursera.example.CourseMetadata
 import org.coursera.naptime.model.Keyed
 
 import scala.collection.JavaConverters._
@@ -26,7 +27,9 @@ class CourseStore {
       description = Some("Machine learning is the science of getting computers to act without being explicitly programmed."),
       extraData = AnyData(new DataMap(
         Map("firstModuleId" -> "wrh7vtpj").asJava),
-        DataConversion.SetReadOnly)),
+        DataConversion.SetReadOnly),
+      courseMetadata = CourseMetadata(
+        certificateInstructor = "andrew-ng")),
     "lhtl" -> Course(
       instructors = List("barb-oakley"),
       partner = "ucsd",
@@ -35,7 +38,9 @@ class CourseStore {
       description = None,
       extraData = AnyData(new DataMap(
         Map("recentEnrollments" -> new Integer(1000)).asJava),
-        DataConversion.SetReadOnly)))
+        DataConversion.SetReadOnly),
+      courseMetadata = CourseMetadata(
+        certificateInstructor = "andrew-ng")))
 
   def get(id: String) = courseStore.get(id)
 

--- a/examples/src/main/scala/stores/InstructorStore.scala
+++ b/examples/src/main/scala/stores/InstructorStore.scala
@@ -14,12 +14,10 @@ class InstructorStore {
 
   instructorStore = instructorStore + (
     "andrew-ng" -> Instructor(
-      courses = List("ml"),
       partner = "stanford",
       name = "Andrew Ng",
       photoUrl = ""),
     "barb-oakley" -> Instructor(
-      courses = List("learning-how-to-learn"),
       partner = "ucsd",
       name = "Barb Oakley",
       photoUrl = ""))

--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/SangriaGraphQlParser.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/SangriaGraphQlParser.scala
@@ -96,7 +96,6 @@ object SangriaGraphQlParser extends GraphQlParser {
         List(OptionallyTypedField(field, typeCondition))
       case inlineFragment: InlineFragment =>
         inlineFragment.selections.flatMap { selection =>
-          println(inlineFragment.typeCondition)
           parseSelection(selection, document, inlineFragment.typeCondition.map(_.name))
         }
       case fragmentSpread: FragmentSpread =>
@@ -104,7 +103,6 @@ object SangriaGraphQlParser extends GraphQlParser {
           fragment <- document.fragments.get(fragmentSpread.name).toList
           selection <- fragment.selections
         } yield {
-          println(fragment.typeConditionOpt)
           parseSelection(selection, document, fragment.typeConditionOpt.map(_.name))
         }).flatten
     }

--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/SangriaGraphQlSchemaBuilder.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/SangriaGraphQlSchemaBuilder.scala
@@ -21,7 +21,6 @@ import com.linkedin.data.schema.RecordDataSchema
 import com.typesafe.scalalogging.StrictLogging
 import org.coursera.naptime.PaginationConfiguration
 import org.coursera.naptime.ResourceName
-import org.coursera.naptime.ari.graphql.schema.FieldRelation
 import org.coursera.naptime.ari.graphql.schema.NaptimePaginatedResourceField
 import org.coursera.naptime.ari.graphql.schema.NaptimePaginationField
 import org.coursera.naptime.ari.graphql.schema.NaptimeResourceField
@@ -160,7 +159,7 @@ class SangriaGraphQlSchemaBuilder(
       resourceName = resourceName.identifier,
       fieldName = fieldName,
       handlerOverride = Some(handler),
-      fieldRelation = FieldRelation())
+      fieldRelation = None)
       .getOrElse {
         throw SchemaGenerationException(
           s"Cannot build field for ${resourceName.identifier} / ${handler.name}")

--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/SangriaGraphQlSchemaBuilder.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/SangriaGraphQlSchemaBuilder.scala
@@ -21,6 +21,7 @@ import com.linkedin.data.schema.RecordDataSchema
 import com.typesafe.scalalogging.StrictLogging
 import org.coursera.naptime.PaginationConfiguration
 import org.coursera.naptime.ResourceName
+import org.coursera.naptime.ari.graphql.schema.FieldRelation
 import org.coursera.naptime.ari.graphql.schema.NaptimePaginatedResourceField
 import org.coursera.naptime.ari.graphql.schema.NaptimePaginationField
 import org.coursera.naptime.ari.graphql.schema.NaptimeResourceField
@@ -157,9 +158,12 @@ class SangriaGraphQlSchemaBuilder(
     val field = NaptimePaginatedResourceField.build(
       schemaMetadata = schemaMetadata,
       resourceName = resourceName.identifier,
-      fieldName = fieldName)
+      fieldName = fieldName,
+      handlerOverride = Some(handler),
+      fieldRelation = FieldRelation())
       .getOrElse {
-        throw SchemaGenerationException(s"Cannot build field for $resourceName / ${handler.name}")
+        throw SchemaGenerationException(
+          s"Cannot build field for ${resourceName.identifier} / ${handler.name}")
       }
 
     val mergedArguments = (field.arguments ++ arguments)

--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/controllers/GraphQLController.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/controllers/GraphQLController.scala
@@ -140,6 +140,7 @@ class GraphQLController @Inject() (
               case error: ErrorWithResolver =>
                 OutgoingQuery(Json.obj("error" -> error.resolveError), None)
               case error: Exception =>
+                logger.error("GraphQL execution error", error)
                 OutgoingQuery(Json.obj("error" -> error.getMessage), None)
             }
           }.getOrElse {

--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/FieldBuilder.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/FieldBuilder.scala
@@ -59,10 +59,9 @@ object FieldBuilder extends StrictLogging {
     val forwardRelationOption = fieldProperties.get(Relations.PROPERTY_NAME).map(_.toString)
     val reverseRelationOption = fieldProperties.get(Relations.REVERSE_PROPERTY_NAME)
       .map(d => ReverseRelationAnnotation(d.asInstanceOf[DataMap], DataConversion.SetReadOnly))
-      .map(_.resourceName)
 
     val relatedResourceOption = if (followRelations) {
-      forwardRelationOption.orElse(reverseRelationOption)
+      forwardRelationOption.orElse(reverseRelationOption.map(_.resourceName))
     } else {
       None
     }
@@ -75,7 +74,8 @@ object FieldBuilder extends StrictLogging {
 
       // Related resource in a list
       case (Some(relatedResourceName), _: ArrayDataSchema) =>
-        NaptimePaginatedResourceField.build(schemaMetadata, relatedResourceName, fieldName)
+        val fieldRelation = FieldRelation(forwardRelationOption, reverseRelationOption)
+        NaptimePaginatedResourceField.build(schemaMetadata, relatedResourceName, fieldName, None, fieldRelation)
           .getOrElse {
             buildField(schemaMetadata, field, namespace, fieldNameOverride, followRelations = false)
           }

--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/FieldBuilder.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/FieldBuilder.scala
@@ -25,6 +25,8 @@ import com.typesafe.scalalogging.StrictLogging
 import org.coursera.courier.templates.DataTemplates.DataConversion
 import org.coursera.naptime.Types.Relations
 import org.coursera.naptime.ari.graphql.SangriaGraphQlContext
+import org.coursera.naptime.ari.graphql.schema.NaptimePaginatedResourceField.ForwardRelation
+import org.coursera.naptime.ari.graphql.schema.NaptimePaginatedResourceField.ReverseRelation
 import org.coursera.naptime.ari.graphql.types.NaptimeTypes
 import org.coursera.naptime.schema.ReverseRelationAnnotation
 import sangria.schema.BooleanType
@@ -74,8 +76,10 @@ object FieldBuilder extends StrictLogging {
 
       // Related resource in a list
       case (Some(relatedResourceName), _: ArrayDataSchema) =>
-        val fieldRelation = FieldRelation(forwardRelationOption, reverseRelationOption)
-        NaptimePaginatedResourceField.build(schemaMetadata, relatedResourceName, fieldName, None, fieldRelation)
+        val fieldRelation = forwardRelationOption.map(ForwardRelation)
+          .orElse(reverseRelationOption.map(ReverseRelation))
+        NaptimePaginatedResourceField
+          .build(schemaMetadata, relatedResourceName, fieldName, None, fieldRelation)
           .getOrElse {
             buildField(schemaMetadata, field, namespace, fieldNameOverride, followRelations = false)
           }

--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/FieldBuilder.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/FieldBuilder.scala
@@ -54,9 +54,10 @@ object FieldBuilder extends StrictLogging {
       fieldNameOverride: Option[String] = None): Field[SangriaGraphQlContext, DataMap] = {
     type ResolverType = Context[SangriaGraphQlContext, DataMap] => Value[SangriaGraphQlContext, Any]
 
-    val forwardRelationOption = field.getProperties.asScala.get(Relations.PROPERTY_NAME).map(_.toString)
-    val reverseRelationOption = field.getProperties.asScala.get(Relations.REVERSE_PROPERTY_NAME)
-      .map(dataMap => ReverseRelationAnnotation(dataMap.asInstanceOf[DataMap], DataConversion.SetReadOnly))
+    val fieldProperties = field.getProperties.asScala
+    val forwardRelationOption = fieldProperties.get(Relations.PROPERTY_NAME).map(_.toString)
+    val reverseRelationOption = fieldProperties.get(Relations.REVERSE_PROPERTY_NAME)
+      .map(d => ReverseRelationAnnotation(d.asInstanceOf[DataMap], DataConversion.SetReadOnly))
       .map(_.resourceName)
 
     val relatedResourceOption = forwardRelationOption.orElse(reverseRelationOption)

--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/FieldBuilder.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/FieldBuilder.scala
@@ -22,8 +22,11 @@ import com.linkedin.data.schema.validation.RequiredMode
 import com.linkedin.data.schema.validation.ValidateDataAgainstSchema
 import com.linkedin.data.schema.validation.ValidationOptions
 import com.typesafe.scalalogging.StrictLogging
+import org.coursera.courier.templates.DataTemplates.DataConversion
+import org.coursera.naptime.Types.Relations
 import org.coursera.naptime.ari.graphql.SangriaGraphQlContext
 import org.coursera.naptime.ari.graphql.types.NaptimeTypes
+import org.coursera.naptime.schema.ReverseRelationAnnotation
 import sangria.schema.BooleanType
 import sangria.schema.Context
 import sangria.schema.Field
@@ -51,7 +54,12 @@ object FieldBuilder extends StrictLogging {
       fieldNameOverride: Option[String] = None): Field[SangriaGraphQlContext, DataMap] = {
     type ResolverType = Context[SangriaGraphQlContext, DataMap] => Value[SangriaGraphQlContext, Any]
 
-    val relatedResourceOption = field.getProperties.asScala.get("related").map(_.toString)
+    val forwardRelationOption = field.getProperties.asScala.get(Relations.PROPERTY_NAME).map(_.toString)
+    val reverseRelationOption = field.getProperties.asScala.get(Relations.REVERSE_PROPERTY_NAME)
+      .map(dataMap => ReverseRelationAnnotation(dataMap.asInstanceOf[DataMap], DataConversion.SetReadOnly))
+      .map(_.resourceName)
+
+    val relatedResourceOption = forwardRelationOption.orElse(reverseRelationOption)
 
     val fieldName = fieldNameOverride.getOrElse(field.getName)
 

--- a/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/SangriaGraphQlParserTest.scala
+++ b/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/SangriaGraphQlParserTest.scala
@@ -323,6 +323,7 @@ class SangriaGraphQlParserTest extends AssertionsForJUnit {
           name = "getAll",
           alias = None,
           args = Set(("limit", JsNumber(10))),
+          typeCondition = Some("CoursesV1Resource"),
           selections = List(
             RequestField(
               name = "id",
@@ -462,7 +463,8 @@ class SangriaGraphQlParserTest extends AssertionsForJUnit {
                   name = "id",
                   alias = None,
                   args = Set.empty,
-                  selections = List.empty))))))))
+                  selections = List.empty,
+                  typeCondition = Some("InstructorsV1")))))))))
     assert(response.get === expectedRequest)
   }
 
@@ -523,6 +525,55 @@ class SangriaGraphQlParserTest extends AssertionsForJUnit {
               alias = None,
               args = Set.empty,
               selections = List.empty))))))
+    assert(response.get === expectedRequest)
+  }
+
+  @Test
+  def parseUnion(): Unit = {
+    val query =
+      """
+        query EmptyQuery($limit: Int!) {
+          CoursesV1Resource {
+            getAll(limit: $limit) {
+              ... on UnionTypeOne {
+                id
+                name
+              }
+              ... on UnionTypeTwo {
+                description
+              }
+            }
+          }
+        }
+      """
+    val variables = Json.obj()
+    val response = SangriaGraphQlParser.parse(query, variables, requestHeader)
+    val expectedRequest = Request(requestHeader, immutable.Seq(
+      TopLevelRequest(
+        ResourceName("courses", 1),
+        RequestField(
+          name = "getAll",
+          alias = None,
+          args = Set(("limit", JsNull)),
+          selections = List(
+            RequestField(
+              name = "id",
+              alias = None,
+              args = Set.empty,
+              selections = List.empty,
+              typeCondition = Some("UnionTypeOne")),
+            RequestField(
+              name = "name",
+              alias = None,
+              args = Set.empty,
+              selections = List.empty,
+              typeCondition = Some("UnionTypeOne")),
+            RequestField(
+              name = "description",
+              alias = None,
+              args = Set.empty,
+              selections = List.empty,
+              typeCondition = Some("UnionTypeTwo")))))))
     assert(response.get === expectedRequest)
   }
 

--- a/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/models.scala
+++ b/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/models.scala
@@ -19,12 +19,12 @@ object Models {
       Handler(
         kind = HandlerKind.GET,
         name = "get",
-        parameters = List(Parameter(name = "id", `type` = "Integer", attributes = List.empty)),
+        parameters = List(Parameter(name = "id", `type` = "String", attributes = List.empty)),
         attributes = List.empty),
       Handler(
         kind = HandlerKind.MULTI_GET,
         name = "multiGet",
-        parameters = List(Parameter(name = "ids", `type` = "List[Integer]", attributes = List.empty)),
+        parameters = List(Parameter(name = "ids", `type` = "List[String]", attributes = List.empty)),
         attributes = List.empty),
       Handler(
         kind = HandlerKind.GET_ALL,
@@ -41,7 +41,22 @@ object Models {
     keyType = "",
     valueType = "",
     mergedType = "org.coursera.naptime.ari.graphql.models.MergedInstructor",
-    handlers = List.empty,
+    handlers = List(
+      Handler(
+        kind = HandlerKind.GET,
+        name = "get",
+        parameters = List(Parameter(name = "id", `type` = "String", attributes = List.empty)),
+        attributes = List.empty),
+      Handler(
+        kind = HandlerKind.MULTI_GET,
+        name = "multiGet",
+        parameters = List(Parameter(name = "ids", `type` = "List[String]", attributes = List.empty)),
+        attributes = List.empty),
+      Handler(
+        kind = HandlerKind.GET_ALL,
+        name = "getAll",
+        parameters = List.empty,
+        attributes = List.empty)),
     className = "",
     attributes = List.empty)
 

--- a/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/schema/NaptimePaginatedResourceFieldTest.scala
+++ b/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/schema/NaptimePaginatedResourceFieldTest.scala
@@ -40,16 +40,16 @@ class NaptimePaginatedResourceFieldTest extends AssertionsForJUnit with MockitoS
   def computeComplexity(): Unit = {
     val field = NaptimePaginatedResourceField.build(schemaMetadata, resourceName, fieldName)
 
-    val limitTen = field.complexity.get.apply(context, Args(Map("limit" -> 10)), 1)
+    val limitTen = field.get.complexity.get.apply(context, Args(Map("limit" -> 10)), 1)
     assert(limitTen === 1 * NaptimePaginatedResourceField.COMPLEXITY_COST * 1)
 
-    val limitFifty = field.complexity.get.apply(context, Args(Map("limit" -> 50)), 1)
+    val limitFifty = field.get.complexity.get.apply(context, Args(Map("limit" -> 50)), 1)
     assert(limitFifty === 5 * NaptimePaginatedResourceField.COMPLEXITY_COST * 1)
 
-    val limitZero = field.complexity.get.apply(context, Args(Map("limit" -> 0)), 1)
+    val limitZero = field.get.complexity.get.apply(context, Args(Map("limit" -> 0)), 1)
     assert(limitZero === 1 * NaptimePaginatedResourceField.COMPLEXITY_COST * 1)
 
-    val childScoreFive = field.complexity.get.apply(context, Args(Map("limit" -> 1)), 5)
+    val childScoreFive = field.get.complexity.get.apply(context, Args(Map("limit" -> 1)), 5)
     assert(childScoreFive === 1 * NaptimePaginatedResourceField.COMPLEXITY_COST * 5)
 
   }

--- a/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/schema/NaptimePaginatedResourceFieldTest.scala
+++ b/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/schema/NaptimePaginatedResourceFieldTest.scala
@@ -39,7 +39,7 @@ class NaptimePaginatedResourceFieldTest extends AssertionsForJUnit with MockitoS
   @Test
   def computeComplexity(): Unit = {
     val field = NaptimePaginatedResourceField.build(
-      schemaMetadata, resourceName, fieldName, None, FieldRelation())
+      schemaMetadata, resourceName, fieldName, None, None)
 
     val limitTen = field.get.complexity.get.apply(context, Args(Map("limit" -> 10)), 1)
     assert(limitTen === 1 * NaptimePaginatedResourceField.COMPLEXITY_COST * 1)

--- a/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/schema/NaptimePaginatedResourceFieldTest.scala
+++ b/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/schema/NaptimePaginatedResourceFieldTest.scala
@@ -38,7 +38,8 @@ class NaptimePaginatedResourceFieldTest extends AssertionsForJUnit with MockitoS
 
   @Test
   def computeComplexity(): Unit = {
-    val field = NaptimePaginatedResourceField.build(schemaMetadata, resourceName, fieldName)
+    val field = NaptimePaginatedResourceField.build(
+      schemaMetadata, resourceName, fieldName, None, FieldRelation())
 
     val limitTen = field.get.complexity.get.apply(context, Args(Map("limit" -> 10)), 1)
     assert(limitTen === 1 * NaptimePaginatedResourceField.COMPLEXITY_COST * 1)

--- a/naptime/src/main/pegasus/org/coursera/naptime/schema/ReverseRelationAnnotation.courier
+++ b/naptime/src/main/pegasus/org/coursera/naptime/schema/ReverseRelationAnnotation.courier
@@ -15,4 +15,6 @@ record ReverseRelationAnnotation {
    */
   arguments: map[string, string]
 
+  relationType: enum RelationType { FINDER, MULTI_GET }
+
 }

--- a/naptime/src/main/pegasus/org/coursera/naptime/schema/ReverseRelationAnnotation.courier
+++ b/naptime/src/main/pegasus/org/coursera/naptime/schema/ReverseRelationAnnotation.courier
@@ -1,0 +1,18 @@
+namespace org.coursera.naptime.schema
+
+/**
+ * The schema for a reverse-relation annotation.
+ */
+record ReverseRelationAnnotation {
+
+  /**
+   * The name of the resource.
+   */
+  resourceName: string
+
+  /**
+   * Arguments passed along to the reverse relation request
+   */
+  arguments: map[string, string]
+
+}

--- a/naptime/src/main/scala/org/coursera/naptime/Types.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/Types.scala
@@ -111,7 +111,7 @@ object Types extends StrictLogging {
           newField.setRecord(mergedSchema)
 
           val reverseRelatedMap = Map[String, AnyRef](
-            Relations.REVERSE_PROPERTY_NAME -> reverseRelation.toAnnotation().data())
+            Relations.REVERSE_PROPERTY_NAME -> reverseRelation.toAnnotation.data())
           newField.setProperties(reverseRelatedMap.asJava)
 
           val existingFields = mergedSchema.getFields

--- a/naptime/src/main/scala/org/coursera/naptime/Types.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/Types.scala
@@ -18,6 +18,7 @@ package org.coursera.naptime
 
 import java.lang.StringBuilder
 
+import com.linkedin.data.schema.ArrayDataSchema
 import com.linkedin.data.schema.DataSchema
 import com.linkedin.data.schema.Name
 import com.linkedin.data.schema.PrimitiveDataSchema
@@ -26,12 +27,14 @@ import com.linkedin.data.schema.RecordDataSchema.RecordType
 import com.linkedin.data.schema.StringDataSchema
 import com.linkedin.data.schema.TyperefDataSchema
 import com.typesafe.scalalogging.StrictLogging
+
 import scala.collection.JavaConverters._
 
 object Types extends StrictLogging {
 
   object Relations {
     val PROPERTY_NAME = "related"
+    val REVERSE_PROPERTY_NAME = "relatedOn"
   }
 
   @deprecated("Please use the one with fields included", "0.2.4")
@@ -93,6 +96,27 @@ object Types extends StrictLogging {
           val relatedMap = Map[String, AnyRef](
             Relations.PROPERTY_NAME -> relation.identifier)
           field.setProperties((properties ++ relatedMap).asJava)
+      }
+    }
+    for ((name, reverseRelation) <- fields.reverseRelations) {
+      Option(mergedSchema.getField(name)) match {
+        case Some(field) =>
+          logger.warn(s"Fields for resource $typeName tries to add reverse relation on field " +
+            s"'$name', but that field is already defined on the model")
+        case None =>
+          val errorMessageBuilder = new StringBuilder
+          val newField = new RecordDataSchema.Field(new ArrayDataSchema(new StringDataSchema)) // TODO(bryan): fix type here
+          newField.setOptional(false)
+          newField.setName(name, errorMessageBuilder)
+          newField.setRecord(mergedSchema)
+
+          val reverseRelatedMap = Map[String, AnyRef](
+            Relations.REVERSE_PROPERTY_NAME -> reverseRelation.toAnnotation().data())
+          newField.setProperties(reverseRelatedMap.asJava)
+
+          val existingFields = mergedSchema.getFields
+          val newFields = (existingFields.asScala ++ List(newField)).asJava
+          mergedSchema.setFields(newFields, errorMessageBuilder)
       }
     }
     mergedSchema

--- a/naptime/src/main/scala/org/coursera/naptime/ari/engine/EngineHelpers.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/ari/engine/EngineHelpers.scala
@@ -1,0 +1,228 @@
+/*
+ * Copyright 2016 Coursera Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.coursera.naptime.ari.engine
+
+import com.linkedin.data.DataMap
+import com.linkedin.data.element.DataElement
+import com.linkedin.data.it.Builder
+import com.linkedin.data.it.IterationOrder
+import com.linkedin.data.schema.ArrayDataSchema
+import com.linkedin.data.schema.RecordDataSchema
+import com.typesafe.scalalogging.StrictLogging
+import org.coursera.courier.templates.DataTemplates.DataConversion
+import org.coursera.naptime.ResourceName
+import org.coursera.naptime.Types.Relations
+import org.coursera.naptime.ari.RequestField
+import org.coursera.naptime.schema.ReverseRelationAnnotation
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable
+
+
+object EngineHelpers extends StrictLogging {
+
+  /**
+    * Defines a field and selection used in a forward relation
+    * (where model A defines the ids on model B)
+    * @param selection field selection defining arguments, field, and nested selections
+    * @param resourceName resource name to fetch the forward relation from
+    * @param ids ids of the elements on resourceName to fetch
+    */
+  case class ForwardRelatedField(
+      selection: RequestField,
+      resourceName: ResourceName,
+      ids: List[String])
+
+  /**
+    * Defines a field and selection used in a reverse relation
+    * (where resource B defines the matching models to be appended to model A)
+    * @param selection field selection defining arguments, field, and nested selections
+    * @param path path of the dynamic field to receive the ids from the reverse relation
+    * @param element top level element, used for argument interpolation
+    * @param annotation details about the reverse relation (including arguments, etc.)
+    */
+  case class ReverseRelatedField(
+      selection: RequestField,
+      path: Seq[String],
+      element: DataMap,
+      annotation: ReverseRelationAnnotation)
+
+  /**
+    * Get subselection fields from a selection. This filters out all "elements" level fields,
+    * which are used only for pagination and do not describe the data needs of a request.
+    * @param selection input RequestField selection
+    * @return List[RequestField] of subselections, with "elements" levels filtered out
+    */
+  private[engine] def getSelections(selection: RequestField): List[RequestField] = {
+    selection.selections.flatMap { subselection =>
+      if (subselection.name == "elements") {
+        subselection.selections
+      } else {
+        List(subselection)
+      }
+    }
+  }
+
+  /**
+    * Mutates a data map in-place by inserting an element in a field at a specified path.
+    * This allows relations to update a list of IDs anywhere on a map (nested, in unions, etc.)
+    *
+    * @param element top-level element to be updated
+    * @param schema data schema defining the fields on the element
+    * @param path list of strings defining the path to the target element
+    * @param data data to be inserted at the specified path
+    */
+  private[engine] def insertAtPath(
+      element: DataMap,
+      schema: RecordDataSchema,
+      path: Seq[String],
+      data: AnyRef): Unit = {
+    val it = Builder
+      .create(element, schema, IterationOrder.PRE_ORDER)
+      .dataIterator()
+    var dataElement: DataElement = null
+    while ( {
+      dataElement = it.next(); dataElement
+    } != null) {
+      if (dataElement.path.toSeq.map(_.toString) == path.dropRight(1)) {
+        dataElement.getValue.asInstanceOf[DataMap].put(path.last, data)
+      }
+    }
+  }
+
+  /**
+    * Parses an element, using an associated schema and a list of selections from the request,
+    * and returns a list of all forward and reverse relations requested from the model
+    *
+    * @param selection field selection defining arguments, field, and nested selections
+    * @param data list of top-level elements / models returned from a previous request.
+    * @param schema associated RecordDataSchema for the elements returned
+    * @return List of forward and reverse relations from all of the elements in the data
+    */
+  private[engine] def collectRelations(
+      selection: RequestField,
+      data: Iterable[DataMap],
+      schema: RecordDataSchema): (List[ForwardRelatedField], List[ReverseRelatedField]) = {
+
+    val forwardRelations = mutable.Buffer[ForwardRelatedField]()
+    val reverseRelations = mutable.Buffer[ReverseRelatedField]()
+
+    data.foreach { element =>
+      val it = Builder.create(element, schema, IterationOrder.PRE_ORDER).dataIterator()
+      var dataElement: DataElement = null
+      while ( {
+        dataElement = it.next(); dataElement
+      } != null) {
+        val path = dataElement.path.toSeq.map(_.toString)
+        for {
+          selection <- selectionAtPath(selection, path).toList
+          if selection.selections.nonEmpty
+          recordField <- dataElement.getSchema match {
+            case record: RecordDataSchema => record.getFields.asScala
+            case _ => List.empty
+          }
+          fieldSelection <- getSelections(selection).find(_.name == recordField.getName)
+        } yield {
+          forwardRelationForField(recordField).foreach { forwardRelation =>
+            val forwardIds = getFieldValues(recordField, dataElement.getValue.asInstanceOf[DataMap])
+            forwardRelations += ForwardRelatedField(fieldSelection, forwardRelation, forwardIds)
+          }
+
+          reverseRelationForField(recordField).foreach { reverseRelation =>
+            reverseRelations += ReverseRelatedField(
+              selection = fieldSelection,
+              path = path :+ recordField.getName,
+              element = element,
+              annotation = reverseRelation)
+          }
+        }
+      }
+    }
+    (forwardRelations.toList, reverseRelations.toList)
+  }
+
+  /**
+    * Returns an optional ResourceName if the specified field has a forward relation specified
+    * @param field field on the RecordDataSchema to check for forward relations
+    * @return optional ResourceName if forward relation exists, None if no forward relation is set
+    */
+  private[engine] def forwardRelationForField(
+      field: RecordDataSchema.Field): Option[ResourceName] = {
+    Option(field.getProperties.get(Relations.PROPERTY_NAME)).map {
+      case idString: String =>
+        ResourceName.parse(idString).getOrElse {
+          throw new IllegalStateException(s"Could not parse identifier '$idString' " +
+            s"for field '$field'")
+        }
+      case identifier =>
+        throw new IllegalStateException(s"Unexpected type for identifier '$identifier' " +
+          s"for field '$field'")
+    }
+  }
+
+  /**
+    * Returns an ReverseRelationAnnotation if the specified field has a reverse relation specified
+    * @param field field on the RecordDataSchema to check for reverse relations
+    * @return optional ReverseRelationAnnotation if relation exists, None if no relation is set
+    */
+  private[engine] def reverseRelationForField(
+      field: RecordDataSchema.Field): Option[ReverseRelationAnnotation] = {
+    Option(field.getProperties.get(Relations.REVERSE_PROPERTY_NAME)).map {
+      case dataMap: DataMap => ReverseRelationAnnotation(dataMap, DataConversion.SetReadOnly)
+    }
+  }
+
+  private[engine] def getFieldValues(
+      field: RecordDataSchema.Field,
+      element: DataMap): List[String] = {
+
+    if (field.getType.getDereferencedDataSchema.isPrimitive) {
+      List(element.get(field.getName).toString)
+    } else if (field.getType.getDereferencedDataSchema.isInstanceOf[ArrayDataSchema]) {
+      Option(element.getDataList(field.getName)).map(_.asScala.map(_.toString).toList).getOrElse {
+        logger.debug(s"Field ${field.getName} was not found / was not a data list " +
+          s"in $element for query field $field")
+        List.empty
+      }
+    } else {
+      throw new IllegalStateException(
+        s"Cannot join on an unknown field type '${field.getType.getDereferencedType}' " +
+          s"for field '${field.getName}'")
+    }
+  }
+
+  /**
+    * Recursively parses a list of selections to find a selection given a path
+    * @param selection top-level selection to begin parsing at
+    * @param path list of child selection names to traverse down
+    * @return optional RequestField selection if path is found, None if path is not found
+    */
+  private[engine] def selectionAtPath(
+      selection: RequestField,
+      path: Seq[String]): Option[RequestField] = {
+    if (path.isEmpty) {
+      // Selection matching path is found
+      Some(selection)
+    } else {
+      getSelections(selection).find(_.name == path.head.replaceAll("\\.", "_"))
+        .flatMap { childSelection =>
+          selectionAtPath(childSelection, path.tail)
+        }
+    }
+  }
+
+}

--- a/naptime/src/main/scala/org/coursera/naptime/ari/engine/EngineImpl.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/ari/engine/EngineImpl.scala
@@ -231,7 +231,7 @@ class EngineImpl @Inject() (
           alias = None,
 
           // TODO: pass through original request fields for pagination
-          args = Set("ids" -> JsString(multiGetIds)),
+          args = Set("ids" -> JsString(multiGetIds)) ++ requestField.args,
 
           selections = requestField.selections))
       executeTopLevelRequest(requestHeader, relatedTopLevelRequest).map { response =>

--- a/naptime/src/main/scala/org/coursera/naptime/ari/engine/EngineImpl.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/ari/engine/EngineImpl.scala
@@ -276,7 +276,7 @@ class EngineImpl @Inject() (
         selection = RequestField(
           name = "reverseRelation",
           alias = None,
-          args = interpolatedArguments,
+          args = interpolatedArguments ++ requestField.args,
           selections = requestField.selections))
       executeTopLevelRequest(requestHeader, relatedTopLevelRequest).map { response =>
         topLevelElement.get("id") -> Response(

--- a/naptime/src/main/scala/org/coursera/naptime/ari/engine/EngineImpl.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/ari/engine/EngineImpl.scala
@@ -18,10 +18,12 @@ package org.coursera.naptime.ari.engine
 
 import javax.inject.Inject
 
+import com.linkedin.data.DataList
 import com.linkedin.data.DataMap
 import com.linkedin.data.schema.ArrayDataSchema
 import com.linkedin.data.schema.RecordDataSchema
 import com.typesafe.scalalogging.StrictLogging
+import org.coursera.courier.templates.DataTemplates.DataConversion
 import org.coursera.naptime.ResourceName
 import org.coursera.naptime.Types.Relations
 import org.coursera.naptime.ari.EngineApi
@@ -32,13 +34,16 @@ import org.coursera.naptime.ari.Response
 import org.coursera.naptime.ari.ResponseMetrics
 import org.coursera.naptime.ari.SchemaProvider
 import org.coursera.naptime.ari.TopLevelRequest
+import org.coursera.naptime.schema.ReverseRelationAnnotation
 import play.api.libs.json.JsString
+import play.api.libs.json.JsValue
 import play.api.mvc.RequestHeader
 
 import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
+import scala.util.matching.Regex
 
 class EngineImpl @Inject() (
     schemaProvider: SchemaProvider,
@@ -92,29 +97,92 @@ class EngineImpl @Inject() (
         val additionalResponses = for {
           nestedField <- nestedLookups
           field <- Option(mergedType.getField(nestedField.name)).toList
-          relatedResource <- relatedResourceForField(field, mergedType).toList
         } yield {
-          val multiGetIds = computeMultiGetIds(topLevelData, nestedField, field)
+          val forwardRelation = relatedResourceForField(field, mergedType)
+          val reverseRelation = reverseRelationForField(field, mergedType)
+          (forwardRelation, reverseRelation) match {
+            case (Some(resourceName), None) =>
+              val multiGetIds = computeMultiGetIds(topLevelData, nestedField, field)
 
-          val relatedTopLevelRequest = TopLevelRequest(
-            resource = relatedResource,
-            selection = RequestField(
-              name = "multiGet",
-              alias = None,
-              args = Set(
-                "ids" ->
-                  JsString(multiGetIds)), // TODO: pass through original request fields for pagination
-              selections = nestedField.selections))
-          executeTopLevelRequest(requestHeader, relatedTopLevelRequest).map { response =>
-            // Exclude the top level ids in the response.
-            Response(
-              topLevelResponses = Map.empty,
-              data = response.data,
-              metrics = response.metrics)
+              val relatedTopLevelRequest = TopLevelRequest(
+                resource = resourceName,
+                selection = RequestField(
+                  name = "multiGet",
+                  alias = None,
+                  args = Set(
+                    "ids" ->
+                      JsString(multiGetIds)), // TODO: pass through original request fields for pagination
+                  selections = nestedField.selections))
+              executeTopLevelRequest(requestHeader, relatedTopLevelRequest).map { response =>
+                // Exclude the top level ids in the response.
+                Response(
+                  topLevelResponses = Map.empty,
+                  data = response.data,
+                  metrics = response.metrics)
+              }.map { response =>
+                FieldRelationResponse(field, Map.empty, List(response))
+              }
+            case (None, Some(reverse)) =>
+              val resourceName = ResourceName.parse(reverse.resourceName).getOrElse {
+                throw new IllegalStateException(s"Could not parse identifier " +
+                  s"'${reverse.resourceName}' for field '$field' in merged type $mergedType")
+              }
+              val responses = topLevelData.map { topLevelElement =>
+                val InterpolationRegex = new Regex("""\$([a-zA-Z0-9_]+)""", "variableName")
+                val interpolatedArguments: Set[(String, JsValue)] = reverse.arguments
+                  .mapValues { value =>
+                    InterpolationRegex.replaceAllIn(value, { regexMatch =>
+                      val variableName = regexMatch.group("variableName")
+                      Option(topLevelElement.get(variableName)).map(_.toString).getOrElse(variableName)
+                    })
+                  }
+                  .mapValues(value => JsString(value))
+                  .toSet
+                val relatedTopLevelRequest = TopLevelRequest(
+                  resource = resourceName,
+                  selection = RequestField(
+                    name = "reverseRelation",
+                    alias = None,
+                    args = interpolatedArguments,
+                    selections = nestedField.selections))
+                executeTopLevelRequest(requestHeader, relatedTopLevelRequest).map { response =>
+                  topLevelElement.get("id") -> Response(
+                    topLevelResponses = Map.empty,
+                    data = response.data,
+                    metrics = response.metrics)
+                }
+              }
+              Future.sequence(responses).map { responseIdPairs =>
+                val idMap = responseIdPairs.toMap.flatMap { case (id, response) =>
+                  response.data.headOption.map { case (resourceName, data) =>
+                    id -> data.keys.toList
+                  }
+                }
+                FieldRelationResponse(field, idMap, responseIdPairs.map(_._2).toList)
+              }
+
+            case (Some(forward), Some(reverse)) =>
+              throw new RuntimeException(
+                s"Both forward and reverse relations cannot be defined on ${field.getName}")
+            case (None, None) => Future.successful(FieldRelationResponse(field, Map.empty, List.empty))
           }
         }
-        Future.sequence(additionalResponses).map { additionalResponses =>
-          additionalResponses.foldLeft(topLevelResponseWithMetrics)(_ ++ _)
+        Future.sequence(additionalResponses).map { fieldResponses =>
+          val mutableTopLevelData = topLevelData
+            .map(_.clone())
+            .map(data => data.get("id") -> data)
+            .toMap
+          fieldResponses.map { fieldRelationResponse =>
+            mutableTopLevelData.foreach { case (id, data) =>
+              val ids = fieldRelationResponse.idMap.getOrElse(id, List.empty)
+              data.put(fieldRelationResponse.field.getName, new DataList(ids.asJava))
+            }
+            fieldRelationResponse.responses
+          }
+          val updatedData = topLevelResponseWithMetrics.data + (topLevelRequest.resource -> mutableTopLevelData)
+          val responseWithUpdatedData = topLevelResponseWithMetrics.copy(data = updatedData)
+          val additionalResponses = fieldResponses.flatMap(_.responses)
+          additionalResponses.foldLeft(responseWithUpdatedData)(_ ++ _)
         }
       }.getOrElse {
         logger.error(s"No merged type found for resource ${topLevelRequest.resource}. Skipping automatic inclusions.")
@@ -142,6 +210,13 @@ class EngineImpl @Inject() (
     }
   }
 
+  private[this] def reverseRelationForField(field: RecordDataSchema.Field, mergedType: RecordDataSchema): Option[ReverseRelationAnnotation] = {
+    Option(field.getProperties.get(Relations.REVERSE_PROPERTY_NAME)).map {
+      case dataMap: DataMap =>
+        ReverseRelationAnnotation(dataMap, DataConversion.SetReadOnly)
+    }
+  }
+
   private[this] def computeMultiGetIds(
       topLevelData: Iterable[DataMap],
       nestedField: RequestField,
@@ -163,4 +238,9 @@ class EngineImpl @Inject() (
     }.toSet.map[String, Set[String]](_.toString).mkString(",") // TODO: escape appropriately.
   }
 }
+
+case class FieldRelationResponse(
+    field: RecordDataSchema.Field,
+    idMap: Map[AnyRef, List[AnyRef]],
+    responses: List[Response])
 

--- a/naptime/src/main/scala/org/coursera/naptime/ari/engine/EngineImpl.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/ari/engine/EngineImpl.scala
@@ -132,7 +132,7 @@ class EngineImpl @Inject() (
     }.getOrElse {
       logger.error(s"No merged type found for resource ${topLevelRequest.resource}. " +
         s"Skipping automatic inclusions.")
-      Future.successful(Response.empty)
+      Future.successful(topLevelResponse)
     }
   }
 

--- a/naptime/src/main/scala/org/coursera/naptime/ari/models.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/ari/models.scala
@@ -165,8 +165,9 @@ case class Response(
           case (Some(dm), None) => dm
           case (None, Some(dm)) => dm
           case (Some(l), Some(r)) =>
-            l.putAll(r)
-            l
+            val mutableL = l.clone()
+            mutableL.putAll(r)
+            mutableL
         }
         key -> merged
       }.toMap

--- a/naptime/src/main/scala/org/coursera/naptime/ari/models.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/ari/models.scala
@@ -122,7 +122,8 @@ case class RequestField(
   name: String,
   alias: Option[String],
   args: Set[(String, JsValue)], // TODO: Should JsValue be a specific ARI type?
-  selections: List[RequestField])
+  selections: List[RequestField],
+  typeCondition: Option[String] = None)
 
 case class ResponseMetrics(
   numRequests: Int = 0,

--- a/naptime/src/main/scala/org/coursera/naptime/models.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/models.scala
@@ -344,7 +344,7 @@ sealed case class Fields[T](
   }
 
   def withReverseRelations(newRelations: Map[String, ReverseRelation[_]]): Fields[T] = {
-    val intersection = newRelations.keySet.intersect(relations.keySet)
+    val intersection = newRelations.keySet.intersect(reverseRelations.keySet)
     require(intersection.isEmpty, s"Duplicate relations provided for: $intersection")
     copy(reverseRelations = reverseRelations ++ newRelations)
   }

--- a/naptime/src/main/scala/org/coursera/naptime/models.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/models.scala
@@ -18,6 +18,7 @@ package org.coursera.naptime
 
 import com.linkedin.data.DataMap
 import org.coursera.naptime.QueryStringParser.NaptimeParseError
+import org.coursera.naptime.schema.RelationType
 import org.coursera.naptime.schema.ReverseRelationAnnotation
 import play.api.http.Status
 import play.api.i18n.Lang
@@ -593,6 +594,20 @@ private[naptime] object QueryStringParser extends RegexParsers {
     parse(includesAllContent, input)
 }
 
-case class ReverseRelation[KeyType](resourceName: ResourceName, arguments: Map[String, String]) {
-  def toAnnotation() = ReverseRelationAnnotation(resourceName.identifier, arguments)
+trait ReverseRelation[KeyType] {
+  val resourceName: ResourceName
+  val arguments: Map[String, String]
+
+  def toAnnotation: ReverseRelationAnnotation
+}
+
+case class FinderReverseRelation[KeyType](
+    resourceName: ResourceName,
+    finderName: String,
+    arguments: Map[String, String]) extends ReverseRelation[KeyType] {
+
+  def toAnnotation: ReverseRelationAnnotation = {
+    val mergedArguments = arguments + ("q" -> finderName)
+    ReverseRelationAnnotation(resourceName.identifier, mergedArguments, RelationType.FINDER)
+  }
 }

--- a/naptime/src/test/scala/org/coursera/naptime/ari/engine/EngineImplTest.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/ari/engine/EngineImplTest.scala
@@ -771,6 +771,18 @@ object EngineImplTest {
     customOutputBody = None,
     attributes = List.empty)
 
+  val MULTIGET_HANDLER = Handler(
+    kind = HandlerKind.MULTI_GET,
+    name = "multiGet",
+    parameters = List(Parameter(
+      name = "ids",
+      `type` = "List[int]",
+      attributes = List.empty,
+      default = None)),
+    inputBody = None,
+    customOutputBody = None,
+    attributes = List.empty)
+
   val COURSES_RESOURCE_ID = ResourceName("courses", 1)
   val COURSES_RESOURCE = Resource(
     kind = ResourceKind.COLLECTION,
@@ -780,7 +792,7 @@ object EngineImplTest {
     keyType = "string",
     valueType = "org.coursera.naptime.test.Course",
     mergedType = MergedCourse.SCHEMA.getFullName,
-    handlers = List(GET_HANDLER),
+    handlers = List(GET_HANDLER, MULTIGET_HANDLER),
     className = "org.coursera.naptime.test.CoursesResource",
     attributes = List.empty)
 
@@ -793,7 +805,7 @@ object EngineImplTest {
     keyType = "string",
     valueType = "org.coursera.naptime.test.Instructor",
     mergedType = MergedInstructor.SCHEMA.getFullName,
-    handlers = List(GET_HANDLER),
+    handlers = List(GET_HANDLER, MULTIGET_HANDLER),
     className = "org.coursera.naptime.test.InstructorsResource",
     attributes = List.empty)
 

--- a/naptime/src/test/scala/org/coursera/naptime/ari/engine/EngineImplTest.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/ari/engine/EngineImplTest.scala
@@ -106,9 +106,15 @@ class EngineImplTest extends AssertionsForJUnit with ScalaFutures with MockitoSu
   when(instructorRouterBuilder.resourceClass()).thenReturn(
     classOf[InstructorsResource].asInstanceOf[Class[instructorRouterBuilder.ResourceClass]])
 
+  val partnerRouterBuilder = mock[ResourceRouterBuilder]
+  when(partnerRouterBuilder.schema).thenReturn(PARTNERS_RESOURCE)
+  when(partnerRouterBuilder.types).thenReturn(extraTypes)
+  when(partnerRouterBuilder.resourceClass()).thenReturn(
+    classOf[PartnersResource].asInstanceOf[Class[partnerRouterBuilder.ResourceClass]])
+
   val injector = mock[Injector]
   val schemaProvider =
-    new LocalSchemaProvider(NaptimeRoutes(injector, Set(courseRouterBuilder, instructorRouterBuilder)))
+    new LocalSchemaProvider(NaptimeRoutes(injector, Set(courseRouterBuilder, instructorRouterBuilder, partnerRouterBuilder)))
   val engine = new EngineImpl(schemaProvider, fetcherApi)
 
   @Test
@@ -461,6 +467,8 @@ class EngineImplTest extends AssertionsForJUnit with ScalaFutures with MockitoSu
       Future.successful(fetcherResponseInstructors))
 
     val result = engine.execute(request).futureValue
+
+    verify(fetcherApi, times(3)).data(any())
 
     assert(1 === result.topLevelResponses.size, s"Result: $result")
     assert(result.topLevelResponses.contains(request.topLevelRequests.head))

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.4.9"
+version in ThisBuild := "0.4.11"


### PR DESCRIPTION
While forward relations are very useful in a majority of cases (i.e. courses -> instructors, where the course model has an instructorId on it), there are some cases where a relation is necessary where the first model doesn't have any reference to the second. For instance, while a Membership model has a CourseId available on it, the Course model has no reference to all of the memberships available.

In order to create this course -> membership relationship though, we can dynamically fetch the relationship via a query to the membership resource, which, given information about the course, can return a list of memberships + ids for the relationship. This is referred to as a "reverse relationship", where the relationship data is stored on the related model.

These relationships are defined in the Naptime resource (via the `Fields` attribute), like so:
```lang=scala
override implicit lazy val val Fields = Fields
  .withReverseRelations(
    "memberships" -> ReverseRelation[MembershipId](
      resourceName = ResourceNames.membershipResourceName,
      arguments = Map(
        "q" -> "meByCourse",
        "courseId" -> "$id",
        "showHidden" -> "true")))
```

The `$id` string is treated like string interpolation, and will be replaced with the value of the "id" field on the fetched course.

During execution, the engine will make the API call as described on the relationship (appending all interpolated arguments listed), and will make that response available. It will also create a new dynamic field on the original model (in this case, Course), with the ids of the related resources for easier traversal / interop with forward relations.

PTAL @yifan-coursera  -- let me know if you want to go over this one in person.

And if you're still interested, cc @saeta