### PR TITLE
Add model for multiget reverse relation

### DIFF
--- a/naptime/src/main/scala/org/coursera/naptime/models.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/models.scala
@@ -611,3 +611,12 @@ case class FinderReverseRelation[KeyType](
     ReverseRelationAnnotation(resourceName.identifier, mergedArguments, RelationType.FINDER)
   }
 }
+
+case class MultiGetReverseRelation[KeyType](
+    resourceName: ResourceName,
+    arguments: Map[String, String]) extends ReverseRelation[KeyType] {
+
+  def toAnnotation: ReverseRelationAnnotation = {
+    ReverseRelationAnnotation(resourceName.identifier, arguments, RelationType.MULTI_GET)
+  }
+}


### PR DESCRIPTION
Adds the model to support multiget reverse relations. Note: the engineimpl / schema builder already supported multigets... this was the only thing missing

PTAL @jnwng / cc @yifan-coursera 