### PR TITLE
Fix escaping exceptions in StringKey parsing

### DIFF
--- a/naptime-models/src/main/scala/org/coursera/naptime/courier/CourierFormats.scala
+++ b/naptime-models/src/main/scala/org/coursera/naptime/courier/CourierFormats.scala
@@ -290,12 +290,16 @@ object CourierFormats extends StrictLogging {
 
       override def reads(key: StringKey): Option[T] = {
         val string = key.key
-        val dataMap = stringKeyCodec.bytesToMap(string.getBytes(StringKeyCodec.charset))
-        validateAndFixUp(dataMap, schema)
+        val bytes = string.getBytes(StringKeyCodec.charset)
         try {
+          val dataMap = stringKeyCodec.bytesToMap(bytes)
+          validateAndFixUp(dataMap, schema)
           dataMap.setReadOnly()
           Some(DataTemplateUtil.wrap(dataMap, clazz))
         } catch {
+          case parseException: IOException =>
+            logger.debug(s"${parseException.getMessage}", parseException)
+            None
           case castException: TemplateOutputCastException =>
             logger.debug(s"Template cast failed for stringKey: $string", castException)
             None
@@ -333,9 +337,10 @@ object CourierFormats extends StrictLogging {
 
       override def reads(key: StringKey): Option[T] = {
         val string = key.key
-        val dataList = stringKeyCodec.bytesToList(string.getBytes(StringKeyCodec.charset))
-        validateAndFixUp(dataList, schema)
+        val bytes = string.getBytes(StringKeyCodec.charset)
         try {
+          val dataList = stringKeyCodec.bytesToList(bytes)
+          validateAndFixUp(dataList, schema)
           dataList.setReadOnly()
           Some(DataTemplateUtil.wrap(dataList, clazz.getConstructor(classOf[DataList])))
         } catch {

--- a/naptime-models/src/test/scala/org/coursera/naptime/courier/CourierFormatsTest.scala
+++ b/naptime-models/src/test/scala/org/coursera/naptime/courier/CourierFormatsTest.scala
@@ -209,6 +209,17 @@ class CourierFormatsTest extends AssertionsForJUnit {
 
     val roundTripped = StringKey.unapply(stringKey).get
     assert(roundTripped === string)
+
+    val string2 = "nottwo"
+    val stringKey2 = StringKey(string2)
+    val mock2 = stringKey2.asOpt[MockRecord]
+
+    val string3 = "value~notnumeric"
+    val stringKey3 = StringKey(string3)
+    val mock3 = stringKey3.asOpt[MockRecord]
+
+    assert(mock2 === None) // IOException
+    assert(mock3 === None) // DataValidationException
   }
 
   @Test
@@ -226,6 +237,12 @@ class CourierFormatsTest extends AssertionsForJUnit {
 
     val roundTripped = StringKey.unapply(stringKey).get
     assert(roundTripped === string)
+
+
+    val string2 = "1,2,"
+    val stringKey2 = StringKey(string2)
+    val mock2 = stringKey2.asOpt[IntArray]
+    assert(mock2 === None) // DataValidationException
   }
 
   @Test


### PR DESCRIPTION
In the `read` provided by `recordTemplateStringKeyFormat`, if the tuple [here](https://github.com/kyewei/naptime/blob/cb5290356348a1fba99cd850415047298c66698f/naptime-models/src/main/scala/org/coursera/naptime/courier/StringKeyCodec.scala#L198) fails the check, the error leaks out and a `None` is not returned. Similarly, if a validation in `validateAndFixUp()` fails, the exceptions escapes as well.

Changes: Wrapped lines in try-catch and added tests.


@yifan-coursera 