### PR TITLE
Use pegasus schemas for nested courier models inside case classes

### DIFF
--- a/naptime-models/src/main/scala/org/coursera/naptime/courier/SchemaInference.scala
+++ b/naptime-models/src/main/scala/org/coursera/naptime/courier/SchemaInference.scala
@@ -16,7 +16,6 @@
 
 package org.coursera.naptime.courier
 
-import com.linkedin.data.DataComplex
 import com.linkedin.data.DataMap
 import com.linkedin.data.schema.DataSchema
 import com.linkedin.data.schema.DataSchemaUtil
@@ -58,7 +57,7 @@ object SchemaInference {
    */
   def inferSchema(typ: ru.Type): JsObject = {
     val traverser = new ScalaClassTraverser(typ)
-    traverser.extractPegasusSchemaIfPresent().getOrElse {
+    traverser.extractPegasusSchemaIfPresent().flatMap(_.asOpt[JsObject]).getOrElse {
       traverser.inferSchema().schema match {
         case obj: JsObject => obj
         case value: JsValue => Json.obj("type" -> value)
@@ -82,15 +81,19 @@ private[courier] class ScalaClassTraverser(rootType: ru.Type) {
     inferSchema(rootType)
   }
 
+  def extractPegasusSchemaIfPresent(): Option[JsValue] = {
+    extractPegasusSchemaIfPresent(rootType)
+  }
+
   // If the type is a Courier generated data binding, extract the pegasus schema from the class.
-  def extractPegasusSchemaIfPresent(): Option[JsObject] = {
-    if (rootType <:< runtimeMirror.typeOf[DataTemplate[_]]) {
-      val maybeSchema = runtimeMirror.runtimeClass(rootType) match {
-        case clazz: Class[DataTemplate[DataComplex] @unchecked] => Some(CourierSerializer.getSchema(clazz))
+  def extractPegasusSchemaIfPresent(typ: ru.Type): Option[JsValue] = {
+    if (typ <:< runtimeMirror.typeOf[DataTemplate[_]]) {
+      val maybeSchema = runtimeMirror.runtimeClass(typ) match {
+        case clazz: Class[DataTemplate[Object] @unchecked] => Some(CourierSerializer.getSchema(clazz))
       }
       maybeSchema.map(schemaToJson)
-    } else if (rootType <:< ru.typeOf[scala.Enumeration#Value]) {
-      inferEnumObjectFromValue(rootType) collect {
+    } else if (typ <:< ru.typeOf[scala.Enumeration#Value]) {
+      inferEnumObjectFromValue(typ) collect {
         case EnumerationInfo(enum, enumSymbol)
           // Is the enum a Courier generated enum?
           if enumSymbol.isType &&
@@ -103,14 +106,17 @@ private[courier] class ScalaClassTraverser(rootType: ru.Type) {
     }
   }
 
-  private[this] def schemaToJson(schema: DataSchema): JsObject = {
+  private[this] def schemaToJson(schema: DataSchema): JsValue = {
     val schemaJson = SchemaToJsonEncoder.schemaToJson(schema, JsonBuilder.Pretty.COMPACT)
-    Json.parse(schemaJson).as[JsObject]
+    Json.parse(schemaJson)
   }
 
   private[this] def inferSchema(typ: ru.Type): InferredSchema = {
     val typeName = typ.typeSymbol.fullName
-    if (isPredef(typ)) {
+    val maybePegasusSchema = extractPegasusSchemaIfPresent(typ)
+    if (maybePegasusSchema.isDefined) {
+      InferredSchema(maybePegasusSchema.get)
+    } else if (isPredef(typ)) {
       inferPredef(typ)
     } else if (typ <:< ru.typeOf[scala.Enumeration#Value]) {
       inferEnum(typ)
@@ -222,7 +228,7 @@ private[courier] class ScalaClassTraverser(rootType: ru.Type) {
       pegasusName: String,
       scalaClassName: String,
       coercerClass: String,
-      pegasusRefType: DataSchema): JsObject = {
+      pegasusRefType: DataSchema): JsValue = {
     val schema = new TyperefDataSchema(new Name(pegasusName))
     schema.setReferencedType(pegasusRefType)
     schema.setProperties(Map[String, AnyRef](

--- a/naptime-models/src/test/pegasus/org/coursera/naptime/courier/TestUnion.courier
+++ b/naptime-models/src/test/pegasus/org/coursera/naptime/courier/TestUnion.courier
@@ -1,0 +1,3 @@
+namespace org.coursera.naptime.courier
+
+typeref TestUnion = union[int, string]

--- a/naptime-models/src/test/scala/org/coursera/naptime/courier/SchemaInferenceTest.scala
+++ b/naptime-models/src/test/scala/org/coursera/naptime/courier/SchemaInferenceTest.scala
@@ -12,7 +12,7 @@ class SchemaInferenceTest extends AssertionsForJUnit {
   import SchemaInference._
 
   @Test
-  def testCourierCLass(): Unit = {
+  def testCourierClass(): Unit = {
     val inferred = SchemaInference.inferSchema[MockRecord]
     val expected = Json.parse(MockRecord.SCHEMA_JSON)
     assert(inferred === expected)
@@ -217,6 +217,27 @@ class SchemaInferenceTest extends AssertionsForJUnit {
           |}
         """.stripMargin))
   }
+
+  @Test
+  def nestedCourierUnion(): Unit = {
+    assert(inferSchema[WithNestedUnion] ===
+      Json.parse(
+        """{
+          |  "fields": [
+          |    {
+          |      "name": "nestedUnion",
+          |      "type": [
+          |        "int",
+          |        "string"
+          |      ]
+          |    }
+          |  ],
+          |  "name": "WithNestedUnion",
+          |  "namespace": "org.coursera.naptime.courier",
+          |  "type": "record"
+          |}
+        """.stripMargin))
+  }
 }
 
 
@@ -230,6 +251,7 @@ case class WithRecord(record: Simple)
 case class WithArrays(ints: Seq[Int])
 case class WithMaps(ints: Map[String, Int])
 case class WithTypedKeyMaps(ints: Map[Int, Int])
+case class WithNestedUnion(nestedUnion: TestUnion)
 
 sealed trait TypedDefinition
 case class MemberOne() extends TypedDefinition
@@ -237,16 +259,16 @@ case class MemberTwo() extends TypedDefinition
 
 package object enums {
   object Enum1 extends Enumeration {
-    val SUMBOL_1 = Value("SYMBOL_1")
-    val SUMBOL_2 = Value("SYMBOL_2")
+    val SYMBOL_1 = Value("SYMBOL_1")
+    val SYMBOL_2 = Value("SYMBOL_2")
   }
 
   type Enum1 = Enum1.Value
 }
 
 object Enum2 extends Enumeration {
-  val SUMBOL_A = Value("SYMBOL_A")
-  val SUMBOL_B = Value("SYMBOL_B")
+  val SYMBOL_A = Value("SYMBOL_A")
+  val SYMBOL_B = Value("SYMBOL_B")
   type Enum2 = Enum2.Value
 }
 
@@ -262,7 +284,7 @@ object CourierEnum extends Enumeration {
       |""".stripMargin
   val SCHEMA = DataTemplateUtil.parseSchema(SCHEMA_JSON).asInstanceOf[EnumDataSchema]
 
-  val SUMBOL_X = Value("SYMBOL_X")
-  val SUMBOL_Y = Value("SYMBOL_Y")
+  val SYMBOL_X = Value("SYMBOL_X")
+  val SYMBOL_Y = Value("SYMBOL_Y")
   type CourierEnum = CourierEnum.Value
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.4.19"
+version in ThisBuild := "0.4.21"


### PR DESCRIPTION
In some cases, we have a scala case class that has a nested Courier record / union as a field inside of it. Currently, when we try to infer the schema, we'll come across the nested union schema, and mark it as "unable to be inferred". However, we _have_ the schema available at that point, we're just not using it.

This change checks every class we try to infer (including nested classes inside a case class) and check if it's a pegasus schema. If it is, we pull the known schema from that, and ignore all attempted inferred schemas.

cc @saeta 