### PR TITLE
Use asScala explicitly in MacroImpl

### DIFF
--- a/naptime/src/main/scala/org/coursera/naptime/router2/MacroImpls.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/router2/MacroImpls.scala
@@ -229,13 +229,13 @@ class MacroImpls(val c: blackbox.Context) {
       } else {
         q"""
           scala.util.Try {
-            import scala.collection.JavaConversions._
+            import scala.collection.JavaConverters._
             val resolver = new com.linkedin.data.schema.resolver.DefaultDataSchemaResolver()
             val parser = new com.linkedin.data.schema.SchemaParser(resolver)
             val schemaJson = org.coursera.naptime.courier.SchemaInference.inferSchema(
               scala.reflect.runtime.universe.typeTag[$targetType])
             parser.parse(schemaJson.toString)
-            parser.topLevelDataSchemas.head.asInstanceOf[com.linkedin.data.schema.RecordDataSchema]
+            parser.topLevelDataSchemas.asScala.head.asInstanceOf[com.linkedin.data.schema.RecordDataSchema]
           }.toOption"""
       }
     }
@@ -249,13 +249,13 @@ class MacroImpls(val c: blackbox.Context) {
       } else {
         q"""
           scala.util.Try {
-            import scala.collection.JavaConversions._
+            import scala.collection.JavaConverters._
             val resolver = new com.linkedin.data.schema.resolver.DefaultDataSchemaResolver()
             val parser = new com.linkedin.data.schema.SchemaParser(resolver)
             val schemaJson = org.coursera.naptime.courier.SchemaInference.inferSchemaFromWeakTypeTag(
               scala.reflect.runtime.universe.weakTypeTag[$targetType])
             parser.parse(schemaJson.toString)
-            parser.topLevelDataSchemas.head.asInstanceOf[com.linkedin.data.schema.DataSchema]
+            parser.topLevelDataSchemas.asScala.head.asInstanceOf[com.linkedin.data.schema.DataSchema]
           }.toOption"""
       }
       q"""


### PR DESCRIPTION
Use the explicit collection.JavaConverters instead of implicit conversions in collection.JavaConversions.

JavaConversions is deprecated in 2.12. And due to the macro impl, this breaks linter we plan to add into infra-services.

http://www.scala-lang.org/api/2.12.x/scala/collection/JavaConversions$.html