### PR TITLE
Support defining relations on nested models / unions

### DIFF
--- a/examples/src/main/pegasus/org/coursera/example/CourseMetadata.courier
+++ b/examples/src/main/pegasus/org/coursera/example/CourseMetadata.courier
@@ -1,8 +1,5 @@
 namespace org.coursera.example
 
 record CourseMetadata {
-
-  @related = "instructors.v1"
-  certificateInstructor: InstructorId
-
+  certificateInstructorId: InstructorId
 }

--- a/examples/src/main/pegasus/org/coursera/example/InstructorId.courier
+++ b/examples/src/main/pegasus/org/coursera/example/InstructorId.courier
@@ -1,3 +1,3 @@
 namespace org.coursera.example
 
-typeref InstructorId = string
+typeref InstructorId = int

--- a/examples/src/main/pegasus/org/coursera/example/Partner.courier
+++ b/examples/src/main/pegasus/org/coursera/example/Partner.courier
@@ -2,7 +2,7 @@ namespace org.coursera.example
 
 record Partner {
   courses: array[CourseId]
-  instructors: array[InstructorId]
+  instructorIds: array[InstructorId]
   name: string
   homepage: string
 }

--- a/examples/src/main/scala/resources/CoursesResource.scala
+++ b/examples/src/main/scala/resources/CoursesResource.scala
@@ -24,7 +24,7 @@ class CoursesResource @Inject() (
     .withReverseRelations(
       "instructors" -> MultiGetReverseRelation(
         resourceName = ResourceName("instructors", 1),
-        idsString = "$instructorIds"),
+        ids = "$instructorIds"),
       "partner" -> GetReverseRelation(
         resourceName = ResourceName("partners", 1),
         id = "$partnerId"),

--- a/examples/src/main/scala/resources/CoursesResource.scala
+++ b/examples/src/main/scala/resources/CoursesResource.scala
@@ -29,7 +29,12 @@ class CoursesResource @Inject() (
       "partner" -> GetReverseRelation(
         resourceName = ResourceName("partners", 1),
         id = "$partnerId",
-        arguments = Map.empty))
+        arguments = Map.empty),
+      "courseMetadata/org.coursera.example.CourseMetadata/certificateInstructor" ->
+        GetReverseRelation(
+          resourceName = ResourceName("instructors", 1),
+          id = "${courseMetadata/org.coursera.example.CourseMetadata/certificateInstructorId}",
+          arguments = Map.empty))
 
   def get(id: String = "v1-123") = Nap.get { context =>
     OkIfPresent(id, courseStore.get(id))

--- a/examples/src/main/scala/resources/CoursesResource.scala
+++ b/examples/src/main/scala/resources/CoursesResource.scala
@@ -24,17 +24,14 @@ class CoursesResource @Inject() (
     .withReverseRelations(
       "instructors" -> MultiGetReverseRelation(
         resourceName = ResourceName("instructors", 1),
-        idsString = "$instructorIds",
-        arguments = Map.empty),
+        idsString = "$instructorIds"),
       "partner" -> GetReverseRelation(
         resourceName = ResourceName("partners", 1),
-        id = "$partnerId",
-        arguments = Map.empty),
+        id = "$partnerId"),
       "courseMetadata/org.coursera.example.CourseMetadata/certificateInstructor" ->
         GetReverseRelation(
           resourceName = ResourceName("instructors", 1),
-          id = "${courseMetadata/org.coursera.example.CourseMetadata/certificateInstructorId}",
-          arguments = Map.empty))
+          id = "${courseMetadata/org.coursera.example.CourseMetadata/certificateInstructorId}"))
 
   def get(id: String = "v1-123") = Nap.get { context =>
     OkIfPresent(id, courseStore.get(id))

--- a/examples/src/main/scala/resources/InstructorsResource.scala
+++ b/examples/src/main/scala/resources/InstructorsResource.scala
@@ -15,22 +15,22 @@ import stores.InstructorStore
 @Singleton
 class InstructorsResource @Inject() (
     instructorStore: InstructorStore)
-  extends CourierCollectionResource[String, Instructor] {
+  extends CourierCollectionResource[Int, Instructor] {
 
   override def resourceName = "instructors"
   override def resourceVersion = 1
   override implicit lazy val Fields: Fields[Instructor] = BaseFields
     .withReverseRelations(
-      "courses" -> FinderReverseRelation[String](
+      "courses" -> FinderReverseRelation(
         resourceName = ResourceName("courses", 1),
         finderName = "byInstructor",
         arguments = Map("instructorId" -> "$id")))
 
-  def get(id: String) = Nap.get { context =>
+  def get(id: Int) = Nap.get { context =>
     OkIfPresent(id, instructorStore.get(id))
   }
 
-  def multiGet(ids: Set[String]) = Nap.multiGet { context =>
+  def multiGet(ids: Set[Int]) = Nap.multiGet { context =>
     Ok(instructorStore.all()
       .filter(instructor => ids.contains(instructor._1))
       .map { case (id, instructor) => Keyed(id, instructor) }.toList)

--- a/examples/src/main/scala/resources/PartnersResource.scala
+++ b/examples/src/main/scala/resources/PartnersResource.scala
@@ -5,6 +5,7 @@ import javax.inject.Singleton
 
 import org.coursera.example.Partner
 import org.coursera.naptime.Fields
+import org.coursera.naptime.MultiGetReverseRelation
 import org.coursera.naptime.Ok
 import org.coursera.naptime.ResourceName
 import org.coursera.naptime.model.Keyed
@@ -18,9 +19,12 @@ class PartnersResource @Inject() (
 
   override def resourceName = "partners"
   override def resourceVersion = 1
-  override implicit lazy val Fields: Fields[Partner] = BaseFields.withRelated(
-    "courses" -> ResourceName("courses", 1),
-    "instructors" -> ResourceName("instructors", 1))
+  override implicit lazy val Fields: Fields[Partner] = BaseFields
+    .withRelated("courses" -> ResourceName("courses", 1))
+    .withReverseRelations(
+      "instructors" -> MultiGetReverseRelation(
+        resourceName = ResourceName("instructors", 1),
+        ids = "$instructorIds"))
 
   def get(id: String) = Nap.get { context =>
     OkIfPresent(id, partnerStore.get(id))

--- a/examples/src/main/scala/stores/CourseStore.scala
+++ b/examples/src/main/scala/stores/CourseStore.scala
@@ -20,7 +20,7 @@ class CourseStore {
 
   courseStore = courseStore + (
     "ml" -> Course(
-      instructorIds = List("andrew-ng"),
+      instructorIds = List(1),
       partnerId = "stanford",
       slug = "machine-learning",
       name = "Machine Learning",
@@ -29,9 +29,9 @@ class CourseStore {
         Map("firstModuleId" -> "wrh7vtpj").asJava),
         DataConversion.SetReadOnly),
       courseMetadata = CourseMetadata(
-        certificateInstructorId = "andrew-ng")),
+        certificateInstructorId = 1)),
     "lhtl" -> Course(
-      instructorIds = List("barb-oakley"),
+      instructorIds = List(2),
       partnerId = "ucsd",
       slug = "learning-how-to-learn",
       name = "Learning How to Learn",
@@ -40,7 +40,7 @@ class CourseStore {
         Map("recentEnrollments" -> new Integer(1000)).asJava),
         DataConversion.SetReadOnly),
       courseMetadata = CourseMetadata(
-        certificateInstructorId = "andrew-ng")))
+        certificateInstructorId = 1)))
 
   def get(id: String) = courseStore.get(id)
 

--- a/examples/src/main/scala/stores/CourseStore.scala
+++ b/examples/src/main/scala/stores/CourseStore.scala
@@ -29,7 +29,7 @@ class CourseStore {
         Map("firstModuleId" -> "wrh7vtpj").asJava),
         DataConversion.SetReadOnly),
       courseMetadata = CourseMetadata(
-        certificateInstructor = "andrew-ng")),
+        certificateInstructorId = "andrew-ng")),
     "lhtl" -> Course(
       instructorIds = List("barb-oakley"),
       partnerId = "ucsd",
@@ -40,7 +40,7 @@ class CourseStore {
         Map("recentEnrollments" -> new Integer(1000)).asJava),
         DataConversion.SetReadOnly),
       courseMetadata = CourseMetadata(
-        certificateInstructor = "andrew-ng")))
+        certificateInstructorId = "andrew-ng")))
 
   def get(id: String) = courseStore.get(id)
 

--- a/examples/src/main/scala/stores/InstructorStore.scala
+++ b/examples/src/main/scala/stores/InstructorStore.scala
@@ -9,23 +9,23 @@ import org.coursera.naptime.model.Keyed
 @Singleton
 class InstructorStore {
   @volatile
-  var instructorStore = Map.empty[String, Instructor]
+  var instructorStore = Map.empty[Int, Instructor]
   val nextId = new AtomicInteger(0)
 
   instructorStore = instructorStore + (
-    "andrew-ng" -> Instructor(
+    1 -> Instructor(
       partner = "stanford",
       name = "Andrew Ng",
       photoUrl = ""),
-    "barb-oakley" -> Instructor(
+    2 -> Instructor(
       partner = "ucsd",
       name = "Barb Oakley",
       photoUrl = ""))
 
 
-  def get(id: String) = instructorStore.get(id)
+  def get(id: Int) = instructorStore.get(id)
 
-  def create(instructor: Keyed[String, Instructor]): Unit = {
+  def create(instructor: Keyed[Int, Instructor]): Unit = {
     instructorStore = instructorStore + (instructor.key -> instructor.value)
   }
 

--- a/examples/src/main/scala/stores/PartnerStore.scala
+++ b/examples/src/main/scala/stores/PartnerStore.scala
@@ -16,12 +16,12 @@ class PartnerStore {
   partnerStore = partnerStore + (
     "stanford" -> Partner(
       courses = List("ml"),
-      instructors = List(1),
+      instructorIds = List(1),
       name = "Stanford University",
       homepage = ""),
     "ucsd" -> Partner(
       courses = List("lhtl"),
-      instructors = List(2),
+      instructorIds = List(2),
       name = "UCSD",
       homepage = ""))
 

--- a/examples/src/main/scala/stores/PartnerStore.scala
+++ b/examples/src/main/scala/stores/PartnerStore.scala
@@ -16,12 +16,12 @@ class PartnerStore {
   partnerStore = partnerStore + (
     "stanford" -> Partner(
       courses = List("ml"),
-      instructors = List("andrew-ng"),
+      instructors = List(1),
       name = "Stanford University",
       homepage = ""),
     "ucsd" -> Partner(
       courses = List("lhtl"),
-      instructors = List("barb-oakley"),
+      instructors = List(2),
       name = "UCSD",
       homepage = ""))
 

--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/NaptimePaginatedResourceField.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/NaptimePaginatedResourceField.scala
@@ -44,7 +44,6 @@ object NaptimePaginatedResourceField {
           resource.handlers.find(_.kind == HandlerKind.MULTI_GET)
         case (None, Some(ReverseRelation(annotation))) =>
           annotation.relationType match {
-
             case RelationType.FINDER =>
               val finderName = annotation.arguments.get("q").getOrElse {throw new IllegalStateException("Finder reverse relation on " +
                   s"${annotation.resourceName} does not have a q parameter specified")
@@ -54,7 +53,7 @@ object NaptimePaginatedResourceField {
             case RelationType.MULTI_GET =>
               resource.handlers.find(_.kind == HandlerKind.MULTI_GET)
 
-            case RelationType.$UNKNOWN =>
+            case RelationType.GET | RelationType.SINGLE_ELEMENT_FINDER | RelationType.$UNKNOWN =>
               None
           }
         case _ =>

--- a/naptime-testing/src/test/pegasus/org/coursera/naptime/Course.courier
+++ b/naptime-testing/src/test/pegasus/org/coursera/naptime/Course.courier
@@ -3,5 +3,5 @@ namespace org.coursera.naptime
 record Course {
   name: string
   description: string
-  instructors: array[InstructorId]
+  instructorIds: array[InstructorId]
 }

--- a/naptime-testing/src/test/pegasus/org/coursera/naptime/couriertests/ExpectedMergedCourse.courier
+++ b/naptime-testing/src/test/pegasus/org/coursera/naptime/couriertests/ExpectedMergedCourse.courier
@@ -9,6 +9,12 @@ record ExpectedMergedCourse {
 
   description: string
 
-  @related = "instructors.v1"
-  instructors: array[InstructorId]
+  instructorIds: array[InstructorId]
+
+  @relatedOn = {
+    "resourceName": "instructors.v1",
+    "arguments": {"ids": "$instructorIds"},
+    "relationType": "MULTI_GET"
+  }
+  instructors: array[string]
 }

--- a/naptime-testing/src/test/scala/org/coursera/naptime/NestedMacroCourierTests.scala
+++ b/naptime-testing/src/test/scala/org/coursera/naptime/NestedMacroCourierTests.scala
@@ -36,7 +36,7 @@ object NestedMacroCourierTests {
       .withReverseRelations(
         "instructors" -> MultiGetReverseRelation(
           resourceName = ResourceName("instructors", 1),
-          idsString = "$instructorIds"))
+          ids = "$instructorIds"))
 
     /**
      * This `var` can be overridden to help fake out the implementation in particular functions.

--- a/naptime/src/main/scala/org/coursera/naptime/Types.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/Types.scala
@@ -201,6 +201,10 @@ object Types extends StrictLogging {
           val newFields = (existingFields.asScala ++ List(field)).asJava
           val errorMessageBuilder = new StringBuilder
           recordDataSchema.setFields(newFields, errorMessageBuilder)
+          val error = errorMessageBuilder.toString
+          if (error.nonEmpty) {
+            logger.warn("Error while inserting field", error)
+          }
           recordDataSchema
         } else {
           val fieldOption = Option(recordDataSchema.getField(location.head))

--- a/naptime/src/main/scala/org/coursera/naptime/Types.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/Types.scala
@@ -92,18 +92,6 @@ object Types extends StrictLogging {
       case unknown: DataSchema =>
         throw new RuntimeException(s"Cannot compute asymmetric type for key type: $unknown")
     }
-    for ((name, relation) <- fields.relations) {
-      Option(mergedSchema.getField(name)) match {
-        case None =>
-          logger.warn(s"Fields for resource $typeName mentions field name '$name' but this field " +
-            "is not found in the merged type schema.")
-        case Some(field) =>
-          val properties = field.getProperties.asScala
-          val relatedMap = Map[String, AnyRef](
-            Relations.PROPERTY_NAME -> relation.identifier)
-          field.setProperties((properties ++ relatedMap).asJava)
-      }
-    }
     for ((name, reverseRelation) <- fields.reverseRelations) {
       Option(mergedSchema.getField(name)) match {
         case Some(field) =>

--- a/naptime/src/main/scala/org/coursera/naptime/ari/engine/EngineHelpers.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/ari/engine/EngineHelpers.scala
@@ -110,6 +110,29 @@ object EngineHelpers extends StrictLogging {
   }
 
   /**
+    * Iterates through a data map and returns the value stored at a particular path in the data map,
+    * or None if the path isn't found (or the data is null)
+    *
+    * @param element top-level element to be updated
+    * @param schema data schema defining the fields on the element
+    * @param path list of strings defining the path to the target element
+    */
+  private[engine] def getValueAtPath(
+      element: DataMap,
+      schema: RecordDataSchema,
+      path: Seq[String]): Option[Object] = {
+      val it = Builder.create(element, schema, IterationOrder.PRE_ORDER).dataIterator()
+      Iterator
+        .continually(it.next)
+        .takeWhile(_ != null)
+        .filter(_.path.toSeq.map(_.toString) == path.dropRight(1))
+        .map(_.getValue.asInstanceOf[DataMap].get(path.last))
+        .toList
+        .headOption
+        .flatMap(Option(_))
+  }
+
+  /**
     * Parses an element, using an associated schema and a list of selections from the request,
     * and returns a list of all forward and reverse relations requested from the model
     *

--- a/naptime/src/main/scala/org/coursera/naptime/ari/engine/EngineHelpers.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/ari/engine/EngineHelpers.scala
@@ -125,10 +125,8 @@ object EngineHelpers extends StrictLogging {
       Iterator
         .continually(it.next)
         .takeWhile(_ != null)
-        .filter(_.path.toSeq.map(_.toString) == path.dropRight(1))
+        .find(_.path.toSeq.map(_.toString) == path.dropRight(1))
         .map(_.getValue.asInstanceOf[DataMap].get(path.last))
-        .toList
-        .headOption
         .flatMap(Option(_))
   }
 

--- a/naptime/src/main/scala/org/coursera/naptime/ari/engine/EngineImpl.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/ari/engine/EngineImpl.scala
@@ -264,9 +264,10 @@ class EngineImpl @Inject() (
                 .getOrElse(List[AnyRef]())
 
               // MultiGets return a list of ids, and Gets return a single id (or null)
+              val intersection = responseIds.filter(id => ids.contains(id.toString))
               val filteredIds = reverse.relationType match {
-                case MULTI_GET => new DataList(ids.intersect(responseIds).asJava)
-                case GET => ids.intersect(responseIds).headOption.orNull
+                case MULTI_GET => new DataList(intersection.asJava)
+                case GET => intersection.headOption.orNull
                 case _ => throw new RuntimeException(s"Unhandled relation type")
               }
               element.get("id") -> filteredIds

--- a/naptime/src/main/scala/org/coursera/naptime/ari/engine/EngineImpl.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/ari/engine/EngineImpl.scala
@@ -197,6 +197,12 @@ class EngineImpl @Inject() (
   }
 
   /**
+    * This regex is used to match both "$instructorIds" and "${instructorDetails/instructorIds}"
+    */
+  private[this] val InterpolationRegex =
+    new Regex("""\$(?:([a-zA-Z0-9_]+)|\{([^\}]+)\})""", "withoutBraces", "withBraces")
+
+  /**
     * Executes a series of topLevelRequests for a reverse relation
     * @param requestHeader incoming requestheader containing cookies, headers, etc.
     * @param requestField selection specifying arguments and nested selections on the relation
@@ -219,7 +225,6 @@ class EngineImpl @Inject() (
         s"'${reverse.resourceName}''")
     }
     val argumentsByElement = data.map { topLevelElement =>
-      val InterpolationRegex = new Regex("""\$(?:([a-zA-Z0-9_]+)|\{([^\}]+)\})""", "withoutBraces", "withBraces")
       val arguments: Set[(String, JsValue)] = reverse.arguments
         .mapValues { value =>
           InterpolationRegex.replaceAllIn(

--- a/naptime/src/main/scala/org/coursera/naptime/ari/fetcher/LocalFetcher.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/ari/fetcher/LocalFetcher.scala
@@ -79,6 +79,7 @@ class LocalFetcher @Inject() (
           headers = request.requestHeader.headers.remove("content-type")) // TODO: handle header filtering more properly
         handler <- router.routeRequest(path, fakePlayRequest)
       } yield {
+        logger.info(s"Making local request to ${topLevelRequest.resource.identifier} / ${fakePlayRequest.queryString}")
         val taggedRequest = handler.tagRequest(fakePlayRequest)
         handler match {
           case naptimeAction: RestAction[_, _, _, _, _, _] =>

--- a/naptime/src/main/scala/org/coursera/naptime/models.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/models.scala
@@ -615,12 +615,12 @@ case class FinderReverseRelation(
 
 case class MultiGetReverseRelation(
     resourceName: ResourceName,
-    idsString: String,
+    ids: String,
     arguments: Map[String, String] = Map.empty)
   extends ReverseRelation {
 
   def toAnnotation: ReverseRelationAnnotation = {
-    val mergedArguments = arguments + ("ids" -> idsString)
+    val mergedArguments = arguments + ("ids" -> ids)
     ReverseRelationAnnotation(resourceName.identifier, mergedArguments, RelationType.MULTI_GET)
   }
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.4.17"
+version in ThisBuild := "0.4.18"


### PR DESCRIPTION
This change allows a relation (either forward or reverse), defined on the `Fields` object in a resource, to reference deeply nested records and unions.

For example, if a Course model has a union of Instructors and TeachingAssistants, a related resource can be added to the Instructor model through the union.

This also changes the variable interpolation to support referencing these nested models too.

PTAL @yifan-coursera and cc @jnwng 