### PR TITLE
Make nullable field retrieval safer

### DIFF
--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/FieldBuilder.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/FieldBuilder.scala
@@ -125,7 +125,8 @@ object FieldBuilder extends StrictLogging {
         Field.apply[SangriaGraphQlContext, DataMap, Any, Any](
           name = FieldBuilder.formatName(fieldName),
           fieldType = ListType(innerField.fieldType),
-          resolve = context => context.value.getDataList(fieldName).asScala)
+          resolve = context => Option(context.value.getDataList(fieldName))
+            .map(_.asScala).getOrElse(null))
 
       case (None, _: MapDataSchema) =>
         Field.apply[SangriaGraphQlContext, DataMap, Any, Any](

--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/FieldBuilder.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/FieldBuilder.scala
@@ -126,7 +126,8 @@ object FieldBuilder extends StrictLogging {
           name = FieldBuilder.formatName(fieldName),
           fieldType = ListType(innerField.fieldType),
           resolve = context => Option(context.value.getDataList(fieldName))
-            .map(_.asScala).getOrElse(null))
+            .map(_.asScala)
+            .getOrElse(null))
 
       case (None, _: MapDataSchema) =>
         Field.apply[SangriaGraphQlContext, DataMap, Any, Any](

--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/NaptimePaginatedResourceField.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/NaptimePaginatedResourceField.scala
@@ -129,7 +129,9 @@ object NaptimePaginatedResourceField {
       val connection = context.ctx.response.data.get(parsedResourceName).map { objects =>
         val ids = Option(context.value.parentContext.value).map { parentElement =>
           // Nested Request
-          val allIds = parentElement.getDataList(fieldName).asScala
+          val allIds = Option(parentElement.getDataList(fieldName))
+            .map(_.asScala)
+            .getOrElse(List.empty)
           val startOption = context.value.parentContext.arg(NaptimePaginationField.startArgument)
           val limit = context.value.parentContext.arg(NaptimePaginationField.limitArgument)
           val idsWithStart = startOption
@@ -144,7 +146,7 @@ object NaptimePaginatedResourceField {
                 context.value.parentContext.astFields.headOption.flatMap(_.alias) &&
               context.value.parentContext.astFields.headOption.map(_.name)
                 .contains(topLevelRequest.selection.name)
-          }.map(_._2.ids.asScala).getOrElse(List.empty)
+          }.flatMap(r => Option(r._2.ids).map(_.asScala)).getOrElse(List.empty)
         }
         objects.collect {
           case (id, element) if ids.contains(id) => element

--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/NaptimePaginationField.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/NaptimePaginationField.scala
@@ -65,7 +65,9 @@ object NaptimePaginationField extends StrictLogging {
       val responsePagination = context.ctx.response.data.get(parsedResourceName).map { objects =>
         Option(context.value.parentContext.value).map { parentElement =>
           // Nested Request
-          val idsFromParent = parentElement.getDataList(fieldName).asScala
+          val idsFromParent = Option(parentElement.getDataList(fieldName))
+            .map(_.asScala)
+            .getOrElse(List.empty)
           val startOption = context.value.parentContext.arg(startArgument)
           val limit = context.value.parentContext.arg(limitArgument)
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.4.21"
+version in ThisBuild := "0.4.22"


### PR DESCRIPTION
DataMap’s `getDataList` field can return a null value. However, we were immediately calling `.asScala` on a lot of these values, which would obviously break. To fix this, we wrap the possibly-null value in an `Option` and then handle that safely (by either falling back to an empty list or calling getOrElse(null) after only calling asScala on the unwrapped value.