### PR TITLE
Compare both alias and name when pulling top-level data

### DIFF
--- a/examples/src/main/scala/resources/CoursesResource.scala
+++ b/examples/src/main/scala/resources/CoursesResource.scala
@@ -60,7 +60,7 @@ class CoursesResource @Inject() (
 
   def byInstructor(instructorId: String) = Nap.finder { context =>
     val courses = courseStore.all()
-      .filter(course => course._2.instructorIds.contains(instructorId))
+      .filter(course => course._2.instructorIds.map(_.toString).contains(instructorId))
     Ok(courses.toList.map { case (id, course) => Keyed(id, course) })
   }
 

--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/NaptimePaginatedResourceField.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/NaptimePaginatedResourceField.scala
@@ -141,7 +141,9 @@ object NaptimePaginatedResourceField {
           context.ctx.response.topLevelResponses.find { case (topLevelRequest, _) =>
             topLevelRequest.resource.identifier == resourceName &&
               topLevelRequest.selection.alias ==
-                context.value.parentContext.astFields.headOption.flatMap(_.alias)
+                context.value.parentContext.astFields.headOption.flatMap(_.alias) &&
+              context.value.parentContext.astFields.headOption.map(_.name)
+                .contains(topLevelRequest.selection.name)
           }.map(_._2.ids.asScala).getOrElse(List.empty)
         }
         objects.collect {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.4.18"
+version in ThisBuild := "0.4.19"


### PR DESCRIPTION
Previously we were only comparing resource name and alias when fetching top-level ids. However, if you have a CoursesV1Resource with a nested multiGet and getAll, the ids of the first would be used for all responses.