### PR TITLE
Respect alias names for related resources

### DIFF
--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/NaptimePaginatedResourceField.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/NaptimePaginatedResourceField.scala
@@ -139,7 +139,9 @@ object NaptimePaginatedResourceField {
         } else {
           Option(context.value.parentContext.value).map { parentElement =>
             // Nested Request
-            val allIds = Option(parentElement.getDataList(fieldName))
+            val alias = context.value.parentContext.astFields.headOption.flatMap(_.alias)
+            val aliasedFieldName = alias.getOrElse(fieldName)
+            val allIds = Option(parentElement.getDataList(aliasedFieldName))
               .map(_.asScala)
               .getOrElse(List.empty)
             val startOption = context.value.parentContext.arg(NaptimePaginationField.startArgument)

--- a/naptime/src/main/scala/org/coursera/naptime/ari/engine/EngineHelpers.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/ari/engine/EngineHelpers.scala
@@ -171,7 +171,7 @@ object EngineHelpers extends StrictLogging {
             reverseRelationForField(recordField).foreach { reverseRelation =>
               reverseRelations += ReverseRelatedField(
                 selection = fieldSelection,
-                path = path :+ recordField.getName,
+                path = path :+ fieldSelection.alias.getOrElse(fieldSelection.name),
                 element = element,
                 annotation = reverseRelation)
             }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.6.8"
+version in ThisBuild := "0.6.9"


### PR DESCRIPTION
When we fetch data for related resources, we must insert it in the datamap based on the alias key, not the field name. This allows us to fetch multiple related resources with different parameters, without overwriting the data based on the original field name

PTAL @yifan-coursera @vkuo-coursera 