### PR TITLE
Support typedDefinitions in unions

### DIFF
--- a/examples/src/main/pegasus/org/coursera/example/CertificateCourseMetadata.courier
+++ b/examples/src/main/pegasus/org/coursera/example/CertificateCourseMetadata.courier
@@ -1,0 +1,5 @@
+namespace org.coursera.example
+
+record CertificateCourseMetadata {
+  certificateInstructorId: InstructorId
+}

--- a/examples/src/main/pegasus/org/coursera/example/Course.courier
+++ b/examples/src/main/pegasus/org/coursera/example/Course.courier
@@ -10,5 +10,5 @@ record Course {
 
   extraData: AnyData
 
-  courseMetadata: union[CourseMetadata]
+  courseMetadata: CourseMetadata
 }

--- a/examples/src/main/pegasus/org/coursera/example/CourseMetadata.courier
+++ b/examples/src/main/pegasus/org/coursera/example/CourseMetadata.courier
@@ -1,5 +1,7 @@
 namespace org.coursera.example
 
-record CourseMetadata {
-  certificateInstructorId: InstructorId
+@typedDefinition = {
+  "org.coursera.example.CertificateCourseMetadata": "certificate",
+  "org.coursera.example.DegreeCourseMetadata": "degree"
 }
+typeref CourseMetadata = union[CertificateCourseMetadata, DegreeCourseMetadata]

--- a/examples/src/main/pegasus/org/coursera/example/DegreeCourseMetadata.courier
+++ b/examples/src/main/pegasus/org/coursera/example/DegreeCourseMetadata.courier
@@ -1,0 +1,5 @@
+namespace org.coursera.example
+
+record DegreeCourseMetadata {
+  degreeCertificateName: string
+}

--- a/examples/src/main/scala/resources/CoursesResource.scala
+++ b/examples/src/main/scala/resources/CoursesResource.scala
@@ -29,10 +29,10 @@ class CoursesResource @Inject() (
         resourceName = ResourceName("partners", 1),
         id = "$partnerId",
         description = "Partner who produces this course."),
-      "courseMetadata/org.coursera.example.CourseMetadata/certificateInstructor" ->
+      "courseMetadata/org.coursera.example.CertificateCourseMetadata/certificateInstructor" ->
         GetReverseRelation(
           resourceName = ResourceName("instructors", 1),
-          id = "${courseMetadata/org.coursera.example.CourseMetadata/certificateInstructorId}",
+          id = "${courseMetadata/org.coursera.example.CertificateCourseMetadata/certificateInstructorId}",
           description = "Instructor who's name and signature appears on the course certificate."))
 
   def get(id: String = "v1-123") = Nap.get { context =>

--- a/examples/src/main/scala/stores/CourseStore.scala
+++ b/examples/src/main/scala/stores/CourseStore.scala
@@ -6,8 +6,9 @@ import javax.inject.Singleton
 import com.linkedin.data.DataMap
 import org.coursera.courier.templates.DataTemplates.DataConversion
 import org.coursera.example.AnyData
+import org.coursera.example.CertificateCourseMetadata
 import org.coursera.example.Course
-import org.coursera.example.CourseMetadata
+import org.coursera.example.DegreeCourseMetadata
 import org.coursera.naptime.model.Keyed
 
 import scala.collection.JavaConverters._
@@ -28,7 +29,7 @@ class CourseStore {
       extraData = AnyData.build(new DataMap(
         Map("firstModuleId" -> "wrh7vtpj").asJava),
         DataConversion.SetReadOnly),
-      courseMetadata = CourseMetadata(
+      courseMetadata = CertificateCourseMetadata(
         certificateInstructorId = 1)),
     "lhtl" -> Course(
       instructorIds = List(2),
@@ -39,8 +40,8 @@ class CourseStore {
       extraData = AnyData.build(new DataMap(
         Map("recentEnrollments" -> new Integer(1000)).asJava),
         DataConversion.SetReadOnly),
-      courseMetadata = CourseMetadata(
-        certificateInstructorId = 1)))
+      courseMetadata = DegreeCourseMetadata(
+        degreeCertificateName = "iMBA")))
 
   def get(id: String) = courseStore.get(id)
 

--- a/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/schema/NaptimeUnionFieldTest.scala
+++ b/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/schema/NaptimeUnionFieldTest.scala
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2016 Coursera Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.coursera.naptime.ari.graphql.schema
+
+import com.linkedin.data.schema.DataSchema
+import com.linkedin.data.schema.IntegerDataSchema
+import com.linkedin.data.schema.Name
+import com.linkedin.data.schema.RecordDataSchema
+import com.linkedin.data.schema.RecordDataSchema.Field
+import com.linkedin.data.schema.RecordDataSchema.RecordType
+import org.junit.Test
+import org.scalatest.junit.AssertionsForJUnit
+import org.scalatest.mock.MockitoSugar
+import com.linkedin.data.schema.UnionDataSchema
+import org.coursera.naptime.ari.graphql.Models
+import org.mockito.Mockito.when
+import sangria.schema.IntType
+import sangria.schema.ObjectType
+import sangria.schema.UnionType
+
+import scala.collection.JavaConverters._
+
+class NaptimeUnionFieldTest extends AssertionsForJUnit with MockitoSugar {
+
+  private[this] val resourceName = "courses.v1"
+  private[this]val schemaMetadata = mock[SchemaMetadata]
+  private[this]val resource = Models.courseResource
+  when(schemaMetadata.getResourceOpt(resourceName)).thenReturn(Some(resource))
+  when(schemaMetadata.getSchema(resource)).thenReturn(Some(null))
+
+  def buildUnionDataSchema(types: List[DataSchema], typedDefinitions: Option[Map[String, String]] = None): UnionDataSchema = {
+    val union = new UnionDataSchema()
+    val stringBuilder = new java.lang.StringBuilder()
+    union.setTypes(types.asJava, stringBuilder)
+    typedDefinitions.foreach(td => union.setProperties(
+      Map("typedDefinition" -> td.asJava.asInstanceOf[AnyRef]).asJava))
+    union
+  }
+
+  private[this] def buildRecordField(name: String, fields: List[Field]) = {
+    val fullName = new Name(name, "org.coursera.naptime", new java.lang.StringBuilder())
+    val recordDataSchema = new RecordDataSchema(fullName, RecordType.RECORD)
+    fields.foreach(_.setRecord(recordDataSchema))
+    val stringBuilder = new java.lang.StringBuilder()
+    recordDataSchema.setFields(fields.asJava, stringBuilder)
+    recordDataSchema
+  }
+
+  @Test
+  def build_SingleElementUnion() = {
+    val values = List(new IntegerDataSchema())
+    val union = buildUnionDataSchema(values)
+    val fieldName = "intOnlyUnion"
+    val field = NaptimeUnionField.build(schemaMetadata, union, fieldName, None, resourceName)
+
+    val expectedUnionTypes = List(
+      ObjectType("courses_v1_intMember", List(
+        FieldBuilder.buildPrimitiveField(fieldName, new IntegerDataSchema(), IntType))))
+    val expectedField = UnionType("courses_v1_intOnlyUnion", None, expectedUnionTypes)
+    assert(field.fieldType.toString === expectedField.toString)
+  }
+
+  @Test
+  def build_TypedDefinitionUnion() = {
+    val integerField = new Field(new IntegerDataSchema())
+    integerField.setName("integerField", new java.lang.StringBuilder())
+    val simpleFieldDataSchema = buildRecordField("simpleField", List(integerField))
+    val complexFieldDataSchema = buildRecordField("complexField", List(integerField))
+
+    val values = List(simpleFieldDataSchema, complexFieldDataSchema)
+    val union = buildUnionDataSchema(values, Some(Map(
+      "org.coursera.naptime.simpleField" -> "easy",
+      "org.coursera.naptime.complexField" -> "hard")))
+
+    val fieldName = "typedDefinitionTestField"
+    val field = NaptimeUnionField.build(schemaMetadata, union, fieldName, None, resourceName)
+
+    val expectedUnionTypes = List(
+      ObjectType("courses_v1_easyMember", List(
+        NaptimeRecordField.build(
+          schemaMetadata,
+          simpleFieldDataSchema,
+          "easy",
+          Some("org.coursera.naptime"),
+          resourceName))),
+      ObjectType("courses_v1_hardMember", List(
+        NaptimeRecordField.build(
+          schemaMetadata,
+          complexFieldDataSchema,
+          "hard",
+          Some("org.coursera.naptime"),
+          resourceName))))
+    val expectedField = UnionType("courses_v1_typedDefinitionTestField", None, expectedUnionTypes)
+    println(field.fieldType.toString)
+    println(expectedField.toString)
+    assert(field.fieldType.toString === expectedField.toString)
+  }
+
+}

--- a/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/schema/NaptimeUnionFieldTest.scala
+++ b/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/schema/NaptimeUnionFieldTest.scala
@@ -105,8 +105,6 @@ class NaptimeUnionFieldTest extends AssertionsForJUnit with MockitoSugar {
           Some("org.coursera.naptime"),
           resourceName))))
     val expectedField = UnionType("courses_v1_typedDefinitionTestField", None, expectedUnionTypes)
-    println(field.fieldType.toString)
-    println(expectedField.toString)
     assert(field.fieldType.toString === expectedField.toString)
   }
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.6.2"
+version in ThisBuild := "0.6.4"


### PR DESCRIPTION
Many of our Courier unions use `typedDefinitions`, which allows providing a “friendly name” to a union type, instead of using the fully qualified name.

This change adds supports for these typedDefinitions to Courier, both by changing the name of the member key in the union type, as well as parsing the typedDefinition response correctly.

PTAL @yifan-coursera / cc @qtran-coursera