### PR TITLE
Fix null query parameters and error response format

### DIFF
--- a/examples/src/main/scala/stores/CourseStore.scala
+++ b/examples/src/main/scala/stores/CourseStore.scala
@@ -25,7 +25,7 @@ class CourseStore {
       slug = "machine-learning",
       name = "Machine Learning",
       description = Some("Machine learning is the science of getting computers to act without being explicitly programmed."),
-      extraData = AnyData(new DataMap(
+      extraData = AnyData.build(new DataMap(
         Map("firstModuleId" -> "wrh7vtpj").asJava),
         DataConversion.SetReadOnly),
       courseMetadata = CourseMetadata(
@@ -36,7 +36,7 @@ class CourseStore {
       slug = "learning-how-to-learn",
       name = "Learning How to Learn",
       description = None,
-      extraData = AnyData(new DataMap(
+      extraData = AnyData.build(new DataMap(
         Map("recentEnrollments" -> new Integer(1000)).asJava),
         DataConversion.SetReadOnly),
       courseMetadata = CourseMetadata(

--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/controllers/GraphQLController.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/controllers/GraphQLController.scala
@@ -146,12 +146,12 @@ class GraphQLController @Inject() (
                   }
               }.recover {
                 case error: QueryAnalysisError =>
-                  OutgoingQuery(Json.obj("error" -> error.resolveError), None)
+                  OutgoingQuery(error.resolveError.as[JsObject], None)
                 case error: ErrorWithResolver =>
-                  OutgoingQuery(Json.obj("error" -> error.resolveError), None)
+                  OutgoingQuery(error.resolveError.as[JsObject], None)
                 case error: Exception =>
                   logger.error("GraphQL execution error", error)
-                  OutgoingQuery(Json.obj("error" -> error.getMessage), None)
+                  OutgoingQuery(Json.obj("errors" -> Json.arr(error.getMessage)), None)
               }
             }.getOrElse {
               val result = Json.obj("syntaxError" -> "Could not parse document")

--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/controllers/filters/QueryComplexityFilter.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/controllers/filters/QueryComplexityFilter.scala
@@ -46,11 +46,11 @@ class QueryComplexityFilter @Inject() (
       }
     }.recover {
       case error: QueryAnalysisError =>
-        OutgoingQuery(Json.obj("error" -> error.resolveError), None)
+        OutgoingQuery(error.resolveError.as[JsObject], None)
       case error: ErrorWithResolver =>
-        OutgoingQuery(Json.obj("error" -> error.resolveError), None)
+        OutgoingQuery(error.resolveError.as[JsObject], None)
       case error: Exception =>
-        OutgoingQuery(Json.obj("error" -> error.getMessage), None)
+        OutgoingQuery(Json.obj("errors" -> Json.arr(error.getMessage)), None)
     }
   }
 

--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/NaptimePaginationField.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/NaptimePaginationField.scala
@@ -62,7 +62,7 @@ object NaptimePaginationField extends StrictLogging {
       val parsedResourceName = ResourceName.parse(resourceName).getOrElse {
         throw new SchemaExecutionException(s"Cannot parse resource name from $resourceName")
       }
-      val responsePagination = context.ctx.response.data.get(parsedResourceName).map { objects =>
+      val responsePagination = context.ctx.response.data.get(parsedResourceName).map { _ =>
         Option(context.value.parentContext.value).map { parentElement =>
           // Nested Request
           val idsFromParent = Option(parentElement.getDataList(fieldName))

--- a/naptime/src/main/pegasus/org/coursera/naptime/schema/Parameter.courier
+++ b/naptime/src/main/pegasus/org/coursera/naptime/schema/Parameter.courier
@@ -11,6 +11,11 @@ record Parameter {
 
   type: TypeName
 
+  /**
+   * Data schema that describes the format of the parameter
+   */
+  typeSchema: ParameterDataSchema?
+
   attributes: array[Attribute]
 
   /**
@@ -20,13 +25,6 @@ record Parameter {
    * purposes.
    */
   default: ArbitraryValue?
-
-
-  /**
-   * Data schema that describes the format of the parameter
-   */
-  typeSchema: ParameterDataSchema?
-
 
   /**
    * Flag whether the parameter is optional,

--- a/naptime/src/main/pegasus/org/coursera/naptime/schema/Parameter.courier
+++ b/naptime/src/main/pegasus/org/coursera/naptime/schema/Parameter.courier
@@ -11,8 +11,6 @@ record Parameter {
 
   type: TypeName
 
-  typeSchema: ParameterDataSchema?
-
   attributes: array[Attribute]
 
   /**
@@ -22,6 +20,13 @@ record Parameter {
    * purposes.
    */
   default: ArbitraryValue?
+
+
+  /**
+   * Data schema that describes the format of the parameter
+   */
+  typeSchema: ParameterDataSchema?
+
 
   /**
    * Flag whether the parameter is optional,


### PR DESCRIPTION
- Null values for arguments are allowed in graphql, but when sent in REST, they should be omitted completely.
- We're reporting errors under an unnecessary level -- this moves errors up to top level to allow to be parsed by apollo and graphiql better