### PR TITLE
Handle fake related resources

### DIFF
--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/SangriaGraphQlSchemaBuilder.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/SangriaGraphQlSchemaBuilder.scala
@@ -136,6 +136,10 @@ class SangriaGraphQlSchemaBuilder(
       resourceName = resourceName.identifier,
       fieldName = "get",
       idExtractor = Some(idExtractor))
+      .getOrElse {
+        throw SchemaGenerationException(
+          s"Cannot build field for ${resourceName.identifier} / ${handler.name}")
+      }
 
     field.copy(arguments = arguments ++ field.arguments)
   }

--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/FieldBuilder.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/FieldBuilder.scala
@@ -86,7 +86,11 @@ object FieldBuilder extends StrictLogging {
 
       // Single related resource
       case (Some(relatedResourceName), _) =>
-        NaptimeResourceField.build(schemaMetadata, relatedResourceName, fieldName)
+        NaptimeResourceField
+          .build(schemaMetadata, relatedResourceName, fieldName)
+          .getOrElse {
+            buildField(schemaMetadata, field, namespace, fieldNameOverride, followRelations = false)
+          }
 
       // Passthrough Exempt types (fallback to DataMap)
       case (None, recordDataSchema: RecordDataSchema)

--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/NaptimePaginatedResourceField.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/NaptimePaginatedResourceField.scala
@@ -33,9 +33,10 @@ object NaptimePaginatedResourceField {
       handlerOverride: Option[Handler] = None,
       fieldRelation: Option[FieldRelation]): Option[Field[SangriaGraphQlContext, DataMap]] = {
 
-    val resource = schemaMetadata.getResource(resourceName)
-
-    schemaMetadata.getSchema(resource).flatMap { schema =>
+    (for {
+      resource <- schemaMetadata.getResourceOpt(resourceName)
+      schema <- schemaMetadata.getSchema(resource)
+    } yield {
       val handlerOpt = (handlerOverride, fieldRelation) match {
         case (Some(handler), _) =>
           Some(handler)
@@ -84,7 +85,7 @@ object NaptimePaginatedResourceField {
             }),
           arguments = arguments)
       }
-    }
+    }).flatten
   }
 
   //TODO(bryan): add arguments for pagination in here

--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/NaptimePaginatedResourceField.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/NaptimePaginatedResourceField.scala
@@ -94,7 +94,9 @@ object NaptimePaginatedResourceField {
       resourceName: String,
       fieldName: String): ObjectType[SangriaGraphQlContext, ParentContext] = {
 
-    val resource = schemaMetadata.getResource(resourceName)
+    val resource = schemaMetadata.getResourceOpt(resourceName).getOrElse {
+      throw SchemaGenerationException(s"Cannot find schema for $resourceName")
+    }
     schemaMetadata.getSchema(resource).getOrElse {
       throw SchemaGenerationException(s"Cannot find schema for $resourceName")
     }

--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/NaptimeResourceField.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/NaptimeResourceField.scala
@@ -25,23 +25,25 @@ object NaptimeResourceField {
       schemaMetadata: SchemaMetadata,
       resourceName: String,
       fieldName: String,
-      idExtractor: Option[IdExtractor] = None): Field[SangriaGraphQlContext, DataMap] = {
+      idExtractor: Option[IdExtractor] = None): Option[Field[SangriaGraphQlContext, DataMap]] = {
 
-    val resource = schemaMetadata.getResource(resourceName)
-    val arguments = resource.handlers.find(_.kind == HandlerKind.MULTI_GET).map { handler =>
-      SangriaGraphQlSchemaBuilder
-        .generateHandlerArguments(handler, includePagination = false)
-        .filterNot(_.name == "ids")
-    }.getOrElse(List.empty)
+    schemaMetadata.getResourceOpt(resourceName).map { resource =>
+      val arguments = resource.handlers.find(_.kind == HandlerKind.MULTI_GET).map { handler =>
+        SangriaGraphQlSchemaBuilder
+          .generateHandlerArguments(handler, includePagination = false)
+          .filterNot(_.name == "ids")
+      }.getOrElse(List.empty)
 
-    Field.apply[SangriaGraphQlContext, DataMap, Any, Any](
-      name = fieldName,
-      fieldType = getType(schemaMetadata, resourceName),
-      resolve = getResolver(resourceName, fieldName, idExtractor),
-      arguments = arguments,
-      complexity = Some((ctx, args, childScore) => {
-        COMPLEXITY_COST * childScore
-      }))
+      Field.apply[SangriaGraphQlContext, DataMap, Any, Any](
+        name = fieldName,
+        fieldType = getType(schemaMetadata, resourceName),
+        resolve = getResolver(resourceName, fieldName, idExtractor),
+        arguments = arguments,
+        complexity = Some(
+          (ctx, args, childScore) => {
+            COMPLEXITY_COST * childScore
+          }))
+    }
   }
 
 

--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/SchemaMetadata.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/SchemaMetadata.scala
@@ -17,6 +17,12 @@ case class SchemaMetadata(
     }
   }
 
+  def getResourceOpt(resourceName: String): Option[Resource] = {
+    resources.find { resource =>
+      ResourceName(resource.name, resource.version.getOrElse(0L).toInt).identifier == resourceName
+    }
+  }
+
   def getSchema(resource: Resource): Option[RecordDataSchema] = {
     schemas.get(resource.mergedType).flatMap(Option(_))
   }

--- a/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/schema/NaptimePaginatedResourceFieldTest.scala
+++ b/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/schema/NaptimePaginatedResourceFieldTest.scala
@@ -33,7 +33,7 @@ class NaptimePaginatedResourceFieldTest extends AssertionsForJUnit with MockitoS
 
   val schemaMetadata = mock[SchemaMetadata]
   val resource = Models.courseResource
-  when(schemaMetadata.getResource(resourceName)).thenReturn(resource)
+  when(schemaMetadata.getResourceOpt(resourceName)).thenReturn(Some(resource))
   when(schemaMetadata.getSchema(resource)).thenReturn(Some(null))
 
   @Test


### PR DESCRIPTION
Some resources manually construct a related resource to append extra data. However, these related resources don’t actually exist, which was causing the schema builder to break.

This changes things to optionally fall back to the original field type if the resource doesn’t exist

PTAL @jnwng / cc @yifan-coursera 