### PR TITLE
Better handle reverse relations on empty lists

### DIFF
--- a/examples/src/main/pegasus/org/coursera/example/Partner.courier
+++ b/examples/src/main/pegasus/org/coursera/example/Partner.courier
@@ -1,7 +1,7 @@
 namespace org.coursera.example
 
 record Partner {
-  courses: array[CourseId]
+  courseIds: array[CourseId]
   instructorIds: array[InstructorId]
   name: string
   homepage: string

--- a/examples/src/main/scala/resources/PartnersResource.scala
+++ b/examples/src/main/scala/resources/PartnersResource.scala
@@ -20,11 +20,13 @@ class PartnersResource @Inject() (
   override def resourceName = "partners"
   override def resourceVersion = 1
   override implicit lazy val Fields: Fields[Partner] = BaseFields
-    .withRelated("courses" -> ResourceName("courses", 1))
     .withReverseRelations(
       "instructors" -> MultiGetReverseRelation(
         resourceName = ResourceName("instructors", 1),
-        ids = "$instructorIds"))
+        ids = "$instructorIds"),
+      "courses" -> MultiGetReverseRelation(
+        resourceName = ResourceName("courses", 1),
+        ids = "$courseIds"))
 
   def get(id: String) = Nap.get { context =>
     OkIfPresent(id, partnerStore.get(id))

--- a/examples/src/main/scala/stores/PartnerStore.scala
+++ b/examples/src/main/scala/stores/PartnerStore.scala
@@ -15,12 +15,12 @@ class PartnerStore {
 
   partnerStore = partnerStore + (
     "stanford" -> Partner(
-      courses = List("ml"),
+      courseIds = List("ml"),
       instructorIds = List(1),
       name = "Stanford University",
       homepage = ""),
     "ucsd" -> Partner(
-      courses = List("lhtl"),
+      courseIds = List("lhtl"),
       instructorIds = List(2),
       name = "UCSD",
       homepage = ""))

--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/controllers/filters/QueryComplexityFilter.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/controllers/filters/QueryComplexityFilter.scala
@@ -81,5 +81,5 @@ class QueryComplexityFilter @Inject() (
 case class ComplexityFilterConfiguration(maxComplexity: Int)
 
 object ComplexityFilterConfiguration {
-  val DEFAULT = ComplexityFilterConfiguration(10000)
+  val DEFAULT = ComplexityFilterConfiguration(100000)
 }

--- a/naptime/src/main/scala/org/coursera/naptime/ari/engine/EngineHelpers.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/ari/engine/EngineHelpers.scala
@@ -254,7 +254,7 @@ object EngineHelpers extends StrictLogging {
   private[engine] def stringifyArg(value: JsValue): String = {
     value match {
       case JsArray(arrayElements) =>
-        arrayElements.map(stringifyArg).mkString(",")
+        arrayElements.map(stringifyArg).filterNot(_.isEmpty).mkString(",")
       case stringValue: JsString =>
         stringValue.as[String]
       case number: JsNumber =>

--- a/naptime/src/main/scala/org/coursera/naptime/ari/engine/EngineImpl.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/ari/engine/EngineImpl.scala
@@ -238,6 +238,7 @@ class EngineImpl @Inject() (
               }.getOrElse(variableName)
             })
         }
+        .filterNot(_._2.isEmpty)
         .mapValues(value => JsString(value))
         .toSet
       topLevelElement -> arguments

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.4.19"
+version in ThisBuild := "0.4.20"


### PR DESCRIPTION
When lists were stringified and combined for reverse relations, we could end up with a query parameter that looks like `”,idTwo”` in cases where one element’s list of ids was empty. This causes the request to be invalid, and for data to not be returned.

This fix simply filters out empty strings, to ensure that all ids are valid when stringifying the args.