### PR TITLE
Add a metrics collector to pull execution time + parallelize batching

### DIFF
--- a/examples/src/main/scala/ResourceModule.scala
+++ b/examples/src/main/scala/ResourceModule.scala
@@ -9,6 +9,8 @@ import org.coursera.naptime.ari.engine.LoggingEngineMetricsCollector
 import org.coursera.naptime.ari.fetcher.LocalFetcher
 import org.coursera.naptime.ari.graphql.DefaultGraphqlSchemaProvider
 import org.coursera.naptime.ari.graphql.GraphqlSchemaProvider
+import org.coursera.naptime.ari.graphql.controllers.GraphQlControllerMetricsCollector
+import org.coursera.naptime.ari.graphql.controllers.LoggingGraphQlControllerMetricsCollector
 import org.coursera.naptime.ari.graphql.controllers.filters.ComplexityFilterConfiguration
 import org.coursera.naptime.ari.graphql.controllers.filters.DefaultFilters
 import org.coursera.naptime.ari.graphql.controllers.filters.FilterList
@@ -34,5 +36,6 @@ class ResourceModule extends NaptimeModule {
     bind[GraphqlSchemaProvider].to[DefaultGraphqlSchemaProvider]
     bind[FilterList].to[DefaultFilters]
     bind[ComplexityFilterConfiguration].toInstance(ComplexityFilterConfiguration.DEFAULT)
+    bind[GraphQlControllerMetricsCollector].to[LoggingGraphQlControllerMetricsCollector]
   }
 }

--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/controllers/GraphQlControllerMetricsCollector.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/controllers/GraphQlControllerMetricsCollector.scala
@@ -1,0 +1,48 @@
+package org.coursera.naptime.ari.graphql.controllers
+
+import com.typesafe.scalalogging.StrictLogging
+import javax.inject.Singleton
+
+trait GraphQlControllerMetricsCollector {
+
+  def markSangriaQueryParserTime(nanos: Long): Unit
+  def markNaptimeQueryParserTime(nanos: Long): Unit
+  def markEngineExecutionTime(nanos: Long): Unit
+  def markSangriaHydrationTime(nanos: Long): Unit
+
+}
+
+@Singleton
+class LoggingGraphQlControllerMetricsCollector
+  extends GraphQlControllerMetricsCollector
+  with StrictLogging {
+
+  def markSangriaQueryParserTime(nanos: Long): Unit = {
+    logger.info(s"Sangria query parser took: ${nanos / 1000000} ms")
+  }
+
+  def markNaptimeQueryParserTime(nanos: Long): Unit = {
+    logger.info(s"Naptime query parser took: ${nanos / 1000000} ms")
+  }
+
+  def markEngineExecutionTime(nanos: Long): Unit = {
+    logger.info(s"Naptime engine execution took: ${nanos / 1000000} ms")
+  }
+
+  def markSangriaHydrationTime(nanos: Long): Unit = {
+    logger.info(s"Sangria hydration took: ${nanos / 1000000} ms")
+  }
+
+}
+
+
+@Singleton
+class NoopGraphQlControllerMetricsCollector
+  extends GraphQlControllerMetricsCollector
+  with StrictLogging {
+
+  def markSangriaQueryParserTime(nanos: Long): Unit = ()
+  def markNaptimeQueryParserTime(nanos: Long): Unit = ()
+  def markEngineExecutionTime(nanos: Long): Unit = ()
+  def markSangriaHydrationTime(nanos: Long): Unit = ()
+}

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.4.15"
+version in ThisBuild := "0.4.16"


### PR DESCRIPTION
This adds a metrics collector that will collect timing data from the GraphQL controller. In Naptime, a logging collector is used to send the metrics as log statements. However, in other codebases, the data can be sent to a third party collector (i.e. Datadog).

This also makes a small change to better parallelize the GraphQL Batch endpoint (previously, query parsing was all done in serial)

PTAL @yifan-coursera and @jnwng 