### PR TITLE
Don’t fall back to field name if a reverse relation field isn’t set

### DIFF
--- a/naptime/src/main/scala/org/coursera/naptime/ari/engine/EngineImpl.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/ari/engine/EngineImpl.scala
@@ -233,10 +233,8 @@ class EngineImpl @Inject() (
               val withBraces = Option(regexMatch.group("withBraces"))
               val variableName = withoutBraces.orElse(withBraces).getOrElse("")
               EngineHelpers.getValueAtPath(topLevelElement, schema, variableName.split("/")).map {
-                case dataList: DataList =>
-                  Option(dataList).map(_.asScala.mkString(",")).getOrElse("")
-                case other: Any =>
-                  other.toString
+                case dataList: DataList => dataList.asScala.mkString(",")
+                case other: Any => other.toString
               }.getOrElse("")
             })
         }

--- a/naptime/src/main/scala/org/coursera/naptime/ari/engine/EngineImpl.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/ari/engine/EngineImpl.scala
@@ -233,9 +233,11 @@ class EngineImpl @Inject() (
               val withBraces = Option(regexMatch.group("withBraces"))
               val variableName = withoutBraces.orElse(withBraces).getOrElse("")
               EngineHelpers.getValueAtPath(topLevelElement, schema, variableName.split("/")).map {
-                case dataList: DataList => dataList.asScala.mkString(",")
-                case other: Any => other.toString
-              }.getOrElse(variableName)
+                case dataList: DataList =>
+                  Option(dataList).map(_.asScala.mkString(",")).getOrElse("")
+                case other: Any =>
+                  other.toString
+              }.getOrElse("")
             })
         }
         .filterNot(_._2.isEmpty)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.4.22"
+version in ThisBuild := "0.4.23"


### PR DESCRIPTION
If a field isn’t set, that may mean its a nullable field. In that case, we should just fall back to an empty string, so we remove it when making a subsequent multiget.