### PR TITLE
Allow setting docs on reverse-relation fields

### DIFF
--- a/examples/src/main/scala/resources/CoursesResource.scala
+++ b/examples/src/main/scala/resources/CoursesResource.scala
@@ -27,11 +27,13 @@ class CoursesResource @Inject() (
         ids = "$instructorIds"),
       "partner" -> GetReverseRelation(
         resourceName = ResourceName("partners", 1),
-        id = "$partnerId"),
+        id = "$partnerId",
+        description = "Partner who produces this course."),
       "courseMetadata/org.coursera.example.CourseMetadata/certificateInstructor" ->
         GetReverseRelation(
           resourceName = ResourceName("instructors", 1),
-          id = "${courseMetadata/org.coursera.example.CourseMetadata/certificateInstructorId}"))
+          id = "${courseMetadata/org.coursera.example.CourseMetadata/certificateInstructorId}",
+          description = "Instructor who's name and signature appears on the course certificate."))
 
   def get(id: String = "v1-123") = Nap.get { context =>
     OkIfPresent(id, courseStore.get(id))

--- a/naptime-testing/src/test/pegasus/org/coursera/naptime/couriertests/ExpectedMergedCourse.courier
+++ b/naptime-testing/src/test/pegasus/org/coursera/naptime/couriertests/ExpectedMergedCourse.courier
@@ -18,8 +18,7 @@ record ExpectedMergedCourse {
   @relatedOn = {
     "resourceName": "instructors.v1",
     "arguments": {"ids": "$instructorIds"},
-    "relationType": "MULTI_GET",
-    "description": "Instructors for the course"
+    "relationType": "MULTI_GET"
   }
   instructors: array[string]
 }

--- a/naptime-testing/src/test/pegasus/org/coursera/naptime/couriertests/ExpectedMergedCourse.courier
+++ b/naptime-testing/src/test/pegasus/org/coursera/naptime/couriertests/ExpectedMergedCourse.courier
@@ -11,10 +11,15 @@ record ExpectedMergedCourse {
 
   instructorIds: array[InstructorId]
 
+
+  /**
+   * Instructors for the course
+   */
   @relatedOn = {
     "resourceName": "instructors.v1",
     "arguments": {"ids": "$instructorIds"},
-    "relationType": "MULTI_GET"
+    "relationType": "MULTI_GET",
+    "description": "Instructors for the course"
   }
   instructors: array[string]
 }

--- a/naptime-testing/src/test/scala/org/coursera/naptime/NestedMacroCourierTests.scala
+++ b/naptime-testing/src/test/scala/org/coursera/naptime/NestedMacroCourierTests.scala
@@ -36,7 +36,8 @@ object NestedMacroCourierTests {
       .withReverseRelations(
         "instructors" -> MultiGetReverseRelation(
           resourceName = ResourceName("instructors", 1),
-          ids = "$instructorIds"))
+          ids = "$instructorIds",
+          description = "Instructors for the course"))
 
     /**
      * This `var` can be overridden to help fake out the implementation in particular functions.

--- a/naptime/src/main/pegasus/org/coursera/naptime/schema/ReverseRelationAnnotation.courier
+++ b/naptime/src/main/pegasus/org/coursera/naptime/schema/ReverseRelationAnnotation.courier
@@ -20,9 +20,4 @@ record ReverseRelationAnnotation {
    */
   relationType: enum RelationType { FINDER, MULTI_GET, GET, SINGLE_ELEMENT_FINDER }
 
-  /**
-   * Documentation for the relation edge (to be included in the GraphQL schema's documentation)
-   */
-  description: string = ""
-
 }

--- a/naptime/src/main/pegasus/org/coursera/naptime/schema/ReverseRelationAnnotation.courier
+++ b/naptime/src/main/pegasus/org/coursera/naptime/schema/ReverseRelationAnnotation.courier
@@ -20,4 +20,9 @@ record ReverseRelationAnnotation {
    */
   relationType: enum RelationType { FINDER, MULTI_GET, GET, SINGLE_ELEMENT_FINDER }
 
+  /**
+   * Documentation for the relation edge (to be included in the GraphQL schema's documentation)
+   */
+  description: string = ""
+
 }

--- a/naptime/src/main/scala/org/coursera/naptime/Types.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/Types.scala
@@ -115,6 +115,7 @@ object Types extends StrictLogging {
           val reverseRelatedMap = Map[String, AnyRef](
             Relations.REVERSE_PROPERTY_NAME -> reverseRelation.toAnnotation.data())
           newField.setProperties(reverseRelatedMap.asJava)
+          newField.setDoc(reverseRelation.description)
           newField.setName(name.split("/").last, errorMessageBuilder)
           insertFieldAtLocation(mergedSchema, name.split("/").dropRight(1).toList, newField)
       }

--- a/naptime/src/main/scala/org/coursera/naptime/models.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/models.scala
@@ -614,8 +614,7 @@ case class FinderReverseRelation(
     ReverseRelationAnnotation(
       resourceName.identifier,
       mergedArguments,
-      RelationType.FINDER,
-      description)
+      RelationType.FINDER)
   }
 }
 
@@ -631,8 +630,7 @@ case class MultiGetReverseRelation(
     ReverseRelationAnnotation(
       resourceName.identifier,
       mergedArguments,
-      RelationType.MULTI_GET,
-      description)
+      RelationType.MULTI_GET)
   }
 }
 
@@ -648,8 +646,7 @@ case class GetReverseRelation(
     ReverseRelationAnnotation(
       resourceName.identifier,
       mergedArguments,
-      RelationType.GET,
-      description)
+      RelationType.GET)
   }
 }
 
@@ -665,7 +662,6 @@ case class SingleElementFinderReverseRelation(
     ReverseRelationAnnotation(
       resourceName.identifier,
       mergedArguments,
-      RelationType.SINGLE_ELEMENT_FINDER,
-      description)
+      RelationType.SINGLE_ELEMENT_FINDER)
   }
 }

--- a/naptime/src/main/scala/org/coursera/naptime/models.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/models.scala
@@ -597,6 +597,7 @@ private[naptime] object QueryStringParser extends RegexParsers {
 trait ReverseRelation {
   val resourceName: ResourceName
   val arguments: Map[String, String]
+  val description: String
 
   def toAnnotation: ReverseRelationAnnotation
 }
@@ -604,43 +605,8 @@ trait ReverseRelation {
 case class FinderReverseRelation(
     resourceName: ResourceName,
     finderName: String,
-    arguments: Map[String, String] = Map.empty)
-  extends ReverseRelation {
-
-  def toAnnotation: ReverseRelationAnnotation = {
-    val mergedArguments = arguments + ("q" -> finderName)
-    ReverseRelationAnnotation(resourceName.identifier, mergedArguments, RelationType.FINDER)
-  }
-}
-
-case class MultiGetReverseRelation(
-    resourceName: ResourceName,
-    ids: String,
-    arguments: Map[String, String] = Map.empty)
-  extends ReverseRelation {
-
-  def toAnnotation: ReverseRelationAnnotation = {
-    val mergedArguments = arguments + ("ids" -> ids)
-    ReverseRelationAnnotation(resourceName.identifier, mergedArguments, RelationType.MULTI_GET)
-  }
-}
-
-case class GetReverseRelation(
-    resourceName: ResourceName,
-    id: String,
-    arguments: Map[String, String] = Map.empty)
-  extends ReverseRelation {
-
-  def toAnnotation: ReverseRelationAnnotation = {
-    val mergedArguments = arguments + ("ids" -> id)
-    ReverseRelationAnnotation(resourceName.identifier, mergedArguments, RelationType.GET)
-  }
-}
-
-case class SingleElementFinderReverseRelation(
-    resourceName: ResourceName,
-    finderName: String,
-    arguments: Map[String, String] = Map.empty)
+    arguments: Map[String, String] = Map.empty,
+    description: String = "")
   extends ReverseRelation {
 
   def toAnnotation: ReverseRelationAnnotation = {
@@ -648,6 +614,58 @@ case class SingleElementFinderReverseRelation(
     ReverseRelationAnnotation(
       resourceName.identifier,
       mergedArguments,
-      RelationType.SINGLE_ELEMENT_FINDER)
+      RelationType.FINDER,
+      description)
+  }
+}
+
+case class MultiGetReverseRelation(
+    resourceName: ResourceName,
+    ids: String,
+    arguments: Map[String, String] = Map.empty,
+    description: String = "")
+  extends ReverseRelation {
+
+  def toAnnotation: ReverseRelationAnnotation = {
+    val mergedArguments = arguments + ("ids" -> ids)
+    ReverseRelationAnnotation(
+      resourceName.identifier,
+      mergedArguments,
+      RelationType.MULTI_GET,
+      description)
+  }
+}
+
+case class GetReverseRelation(
+    resourceName: ResourceName,
+    id: String,
+    arguments: Map[String, String] = Map.empty,
+    description: String = "")
+  extends ReverseRelation {
+
+  def toAnnotation: ReverseRelationAnnotation = {
+    val mergedArguments = arguments + ("ids" -> id)
+    ReverseRelationAnnotation(
+      resourceName.identifier,
+      mergedArguments,
+      RelationType.GET,
+      description)
+  }
+}
+
+case class SingleElementFinderReverseRelation(
+    resourceName: ResourceName,
+    finderName: String,
+    arguments: Map[String, String] = Map.empty,
+    description: String = "")
+  extends ReverseRelation {
+
+  def toAnnotation: ReverseRelationAnnotation = {
+    val mergedArguments = arguments + ("q" -> finderName)
+    ReverseRelationAnnotation(
+      resourceName.identifier,
+      mergedArguments,
+      RelationType.SINGLE_ELEMENT_FINDER,
+      description)
   }
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.5.0"
+version in ThisBuild := "0.5.1"


### PR DESCRIPTION
This lets us write documentation describing the "edge" field that is auto-created by a reverse relation. For instance, if we add a new PrimaryPartners field on a Course that is populated by some arbitrary finder, we can describe on the field what that relationship means.