### PR TITLE
Fix route path statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,5 +43,5 @@ We've attempted to follow a few principles to help guide development. They are r
 
 ## Using Naptime ##
 
-To learn more about how to use naptime, check out our
+To learn more about how to use naptime, check out our 
 [getting started guide](http://coursera.github.io/naptime/gettingstarted/)!

--- a/naptime/src/main/scala/org/coursera/naptime/router2/NaptimePlayRouter.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/router2/NaptimePlayRouter.scala
@@ -146,8 +146,9 @@ case class NaptimePlayRouter (
      * @return (PathWithoutKeys, PathWithKeySuffix)
      */
     def computeFullPath(resourceSchema: schema.Resource): (String, String) = {
-      val previous = if (resourceSchema.parentClass.isDefined &&
-          !resourceSchema.parentClass.contains("org.coursera.naptime.resources.RootResource")) {
+      val hasNonRootParent = resourceSchema.parentClass.isDefined &&
+          !resourceSchema.parentClass.contains("org.coursera.naptime.resources.RootResource") 
+      val previous = if (hasNonRootParent) {
         try {
           computeFullPath(naptimeRoutes.schemaMap(resourceSchema.parentClass.get))._2
         } catch {
@@ -160,7 +161,7 @@ case class NaptimePlayRouter (
       } else {
         prefix
       }
-      val resourceName = if (resourceSchema.parentClass.isDefined) {
+      val resourceName = if (hasNonRootParent) {
         s"${resourceSchema.name}"
       } else {
         s"${resourceSchema.name}.v${resourceSchema.version.getOrElse("???")}"

--- a/naptime/src/test/scala/org/coursera/naptime/router2/NaptimePlayRouterTest.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/router2/NaptimePlayRouterTest.scala
@@ -93,7 +93,7 @@ class NaptimePlayRouterTest extends AssertionsForJUnit with MockitoSugar {
   def generateDocumentation(): Unit = {
     val documentation = router.documentation
     assert(1 === documentation.length)
-    assert(("GET --- GET", "/fakeResource/$id", "[NAPTIME] org.coursera.naptime.FakeResource.get(id: String)") ===
+    assert(("GET --- GET", "/fakeResource.v1/$id", "[NAPTIME] org.coursera.naptime.FakeResource.get(id: String)") ===
       documentation.head)
   }
 }


### PR DESCRIPTION
Make resources that descend from RootResource print routes in the standard `$name.v$version` format. This is currently causing routes to be mis-printed for resources that subclass `CourierCollectionResource`, and causing our internal tests to fail cc @pseudonom . 