### PR TITLE
Fix `start` pagination for non-string fields (i.e. ints)

### DIFF
--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/NaptimePaginatedResourceField.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/NaptimePaginatedResourceField.scala
@@ -130,7 +130,9 @@ object NaptimePaginatedResourceField {
           val allIds = parentElement.getDataList(fieldName).asScala
           val startOption = context.value.parentContext.arg(NaptimePaginationField.startArgument)
           val limit = context.value.parentContext.arg(NaptimePaginationField.limitArgument)
-          val idsWithStart = startOption.map(s => allIds.dropWhile(_ != s)).getOrElse(allIds)
+          val idsWithStart = startOption
+            .map(s => allIds.dropWhile(_.toString != s))
+            .getOrElse(allIds)
           idsWithStart.take(limit)
         }.getOrElse {
           // Top-Level Request

--- a/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/schema/NaptimePaginationFieldTest.scala
+++ b/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/schema/NaptimePaginationFieldTest.scala
@@ -116,6 +116,17 @@ class NaptimePaginationFieldTest extends AssertionsForJUnit with MockitoSugar {
   }
 
   @Test
+  def resolveNestedWithNonStringStart(): Unit = {
+    val model = new DataMap(Map(fieldName -> new DataList(List(1, 2, 3).asJava)).asJava)
+    val context = createContext(
+      resourceContext,
+      ParentContext(createContext(resourceContext, model, Map("limit" -> 1, "start" -> Some("2")))))
+    val resolver = NaptimePaginationField.getResolver(resourceName, fieldName)
+    val paginationData = resolver(context).value
+    assert(paginationData === ResponsePagination(Some("3"), Some(3)))
+  }
+
+  @Test
   def resolveTopLevel(): Unit = {
     val context = createContext(
       resourceContext,

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.4.13"
+version in ThisBuild := "0.4.14"


### PR DESCRIPTION
When the id field is a non-string value, pagination using `start` was broken because it was comparing an int and start value. This just calls toString on the id value to always compare strings

PTAL @jnwng / cc @yifan-coursera 
