### PR TITLE
Add arguments from multiget handlers on forward relations

### DIFF
--- a/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/models.scala
+++ b/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/models.scala
@@ -19,12 +19,12 @@ object Models {
       Handler(
         kind = HandlerKind.GET,
         name = "get",
-        parameters = List(Parameter(name = "id", `type` = "Integer", attributes = List.empty)),
+        parameters = List(Parameter(name = "id", `type` = "String", attributes = List.empty)),
         attributes = List.empty),
       Handler(
         kind = HandlerKind.MULTI_GET,
         name = "multiGet",
-        parameters = List(Parameter(name = "ids", `type` = "List[Integer]", attributes = List.empty)),
+        parameters = List(Parameter(name = "ids", `type` = "List[String]", attributes = List.empty)),
         attributes = List.empty),
       Handler(
         kind = HandlerKind.GET_ALL,
@@ -41,7 +41,22 @@ object Models {
     keyType = "",
     valueType = "",
     mergedType = "org.coursera.naptime.ari.graphql.models.MergedInstructor",
-    handlers = List.empty,
+    handlers = List(
+      Handler(
+        kind = HandlerKind.GET,
+        name = "get",
+        parameters = List(Parameter(name = "id", `type` = "String", attributes = List.empty)),
+        attributes = List.empty),
+      Handler(
+        kind = HandlerKind.MULTI_GET,
+        name = "multiGet",
+        parameters = List(Parameter(name = "ids", `type` = "List[String]", attributes = List.empty)),
+        attributes = List.empty),
+      Handler(
+        kind = HandlerKind.GET_ALL,
+        name = "getAll",
+        parameters = List.empty,
+        attributes = List.empty)),
     className = "",
     attributes = List.empty)
 

--- a/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/schema/NaptimePaginatedResourceFieldTest.scala
+++ b/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/schema/NaptimePaginatedResourceFieldTest.scala
@@ -40,16 +40,16 @@ class NaptimePaginatedResourceFieldTest extends AssertionsForJUnit with MockitoS
   def computeComplexity(): Unit = {
     val field = NaptimePaginatedResourceField.build(schemaMetadata, resourceName, fieldName)
 
-    val limitTen = field.complexity.get.apply(context, Args(Map("limit" -> 10)), 1)
+    val limitTen = field.get.complexity.get.apply(context, Args(Map("limit" -> 10)), 1)
     assert(limitTen === 1 * NaptimePaginatedResourceField.COMPLEXITY_COST * 1)
 
-    val limitFifty = field.complexity.get.apply(context, Args(Map("limit" -> 50)), 1)
+    val limitFifty = field.get.complexity.get.apply(context, Args(Map("limit" -> 50)), 1)
     assert(limitFifty === 5 * NaptimePaginatedResourceField.COMPLEXITY_COST * 1)
 
-    val limitZero = field.complexity.get.apply(context, Args(Map("limit" -> 0)), 1)
+    val limitZero = field.get.complexity.get.apply(context, Args(Map("limit" -> 0)), 1)
     assert(limitZero === 1 * NaptimePaginatedResourceField.COMPLEXITY_COST * 1)
 
-    val childScoreFive = field.complexity.get.apply(context, Args(Map("limit" -> 1)), 5)
+    val childScoreFive = field.get.complexity.get.apply(context, Args(Map("limit" -> 1)), 5)
     assert(childScoreFive === 1 * NaptimePaginatedResourceField.COMPLEXITY_COST * 5)
 
   }

--- a/naptime/src/main/scala/org/coursera/naptime/ari/engine/EngineImpl.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/ari/engine/EngineImpl.scala
@@ -101,9 +101,7 @@ class EngineImpl @Inject() (
             selection = RequestField(
               name = "multiGet",
               alias = None,
-              args = Set(
-                "ids" ->
-                  JsString(multiGetIds)), // TODO: pass through original request fields for pagination
+              args = Set("ids" -> JsString(multiGetIds)) ++ nestedField.args,
               selections = nestedField.selections))
           executeTopLevelRequest(requestHeader, relatedTopLevelRequest).map { response =>
             // Exclude the top level ids in the response.

--- a/naptime/src/test/scala/org/coursera/naptime/ari/engine/EngineImplTest.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/ari/engine/EngineImplTest.scala
@@ -771,6 +771,18 @@ object EngineImplTest {
     customOutputBody = None,
     attributes = List.empty)
 
+  val MULTIGET_HANDLER = Handler(
+    kind = HandlerKind.MULTI_GET,
+    name = "multiGet",
+    parameters = List(Parameter(
+      name = "ids",
+      `type` = "List[int]",
+      attributes = List.empty,
+      default = None)),
+    inputBody = None,
+    customOutputBody = None,
+    attributes = List.empty)
+
   val COURSES_RESOURCE_ID = ResourceName("courses", 1)
   val COURSES_RESOURCE = Resource(
     kind = ResourceKind.COLLECTION,
@@ -780,7 +792,7 @@ object EngineImplTest {
     keyType = "string",
     valueType = "org.coursera.naptime.test.Course",
     mergedType = MergedCourse.SCHEMA.getFullName,
-    handlers = List(GET_HANDLER),
+    handlers = List(GET_HANDLER, MULTIGET_HANDLER),
     className = "org.coursera.naptime.test.CoursesResource",
     attributes = List.empty)
 
@@ -793,7 +805,7 @@ object EngineImplTest {
     keyType = "string",
     valueType = "org.coursera.naptime.test.Instructor",
     mergedType = MergedInstructor.SCHEMA.getFullName,
-    handlers = List(GET_HANDLER),
+    handlers = List(GET_HANDLER, MULTIGET_HANDLER),
     className = "org.coursera.naptime.test.InstructorsResource",
     attributes = List.empty)
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.4.9"
+version in ThisBuild := "0.4.10"


### PR DESCRIPTION
When we have a partner -> course relation, we need to support the query parameters available on the course resource's multiget (i.e. showHidden) on the relation too. This PR refactors some things around parsing arguments and adds these arguments to all connections. It also changes the schema building behavior to fall back to the original id for related resources if the resource doesn't have a multiGet handler available.

PTAL @yifan-coursera, cc @jnwng (and @saeta because I know you still care ❤️ )