### PR TITLE
Fix enum fallback

### DIFF
--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/NaptimeEnumField.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/NaptimeEnumField.scala
@@ -25,7 +25,7 @@ object NaptimeEnumField {
     val enumSymbols = if (enumDataSchema.getSymbols.asScala.nonEmpty) {
       enumDataSchema.getSymbols.asScala.toList
     } else {
-      List("$UNKNOWN")
+      List("UNKNOWN")
     }
     EnumType(
       name = FieldBuilder.formatName(enumDataSchema.getFullName),

--- a/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/schema/NaptimeEnumFieldTest.scala
+++ b/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/schema/NaptimeEnumFieldTest.scala
@@ -45,7 +45,7 @@ class NaptimeEnumFieldTest extends AssertionsForJUnit with MockitoSugar {
   @Test
   def build_EmptyEnum() = {
     val values = List()
-    val expectedValues = List("$UNKNOWN")
+    val expectedValues = List("UNKNOWN")
     val enum = buildEnumDataSchema(values)
     val field = NaptimeEnumField.build(enum, "myField")
     assert(field.fieldType.asInstanceOf[EnumType[String]].values.map(_.name) === expectedValues)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.4.12"
+version in ThisBuild := "0.4.13"


### PR DESCRIPTION
cc @yifan-coursera and @jnwng:
```Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but "$UNKNOWN" does not.```