### PR TITLE
Refactor GraphQL schema building to capture errors

### DIFF
--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/GraphqlSchemaProvider.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/GraphqlSchemaProvider.scala
@@ -20,8 +20,11 @@ import javax.inject.Inject
 
 import com.linkedin.data.schema.RecordDataSchema
 import com.typesafe.scalalogging.StrictLogging
+import org.coursera.naptime.ResourceName
 import org.coursera.naptime.ari.FullSchema
 import org.coursera.naptime.ari.SchemaProvider
+import org.coursera.naptime.ari.graphql.schema.MissingMergedType
+import org.coursera.naptime.ari.graphql.schema.SchemaErrors
 import sangria.schema.Field
 import sangria.schema.ObjectType
 import sangria.schema.Schema
@@ -34,6 +37,7 @@ import scala.util.control.NonFatal
  */
 trait GraphqlSchemaProvider {
   def schema: Schema[org.coursera.naptime.ari.graphql.SangriaGraphQlContext, Any]
+  def errors: SchemaErrors
 }
 
 /**
@@ -57,26 +61,35 @@ trait GraphqlSchemaProvider {
 class DefaultGraphqlSchemaProvider @Inject() (schemaProvider: SchemaProvider)
   extends GraphqlSchemaProvider with StrictLogging {
   private[this] var fullSchema = FullSchema.empty
-  private[this] var cachedSchema: Schema[SangriaGraphQlContext, Any] = DefaultGraphqlSchemaProvider.EMPTY_SCHEMA
+  private[this] var cachedSchema: Schema[SangriaGraphQlContext, Any] =
+    DefaultGraphqlSchemaProvider.EMPTY_SCHEMA
+  private[this] var schemaErrors: SchemaErrors = SchemaErrors.empty
 
   private[this] def recomputeSchema(latestSchema: FullSchema): Unit = {
     val typesMap = latestSchema.types.collect {
       case record: RecordDataSchema => record.getFullName -> record
     }.toMap
 
-    val types = latestSchema.resources.flatMap { resource =>
-      typesMap.get(resource.mergedType).map(resource.mergedType -> _).orElse {
-        logger.warn(s"Did not find merged type `${resource.mergedType}` for resource " +
-          s"${resource.name}.v${resource.version.getOrElse(0L)}")
-        None
-      }
-    }.toMap
+    val typesAndErrors = latestSchema.resources.map { resource =>
+      typesMap
+        .get(resource.mergedType)
+        .map(mergedType => Right(resource.mergedType -> mergedType))
+        .getOrElse {
+          logger.info(s"Did not find merged type `${resource.mergedType}` for resource " +
+            s"${resource.name}.v${resource.version.getOrElse(0L)}")
+          val resourceName = ResourceName(resource.name, resource.version.getOrElse(0L).toInt)
+          Left(MissingMergedType(resourceName))
+        }
+    }
+    val types = typesAndErrors.flatMap(_.right.toOption).toMap
     try {
       val builder = new SangriaGraphQlSchemaBuilder(latestSchema.resources, types)
-      val graphQlSchema =
-        builder.generateSchema().asInstanceOf[Schema[SangriaGraphQlContext, Any]]
+      val schemaAndErrors = builder.generateSchema()
+      val graphQlSchema = schemaAndErrors.data.asInstanceOf[Schema[SangriaGraphQlContext, Any]]
       fullSchema = latestSchema
       cachedSchema = graphQlSchema
+
+      schemaErrors = schemaAndErrors.errors ++ typesAndErrors.toList.flatMap(_.left.toOption)
     } catch {
       case NonFatal(e) =>
         logger.error(s"Could not build schema.", e)
@@ -97,6 +110,10 @@ class DefaultGraphqlSchemaProvider @Inject() (schemaProvider: SchemaProvider)
     checkSchema()
     cachedSchema
   }
+
+  override def errors: SchemaErrors = {
+    schemaErrors
+  }
 }
 
 object DefaultGraphqlSchemaProvider {
@@ -106,4 +123,6 @@ object DefaultGraphqlSchemaProvider {
       StringType,
       resolve = context => null))
   val EMPTY_SCHEMA = Schema[SangriaGraphQlContext, Any](query = ObjectType[SangriaGraphQlContext, Any](name = "root", fields = EMPTY_FIELDS))
+
 }
+

--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/SangriaGraphQlSchemaBuilder.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/SangriaGraphQlSchemaBuilder.scala
@@ -19,33 +19,16 @@ package org.coursera.naptime.ari.graphql
 import com.linkedin.data.DataMap
 import com.linkedin.data.schema.RecordDataSchema
 import com.typesafe.scalalogging.StrictLogging
-import org.coursera.naptime.ResourceName
-import org.coursera.naptime.ari.graphql.schema.NaptimePaginatedResourceField
-import org.coursera.naptime.ari.graphql.schema.NaptimePaginationField
-import org.coursera.naptime.ari.graphql.schema.NaptimeResourceField
+import org.coursera.naptime.ari.graphql.schema.NaptimeTopLevelResourceField
+import org.coursera.naptime.ari.graphql.schema.SchemaErrors
 import org.coursera.naptime.ari.graphql.schema.SchemaMetadata
-import org.coursera.naptime.schema.ArbitraryValue
-import org.coursera.naptime.schema.Handler
-import org.coursera.naptime.schema.HandlerKind
+import org.coursera.naptime.ari.graphql.schema.WithSchemaErrors
 import org.coursera.naptime.schema.Resource
-import sangria.marshalling.FromInput
-import sangria.schema.Argument
-import sangria.schema.BigDecimalType
-import sangria.schema.BooleanType
 import sangria.schema.Context
-import sangria.schema.FloatType
-import sangria.schema.InputType
-import sangria.schema.IntType
-import sangria.schema.ListInputType
-import sangria.schema.LongType
 import sangria.schema.Schema
-import sangria.schema.StringType
 import sangria.schema.Value
-import sangria.marshalling.FromInput._
 import sangria.schema.Field
 import sangria.schema.ObjectType
-import sangria.schema.OptionInputType
-import sangria.schema.OptionType
 
 class SangriaGraphQlSchemaBuilder(
     resources: Set[Resource],
@@ -56,219 +39,39 @@ class SangriaGraphQlSchemaBuilder(
 
   /**
     * Generates a GraphQL schema for the provided set of resources to this class
-    * Returns a "root" object that has one field available for each Naptime Resource provided.*
+    * Returns a "root" object that has one field available for each Naptime Resource provided.
     *
-    * @return a Sangria GraphQL Schema with all resources defined
+    * @return a Sangria GraphQL Schema with all resources defined,
+    *         and a list of errors that came up while generating the schema
     */
-  def generateSchema(): Schema[SangriaGraphQlContext, DataMap] = {
-    val topLevelResourceObjects = for {
-      resource <- resources
-      resourceObject <- (try {
-        val resourceName = ResourceName(
-          resource.name, resource.version.getOrElse(0L).toInt).identifier
-        generateLookupTypeForResource(resourceName)
-      } catch {
-        case e: Throwable => None
-      }).toList if resourceObject.fields.nonEmpty
-    } yield {
-      Field.apply[SangriaGraphQlContext, DataMap, DataMap, Any](
-        formatResourceTopLevelName(resource),
-        resourceObject,
-        resolve = (context: Context[SangriaGraphQlContext, DataMap]) => {
-          Value(new DataMap())
-        })
+  def generateSchema(): WithSchemaErrors[Schema[SangriaGraphQlContext, DataMap]] = {
+    val topLevelResourceObjectsAndErrors = resources.map { resource =>
+      val lookupTypeAndErrors =
+        NaptimeTopLevelResourceField.generateLookupTypeForResource(resource, schemaMetadata)
+      val fields = lookupTypeAndErrors.data.flatMap { resourceObject =>
+        if (resourceObject.fields.nonEmpty) {
+          Some(Field.apply[SangriaGraphQlContext, DataMap, DataMap, Any](
+            NaptimeTopLevelResourceField.formatResourceTopLevelName(resource),
+            resourceObject,
+            resolve = (_: Context[SangriaGraphQlContext, DataMap]) => {
+              Value(new DataMap())
+            }))
+        } else {
+          None
+        }
+      }
+      lookupTypeAndErrors.copy(data = fields)
     }
+
+    val topLevelResourceObjects = topLevelResourceObjectsAndErrors.flatMap(_.data)
+    val schemaErrors = topLevelResourceObjectsAndErrors.foldLeft(SchemaErrors.empty)(_ ++ _.errors)
 
     val dedupedResources = topLevelResourceObjects.groupBy(_.name).map(_._2.head).toList
     val rootObject = ObjectType[SangriaGraphQlContext, DataMap](
       name = "root",
       description = "Top-level accessor for Naptime resources",
       fields = dedupedResources)
-    Schema(rootObject)
-  }
 
-  /**
-    * Generates an object-type for a given resource name, with each field on the merged output
-    * schema available on this object-type.
-    *
-    * @param resourceName String name of the resource (i.e. 'courses.v1')
-    * @return ObjectType for the resource
-    */
-  def generateLookupTypeForResource(resourceName: String): Option[ObjectType[SangriaGraphQlContext, DataMap]] = {
-
-    try {
-      val resource = schemaMetadata.getResource(resourceName)
-      val fields = resource.handlers.flatMap { handler =>
-        handler.kind match {
-          // We want to make sure that if a resource has a GET handler, it also has a MULTI_GET handler
-          case HandlerKind.GET if resource.handlers.exists(_.kind == HandlerKind.MULTI_GET) =>
-            generateGetHandler(resource, handler)
-          case HandlerKind.GET_ALL | HandlerKind.MULTI_GET | HandlerKind.FINDER =>
-            generateListHandler(resource, handler)
-          case _ => None
-        }
-      }.toList
-      if (fields.nonEmpty) {
-        val resourceObjectType = ObjectType[SangriaGraphQlContext, DataMap](
-          name = formatResourceTopLevelName(resource),
-          fieldsFn = () => fields)
-        Some(resourceObjectType)
-      } else {
-        logger.warn(s"No handlers available for resource $resourceName")
-        None
-      }
-    } catch {
-      case e: Throwable =>
-        logger.error(s"Unknown error when generating resource: ${e.getMessage}")
-        None
-    }
-  }
-
-  def generateGetHandler(
-      resource: Resource,
-      handler: Handler): Option[Field[SangriaGraphQlContext, DataMap]] = {
-    val arguments = SangriaGraphQlSchemaBuilder.generateHandlerArguments(handler)
-    val resourceName = ResourceName(resource.name, resource.version.getOrElse(0L).toInt)
-
-    val idExtractor = (context: Context[SangriaGraphQlContext, DataMap]) => {
-      val id = context.arg[AnyRef]("id")
-      id match {
-        case idOpt: Option[Any] => idOpt.orNull
-        case _ => id
-      }
-    }
-
-    NaptimeResourceField.build(
-      schemaMetadata = schemaMetadata,
-      resourceName = resourceName.identifier,
-      fieldName = "get",
-      idExtractor = Some(idExtractor))
-      .map { field =>
-        field.copy(arguments = arguments ++ field.arguments)
-      }
-  }
-
-  def generateListHandler(
-      resource: Resource,
-      handler: Handler): Option[Field[SangriaGraphQlContext, DataMap]] = {
-    val resourceName = ResourceName(resource.name, resource.version.getOrElse(0L).toInt)
-    val arguments = SangriaGraphQlSchemaBuilder.generateHandlerArguments(handler)
-
-
-    val fieldName = handler.kind match {
-      case HandlerKind.FINDER => handler.name
-      case HandlerKind.GET_ALL => "getAll"
-      case HandlerKind.MULTI_GET => "multiGet"
-      case _ => "error"
-    }
-
-    NaptimePaginatedResourceField.build(
-      schemaMetadata = schemaMetadata,
-      resourceName = resourceName.identifier,
-      fieldName = fieldName,
-      handlerOverride = Some(handler),
-      fieldRelation = None).map { field =>
-
-      val mergedArguments = (field.arguments ++ arguments)
-        .groupBy(_.name)
-        .map(_._2.head)
-        .map(_.asInstanceOf[Argument[Any]])
-        .toList
-      field.copy(arguments = mergedArguments)
-    }
-  }
-
-  /**
-    * Converts a resource name to a GraphQL compatible name. (i.e. 'courses.v1' to 'CoursesV1')
-    *
-    * @param resource Naptime resource
-    * @return GraphQL-safe resource name
-    */
-  def formatResourceName(resource: Resource): String = {
-    s"${resource.name.capitalize}V${resource.version.getOrElse(0)}"
-  }
-
-  /**
-    * Converts a resource to a GraphQL top-level name. (i.e. 'courses.v1' to 'CoursesV1Resource')
-    *
-    * @param resource Naptime resource
-    * @return GraphQL-safe top-level resource name
-    */
-  def formatResourceTopLevelName(resource: Resource): String = {
-    s"${formatResourceName(resource)}Resource"
-  }
-}
-
-object SangriaGraphQlSchemaBuilder extends StrictLogging {
-
-  val PAGINATION_ARGUMENT_NAMES = NaptimePaginationField.paginationArguments.map(_.name)
-
-  def generateHandlerArguments(handler: Handler, includePagination: Boolean = false): List[Argument[Any]] = {
-    val baseParameters = handler.parameters
-      .filterNot(parameter => PAGINATION_ARGUMENT_NAMES.contains(parameter.name))
-      .map { parameter =>
-        val tpe = parameter.`type`
-        val inputType = scalaTypeToSangria(tpe)
-        val fromInputType = scalaTypeToFromInput(tpe)
-        val (optionalInputType, optionalFromInputType: FromInput[Any]) = (inputType, parameter.required) match {
-          case (_: OptionInputType[Any], _) => (inputType, fromInputType)
-          case (_, false) => (OptionInputType(inputType), FromInput.optionInput(fromInputType))
-          case (_, true) => (inputType, fromInputType)
-        }
-        Argument(
-          name = parameter.name,
-          argumentType = optionalInputType)(optionalFromInputType, implicitly).asInstanceOf[Argument[Any]]
-      }.toList
-    val paginationParameters = if (includePagination) {
-      NaptimePaginationField.paginationArguments
-    } else {
-      List.empty
-    }
-    (baseParameters ++ paginationParameters)
-      .groupBy(_.name)
-      .map(_._2.head.asInstanceOf[Argument[Any]])
-      .toList
-  }
-
-  def scalaTypeToSangria(typeName: String): InputType[Any] = {
-    import sangria.marshalling.FromInput.seqInput
-    import sangria.marshalling.FromInput.coercedScalaInput
-
-    val listPattern = "(Set|List|Seq|immutable.Seq)\\[(.*)\\]".r
-    val optionPattern = "(Option)\\[(.*)\\]".r
-    // TODO(bryan): Fill in the missing types here
-    typeName match {
-      case listPattern(_, innerType) => ListInputType(scalaTypeToSangria(innerType))
-      case optionPattern(_, innerType) => OptionInputType(scalaTypeToSangria(innerType))
-      case "string" | "String" => StringType
-      case "int" | "Int" => IntType
-      case "long" | "Long" => LongType
-      case "float" | "Float" => FloatType
-      case "decimal" | "Decimal" => BigDecimalType
-      case "boolean" | "Boolean" => BooleanType
-      case _ => {
-        logger.warn(s"could not parse type from $typeName")
-        StringType
-      }
-    }
-  }
-
-  def scalaTypeToFromInput(typeName: String): FromInput[Any] = {
-    import sangria.marshalling.FromInput.seqInput
-    import sangria.marshalling.FromInput.coercedScalaInput
-
-    val listPattern = "(set|list|seq|immutable.Seq)\\[(.*)\\]".r
-    val optionPattern = "(Option)\\[(.*)\\]".r
-
-    // TODO(bryan): Fix all of this :)
-    typeName.toLowerCase match {
-      case listPattern(outerType, innerType) =>
-        val listType = scalaTypeToFromInput(innerType)
-        sangria.marshalling.FromInput.seqInput(listType).asInstanceOf[FromInput[Any]]
-      case "string" | "int" | "long" | "float" | "decimal" | "boolean" =>
-        sangria.marshalling.FromInput.coercedScalaInput.asInstanceOf[FromInput[Any]]
-      case _ =>
-        sangria.marshalling.FromInput.coercedScalaInput.asInstanceOf[FromInput[Any]]
-    }
+    WithSchemaErrors(Schema(rootObject), schemaErrors)
   }
 }

--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/FieldBuilder.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/FieldBuilder.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 Coursera Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.coursera.naptime.ari.graphql.schema
 
 import com.linkedin.data.DataMap
@@ -24,6 +40,7 @@ import com.linkedin.data.schema.validation.ValidateDataAgainstSchema
 import com.linkedin.data.schema.validation.ValidationOptions
 import com.typesafe.scalalogging.StrictLogging
 import org.coursera.courier.templates.DataTemplates.DataConversion
+import org.coursera.naptime.ResourceName
 import org.coursera.naptime.Types.Relations
 import org.coursera.naptime.ari.graphql.SangriaGraphQlContext
 import org.coursera.naptime.ari.graphql.schema.NaptimePaginatedResourceField.ForwardRelation
@@ -56,7 +73,7 @@ object FieldBuilder extends StrictLogging {
       namespace: Option[String],
       fieldNameOverride: Option[String] = None,
       followRelations: Boolean = true,
-      resourceName: String): Field[SangriaGraphQlContext, DataMap] = {
+      resourceName: ResourceName): Field[SangriaGraphQlContext, DataMap] = {
 
     type ResolverType = Context[SangriaGraphQlContext, DataMap] => Value[SangriaGraphQlContext, Any]
 
@@ -67,7 +84,9 @@ object FieldBuilder extends StrictLogging {
     }
 
     val relatedResourceOption = if (followRelations) {
-      forwardRelationOption.orElse(reverseRelationOption.map(_.resourceName))
+      forwardRelationOption
+        .orElse(reverseRelationOption.map(_.resourceName))
+        .flatMap(ResourceName.parse)
     } else {
       None
     }
@@ -82,8 +101,10 @@ object FieldBuilder extends StrictLogging {
       case (Some(relatedResourceName), _: ArrayDataSchema) =>
         val fieldRelation = forwardRelationOption.map(ForwardRelation)
           .orElse(reverseRelationOption.map(ReverseRelation))
+        // TODO(bryan): don't throw away errors from the left here
         NaptimePaginatedResourceField
           .build(schemaMetadata, relatedResourceName, fieldName, None, fieldRelation)
+          .right
           .getOrElse {
             buildField(schemaMetadata, field, namespace, fieldNameOverride,
               followRelations = false, resourceName = resourceName)
@@ -91,8 +112,10 @@ object FieldBuilder extends StrictLogging {
 
       // Single related resource
       case (Some(relatedResourceName), _) =>
+        // TODO(bryan): don't throw away errors from the left here
         NaptimeResourceField
           .build(schemaMetadata, relatedResourceName, fieldName)
+          .right
           .getOrElse {
             buildField(schemaMetadata, field, namespace, fieldNameOverride,
               followRelations = false, resourceName = resourceName)

--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/NaptimeRecordField.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/NaptimeRecordField.scala
@@ -2,6 +2,7 @@ package org.coursera.naptime.ari.graphql.schema
 
 import com.linkedin.data.DataMap
 import com.linkedin.data.schema.RecordDataSchema
+import org.coursera.naptime.ResourceName
 import org.coursera.naptime.ari.graphql.SangriaGraphQlContext
 import sangria.schema.Field
 import sangria.schema.ObjectType
@@ -16,7 +17,7 @@ object NaptimeRecordField {
       recordDataSchema: RecordDataSchema,
       fieldName: String,
       namespace: Option[String],
-      resourceName: String) = {
+      resourceName: ResourceName) = {
 
     Field.apply[SangriaGraphQlContext, DataMap, Any, Any](
       name = FieldBuilder.formatName(fieldName),
@@ -28,10 +29,11 @@ object NaptimeRecordField {
       schemaMetadata: SchemaMetadata,
       recordDataSchema: RecordDataSchema,
       namespace: Option[String],
-      resourceName: String): ObjectType[SangriaGraphQlContext, DataMap] = {
+      resourceName: ResourceName): ObjectType[SangriaGraphQlContext, DataMap] = {
 
+    val formattedResourceName = NaptimeResourceUtils.formatResourceName(resourceName)
     ObjectType[SangriaGraphQlContext, DataMap](
-      FieldBuilder.formatName(s"${resourceName}_${recordDataSchema.getFullName}"),
+      FieldBuilder.formatName(s"${formattedResourceName}_${recordDataSchema.getFullName}"),
       recordDataSchema.getDoc,
       fieldsFn = () => {
         val fields = recordDataSchema.getFields.asScala.map { field =>

--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/NaptimeResourceField.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/NaptimeResourceField.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 Coursera Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.coursera.naptime.ari.graphql.schema
 
 import com.linkedin.data.DataMap
@@ -25,46 +41,50 @@ object NaptimeResourceField extends StrictLogging {
 
   def build(
       schemaMetadata: SchemaMetadata,
-      resourceName: String,
+      resourceName: ResourceName,
       fieldName: String,
-      idExtractor: Option[IdExtractor] = None): Option[Field[SangriaGraphQlContext, DataMap]] = {
+      idExtractor: Option[IdExtractor] = None):
+    Either[SchemaError, Field[SangriaGraphQlContext, DataMap]] = {
 
     schemaMetadata.getResourceOpt(resourceName).map { resource =>
       val arguments = resource.handlers.find(_.kind == HandlerKind.MULTI_GET).map { handler =>
-        SangriaGraphQlSchemaBuilder
+        NaptimeResourceUtils
           .generateHandlerArguments(handler, includePagination = false)
           .filterNot(_.name == "ids")
       }.getOrElse(List.empty)
 
-      Field.apply[SangriaGraphQlContext, DataMap, Any, Any](
-        name = fieldName,
-        fieldType = getType(schemaMetadata, resourceName),
-        resolve = getResolver(resourceName, fieldName, idExtractor),
-        arguments = arguments,
-        complexity = Some(
-          (ctx, args, childScore) => {
-            COMPLEXITY_COST * childScore
-          }))
-    }
+      getType(schemaMetadata, resourceName).right.map { fieldType =>
+        Field.apply[SangriaGraphQlContext, DataMap, Any, Any](
+          name = fieldName,
+          fieldType = fieldType,
+          resolve = getResolver(resourceName, fieldName, idExtractor),
+          arguments = arguments,
+          complexity = Some(
+            (ctx, args, childScore) => {
+              COMPLEXITY_COST * childScore
+            }))
+      }
+    }.getOrElse(Left(SchemaNotFound(resourceName)))
   }
 
   private[schema] def getType(
       schemaMetadata: SchemaMetadata,
-      resourceName: String): OptionType[DataMap] = {
+      resourceName: ResourceName): Either[SchemaError, OptionType[DataMap]] = {
     val resource = schemaMetadata.getResource(resourceName)
-    val schema = schemaMetadata.getSchema(resource).getOrElse {
-      throw SchemaGenerationException(s"Cannot find schema for $resourceName")
-    }
+    schemaMetadata.getSchema(resource).map { schema =>
 
-    val resourceObjectType = OptionType(ObjectType[SangriaGraphQlContext, DataMap](
-      name = formatResourceName(resource),
-      description = schema.getDoc,
-      fieldsFn = () => {
-        Option(schema.getFields).map(_.asScala.map { field =>
-          generateField(field, schemaMetadata, resource, schema)
-        }.toList).getOrElse(List.empty).flatten
-      }))
-    resourceObjectType
+      val resourceObjectType = OptionType(
+        ObjectType[SangriaGraphQlContext, DataMap](
+          name = formatResourceName(resource),
+          description = schema.getDoc,
+          fieldsFn = () => {
+            Option(schema.getFields).map(
+              _.asScala.map { field =>
+                generateField(field, schemaMetadata, resource, schema)
+              }.toList).getOrElse(List.empty).flatten
+          }))
+      resourceObjectType
+    }.toRight(SchemaNotFound(resourceName))
   }
 
   private[schema] def generateField(
@@ -72,25 +92,33 @@ object NaptimeResourceField extends StrictLogging {
       schemaMetadata: SchemaMetadata,
       resource: Resource,
       schema: RecordDataSchema): Option[Field[SangriaGraphQlContext, DataMap]] = {
-    val forwardRelationOption = field.getProperties.asScala.get(Relations.PROPERTY_NAME).map(_.toString)
+
+    val forwardRelationOption = field.getProperties.asScala
+      .get(Relations.PROPERTY_NAME)
+      .map(_.toString)
+
     if (forwardRelationOption.isDefined) {
-      val relatedResource = schemaMetadata.getResource(forwardRelationOption.get)
-      if (relatedResource.handlers.exists(_.kind == HandlerKind.MULTI_GET)) {
-        Some(FieldBuilder.buildField(schemaMetadata, field, Option(schema.getNamespace),
-          resourceName = formatResourceName(resource)))
-      } else {
-        logger.warn(s"Unable to build field for forward relation from " +
-          s"${resource.name} -> ${forwardRelationOption.get} due to the lack of a MULTI_GET handler")
-        None
-      }
+      (for {
+        resourceName <- ResourceName.parse(forwardRelationOption.get)
+        relatedResource <- schemaMetadata.getResourceOpt(resourceName)
+      } yield {
+        if (relatedResource.handlers.exists(_.kind == HandlerKind.MULTI_GET)) {
+          Some(FieldBuilder.buildField(schemaMetadata, field, Option(schema.getNamespace),
+            resourceName = ResourceName.fromResource(resource)))
+        } else {
+          logger.warn(s"Unable to build field for forward relation from " +
+            s"${resource.name} -> ${forwardRelationOption.get} due to the lack of a MULTI_GET handler")
+          None
+        }
+      }).getOrElse(None)
     } else {
       Some(FieldBuilder.buildField(schemaMetadata, field, Option(schema.getNamespace),
-        resourceName = formatResourceName(resource)))
+        resourceName = ResourceName.fromResource(resource)))
     }
   }
 
   private[this] def getResolver(
-      resourceName: String,
+      resourceName: ResourceName,
       fieldName: String,
       idExtractor: Option[IdExtractor]): FieldBuilder.ResolverType = {
     (context: Context[SangriaGraphQlContext, DataMap]) => {
@@ -100,16 +128,13 @@ object NaptimeResourceField extends StrictLogging {
       if (id == null) {
         Value[SangriaGraphQlContext, Any](null)
       } else {
-        val parsedResourceName = ResourceName.parse(resourceName).getOrElse {
-          throw SchemaExecutionException(s"Cannot parse resource name from $resourceName")
-        }
-        context.ctx.response.data.get(parsedResourceName)
+        context.ctx.response.data.get(resourceName)
           .flatMap { resourceSet =>
             resourceSet
               .find(resource => id == resource._1)
               .map(optionalElement => Value[SangriaGraphQlContext, Any](optionalElement._2))
           }.getOrElse {
-            throw NotFoundException(s"Cannot find $resourceName/$id")
+            throw NotFoundException(s"Cannot find ${resourceName.identifier}/$id")
           }
       }
     }

--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/NaptimeResourceField.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/NaptimeResourceField.scala
@@ -97,6 +97,7 @@ object NaptimeResourceField extends StrictLogging {
       .get(Relations.PROPERTY_NAME)
       .map(_.toString)
 
+    // TODO(bryan): Remove all references to forward relations once fully deprecated
     if (forwardRelationOption.isDefined) {
       (for {
         resourceName <- ResourceName.parse(forwardRelationOption.get)

--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/NaptimeResourceUtils.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/NaptimeResourceUtils.scala
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2016 Coursera Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.coursera.naptime.ari.graphql.schema
+
+import com.typesafe.scalalogging.StrictLogging
+import org.coursera.naptime.ResourceName
+import org.coursera.naptime.schema.Handler
+import sangria.marshalling.FromInput
+import sangria.schema.Argument
+import sangria.schema.BigDecimalType
+import sangria.schema.BooleanType
+import sangria.schema.FloatType
+import sangria.schema.InputType
+import sangria.schema.IntType
+import sangria.schema.ListInputType
+import sangria.schema.LongType
+import sangria.schema.OptionInputType
+import sangria.schema.StringType
+
+object NaptimeResourceUtils extends StrictLogging {
+  private[this] val PAGINATION_ARGUMENT_NAMES: List[String] =
+    NaptimePaginationField.paginationArguments.map(_.name)
+
+  def generateHandlerArguments(
+      handler: Handler,
+      includePagination: Boolean = false): List[Argument[Any]] = {
+    val baseParameters = handler.parameters
+      .filterNot(parameter => PAGINATION_ARGUMENT_NAMES.contains(parameter.name))
+      .map { parameter =>
+        val tpe = parameter.`type`
+        val inputType = scalaTypeToSangria(tpe)
+        val fromInputType = scalaTypeToFromInput(tpe)
+        val (optionalInputType, optionalFromInputType: FromInput[Any]) =
+          (inputType, parameter.required) match {
+            case (_: OptionInputType[Any], _) => (inputType, fromInputType)
+            case (_, false) => (OptionInputType(inputType), FromInput.optionInput(fromInputType))
+            case (_, true) => (inputType, fromInputType)
+          }
+        Argument(
+          name = parameter.name,
+          argumentType = optionalInputType)(optionalFromInputType, implicitly)
+            .asInstanceOf[Argument[Any]]
+      }.toList
+    val paginationParameters = if (includePagination) {
+      NaptimePaginationField.paginationArguments
+    } else {
+      List.empty
+    }
+    (baseParameters ++ paginationParameters)
+      .groupBy(_.name)
+      .map(_._2.head.asInstanceOf[Argument[Any]])
+      .toList
+  }
+
+  private[this] def scalaTypeToSangria(typeName: String): InputType[Any] = {
+    import sangria.marshalling.FromInput.seqInput
+    import sangria.marshalling.FromInput.coercedScalaInput
+
+    val listPattern = "(Set|List|Seq|immutable.Seq)\\[(.*)\\]".r
+    val optionPattern = "(Option)\\[(.*)\\]".r
+    // TODO(bryan): Fill in the missing types here
+    typeName match {
+      case listPattern(_, innerType) => ListInputType(scalaTypeToSangria(innerType))
+      case optionPattern(_, innerType) => OptionInputType(scalaTypeToSangria(innerType))
+      case "string" | "String" => StringType
+      case "int" | "Int" => IntType
+      case "long" | "Long" => LongType
+      case "float" | "Float" => FloatType
+      case "decimal" | "Decimal" => BigDecimalType
+      case "boolean" | "Boolean" => BooleanType
+      case _ => {
+        logger.info(s"could not parse type from $typeName")
+        StringType
+      }
+    }
+  }
+
+  private[this] def scalaTypeToFromInput(typeName: String): FromInput[Any] = {
+    import sangria.marshalling.FromInput.seqInput
+    import sangria.marshalling.FromInput.coercedScalaInput
+
+    val listPattern = "(set|list|seq|immutable.Seq)\\[(.*)\\]".r
+
+    // TODO(bryan): Fix all of this :)
+    typeName.toLowerCase match {
+      case listPattern(outerType, innerType) =>
+        val listType = scalaTypeToFromInput(innerType)
+        sangria.marshalling.FromInput.seqInput(listType).asInstanceOf[FromInput[Any]]
+      case "string" | "int" | "long" | "float" | "decimal" | "boolean" =>
+        sangria.marshalling.FromInput.coercedScalaInput.asInstanceOf[FromInput[Any]]
+      case _ =>
+        sangria.marshalling.FromInput.coercedScalaInput.asInstanceOf[FromInput[Any]]
+    }
+  }
+
+  /**
+    * Converts a resource name to a GraphQL compatible name. (i.e. 'courses.v1' to 'CoursesV1')
+    *
+    * @param resourceName Naptime resource name
+    * @return GraphQL-safe resource name
+    */
+  def formatResourceName(resourceName: ResourceName): String = {
+    s"${resourceName.topLevelName.capitalize}V${resourceName.version}"
+  }
+}

--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/NaptimeTopLevelResourceField.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/NaptimeTopLevelResourceField.scala
@@ -56,7 +56,6 @@ object NaptimeTopLevelResourceField extends StrictLogging {
       .filterNot(handler => MUTATION_HANDLERS.contains(handler.kind))
       .map { handler =>
         handler.kind match {
-          // We want to make sure that if a resource has a GET handler, it also has a MULTI_GET
           case HandlerKind.GET =>
             generateGetHandler(resource, handler, schemaMetadata)
           case HandlerKind.GET_ALL | HandlerKind.MULTI_GET | HandlerKind.FINDER =>

--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/NaptimeTopLevelResourceField.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/NaptimeTopLevelResourceField.scala
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2016 Coursera Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.coursera.naptime.ari.graphql.schema
+
+import com.linkedin.data.DataMap
+import com.typesafe.scalalogging.StrictLogging
+import org.coursera.naptime.ResourceName
+import org.coursera.naptime.ari.graphql.SangriaGraphQlContext
+import org.coursera.naptime.schema.Handler
+import org.coursera.naptime.schema.HandlerKind
+import org.coursera.naptime.schema.Resource
+import sangria.schema.Argument
+import sangria.schema.Context
+import sangria.schema.Field
+import sangria.schema.ObjectType
+
+object NaptimeTopLevelResourceField extends StrictLogging {
+
+  val MUTATION_HANDLERS: Set[HandlerKind] = Set(
+    HandlerKind.ACTION,
+    HandlerKind.CREATE,
+    HandlerKind.DELETE,
+    HandlerKind.PATCH,
+    HandlerKind.UPSERT)
+
+  /**
+    * Generates an object-type for a given resource name, with each field on the merged output
+    * schema available on this object-type.
+    *
+    * @param resource Resource to generate lookup type for
+    * @return WithSchemaErrors[ObjectType] including the ObjectType for the resource,
+    *         if we were able to generate it, and any errors generated while creating the type.
+    */
+  def generateLookupTypeForResource(
+      resource: Resource,
+      schemaMetadata: SchemaMetadata):
+    WithSchemaErrors[Option[ObjectType[SangriaGraphQlContext, DataMap]]] = {
+
+    val resourceName = ResourceName.fromResource(resource)
+
+    val fieldsAndErrors = resource.handlers
+      .filterNot(handler => MUTATION_HANDLERS.contains(handler.kind))
+      .map { handler =>
+        handler.kind match {
+          // We want to make sure that if a resource has a GET handler, it also has a MULTI_GET
+          case HandlerKind.GET =>
+            generateGetHandler(resource, handler, schemaMetadata)
+          case HandlerKind.GET_ALL | HandlerKind.MULTI_GET | HandlerKind.FINDER =>
+            generateListHandler(resource, handler, schemaMetadata)
+          case unknownHandler: HandlerKind =>
+            Left(UnknownHandlerType(resourceName, unknownHandler.name))
+        }
+    }.toList
+
+    val fields = fieldsAndErrors.flatMap(_.right.toOption)
+    val errors = SchemaErrors(fieldsAndErrors.flatMap(_.left.toOption))
+
+    if (fields.nonEmpty) {
+      val resourceObjectType = ObjectType[SangriaGraphQlContext, DataMap](
+        name = formatResourceTopLevelName(resource),
+        fieldsFn = () => fields)
+      WithSchemaErrors(Some(resourceObjectType), errors)
+    } else {
+      WithSchemaErrors(None, errors + NoHandlersAvailable(resourceName))
+    }
+  }
+
+  private[this] def generateGetHandler(
+      resource: Resource,
+      handler: Handler,
+      schemaMetadata: SchemaMetadata):
+    Either[SchemaError, Field[SangriaGraphQlContext, DataMap]] = {
+
+    // We use MultiGets under the hood for all Gets,
+    // so only add a Get handler if there's also a MultiGet available
+    if (resource.handlers.exists(_.kind == HandlerKind.MULTI_GET)) {
+      val arguments = NaptimeResourceUtils.generateHandlerArguments(handler)
+      val resourceName = ResourceName.fromResource(resource)
+
+      val idExtractor = (context: Context[SangriaGraphQlContext, DataMap]) => {
+        val id = context.arg[AnyRef]("id")
+        id match {
+          case idOpt: Option[Any] => idOpt.orNull
+          case _ => id
+        }
+      }
+
+      NaptimeResourceField.build(
+        schemaMetadata = schemaMetadata,
+        resourceName = resourceName,
+        fieldName = "get",
+        idExtractor = Some(idExtractor))
+        .right
+        .map { field =>
+          field.copy(arguments = arguments ++ field.arguments)
+        }
+    } else {
+      Left(HasGetButMissingMultiGet(ResourceName.fromResource(resource)))
+    }
+  }
+
+  private[this] def generateListHandler(
+      resource: Resource,
+      handler: Handler,
+      schemaMetadata: SchemaMetadata):
+    Either[SchemaError, Field[SangriaGraphQlContext, DataMap]] = {
+
+    val resourceName = ResourceName(resource.name, resource.version.getOrElse(0L).toInt)
+    val arguments = NaptimeResourceUtils.generateHandlerArguments(handler)
+
+    val fieldName = handler.kind match {
+      case HandlerKind.FINDER => handler.name
+      case HandlerKind.GET_ALL => "getAll"
+      case HandlerKind.MULTI_GET => "multiGet"
+      case _ => "error"
+    }
+
+    NaptimePaginatedResourceField.build(
+      schemaMetadata = schemaMetadata,
+      resourceName = resourceName,
+      fieldName = fieldName,
+      handlerOverride = Some(handler),
+      fieldRelation = None).right.map { field =>
+
+      val mergedArguments = (field.arguments ++ arguments)
+        .groupBy(_.name)
+        .map(_._2.head)
+        .map(_.asInstanceOf[Argument[Any]])
+        .toList
+      field.copy(arguments = mergedArguments)
+    }
+  }
+
+  /**
+    * Converts a resource name to a GraphQL compatible name. (i.e. 'courses.v1' to 'CoursesV1')
+    *
+    * @param resource Naptime resource
+    * @return GraphQL-safe resource name
+    */
+  def formatResourceName(resource: Resource): String = {
+    s"${resource.name.capitalize}V${resource.version.getOrElse(0)}"
+  }
+
+  /**
+    * Converts a resource to a GraphQL top-level name. (i.e. 'courses.v1' to 'CoursesV1Resource')
+    *
+    * @param resource Naptime resource
+    * @return GraphQL-safe top-level resource name
+    */
+  def formatResourceTopLevelName(resource: Resource): String = {
+    s"${formatResourceName(resource)}Resource"
+  }
+}

--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/NaptimeUnionField.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/NaptimeUnionField.scala
@@ -4,6 +4,7 @@ import com.linkedin.data.DataMap
 import com.linkedin.data.schema.NamedDataSchema
 import com.linkedin.data.schema.RecordDataSchema.{Field => RecordDataSchemaField}
 import com.linkedin.data.schema.UnionDataSchema
+import org.coursera.naptime.ResourceName
 import org.coursera.naptime.ari.graphql.SangriaGraphQlContext
 import sangria.schema.Field
 import sangria.schema.ObjectType
@@ -22,7 +23,7 @@ object NaptimeUnionField {
       unionDataSchema: UnionDataSchema,
       fieldName: String,
       namespace: Option[String],
-      resourceName: String): Field[SangriaGraphQlContext, DataMap] = {
+      resourceName: ResourceName): Field[SangriaGraphQlContext, DataMap] = {
     Field.apply[SangriaGraphQlContext, DataMap, Any, Any](
       name = fieldName,
       fieldType = getType(schemaMetadata, unionDataSchema, fieldName, namespace, resourceName),
@@ -42,7 +43,7 @@ object NaptimeUnionField {
       unionDataSchema: UnionDataSchema,
       fieldName: String,
       namespace: Option[String],
-      resourceName: String): UnionType[SangriaGraphQlContext] = {
+      resourceName: ResourceName): UnionType[SangriaGraphQlContext] = {
 
     val objects = unionDataSchema.getTypes.asScala.map { subType =>
 
@@ -72,9 +73,10 @@ object NaptimeUnionField {
         unionMemberFieldName,
         subTypeField.fieldType,
         resolve = subTypeField.resolve)
+      val formattedResourceName = NaptimeResourceUtils.formatResourceName(resourceName)
 
       ObjectType[SangriaGraphQlContext, DataMap](
-        name = FieldBuilder.formatName(s"$resourceName/${unionMemberKey}Member"),
+        name = FieldBuilder.formatName(s"$formattedResourceName/${unionMemberKey}Member"),
         fields = List(field))
     }.toList
     val unionName = buildFullyQualifiedName(resourceName, fieldName)
@@ -92,8 +94,8 @@ object NaptimeUnionField {
     }
   }
 
-  def buildFullyQualifiedName(namespace: String, fieldName: String): String = {
-    FieldBuilder.formatName(s"$namespace.$fieldName")
+  def buildFullyQualifiedName(resourceName: ResourceName, fieldName: String): String = {
+    FieldBuilder.formatName(s"${NaptimeResourceUtils.formatResourceName(resourceName)}.$fieldName")
   }
 
 

--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/SchemaErrors.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/SchemaErrors.scala
@@ -1,0 +1,74 @@
+package org.coursera.naptime.ari.graphql.schema
+
+import org.coursera.naptime.ResourceName
+
+sealed trait SchemaError {
+  def resourceName: ResourceName
+  def key: String
+  def message: String
+}
+
+case class HasGetButMissingMultiGet(resourceName: ResourceName) extends SchemaError {
+  val key = "HAS_GET_BUT_MISSING_MULTIGET"
+  val message = "Resource has GET handler, but no MULTI_GET is available."
+}
+
+case class NoHandlersAvailable(resourceName: ResourceName) extends SchemaError {
+  val key = "NO_HANDLERS_AVAILABLE"
+  val message = "No handlers were detected on this resource."
+}
+
+case class MissingMergedType(resourceName: ResourceName) extends SchemaError {
+  val key = "MISSING_MERGED_TYPE"
+  val message = "No mergedType was available from the schemas.v1 endpoint."
+}
+
+case class HasForwardRelationButMissingMultiGet(
+    resourceName: ResourceName,
+    fieldName: String)
+  extends SchemaError {
+
+  val key = "HAS_FORWARD_RELATION_BUT_MISSING_MULTIGET"
+  val message = s"There is a forward relation on $fieldName, but no MULTI_GET is available."
+}
+
+case class UnknownHandlerType(resourceName: ResourceName, handlerType: String) extends SchemaError {
+  val key = "UNKNOWN_HANDLER_TYPE"
+  val message = s"A handler type of $handlerType was not expected."
+}
+
+case class SchemaNotFound(resourceName: ResourceName) extends SchemaError {
+  val key = "SCHEMA_NOT_FOUND"
+  val message = "Could not find schema to build resource field."
+}
+
+case class MissingQParameterOnFinderRelation(resourceName: ResourceName, fieldName: String) extends SchemaError {
+  val key = "MISSING_Q_PARAMETER"
+  val message = s"Cannot have a finder relation on field $fieldName without having a `q` parameter"
+}
+
+case class UnhandledSchemaError(resourceName: ResourceName, error: String) extends SchemaError {
+  val key = "UNHANDLED_SCHEMA_ERROR"
+  val message = s"Unhandled error: $error"
+}
+
+
+case class SchemaErrors(errors: List[SchemaError]) {
+  def ++(that: List[SchemaError]): SchemaErrors = {
+    copy(errors = errors ++ that)
+  }
+
+  def ++(that: SchemaErrors): SchemaErrors = {
+    copy(errors = errors ++ that.errors)
+  }
+
+  def +(error: SchemaError): SchemaErrors = {
+    copy(errors = errors :+ error)
+  }
+}
+
+object SchemaErrors {
+  val empty = SchemaErrors(List.empty)
+}
+
+case class WithSchemaErrors[T](data: T, errors: SchemaErrors = SchemaErrors.empty)

--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/SchemaMetadata.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/SchemaMetadata.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 Coursera Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.coursera.naptime.ari.graphql.schema
 
 import com.linkedin.data.schema.RecordDataSchema
@@ -9,17 +25,17 @@ case class SchemaMetadata(
     resources: Set[Resource],
     schemas: Map[String, RecordDataSchema]) {
 
-  def getResource(resourceName: String): Resource = {
+  def getResource(resourceName: ResourceName): Resource = {
     resources.find { resource =>
-      ResourceName(resource.name, resource.version.getOrElse(0L).toInt).identifier == resourceName
+      ResourceName.fromResource(resource) == resourceName
     }.getOrElse {
       throw new RuntimeException(s"Cannot find resource with name $resourceName")
     }
   }
 
-  def getResourceOpt(resourceName: String): Option[Resource] = {
+  def getResourceOpt(resourceName: ResourceName): Option[Resource] = {
     resources.find { resource =>
-      ResourceName(resource.name, resource.version.getOrElse(0L).toInt).identifier == resourceName
+      ResourceName.fromResource(resource) == resourceName
     }
   }
 

--- a/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/SangriaGraphQlSchemaExecutionTest.scala
+++ b/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/SangriaGraphQlSchemaExecutionTest.scala
@@ -87,7 +87,7 @@ class SangriaGraphQlSchemaExecutionTest extends AssertionsForJUnit with ScalaFut
 
   @Test
   def parseComplexLists(): Unit = {
-    val schema = builder.generateSchema().asInstanceOf[Schema[SangriaGraphQlContext, Any]]
+    val schema = builder.generateSchema().data.asInstanceOf[Schema[SangriaGraphQlContext, Any]]
     val query =
       """
       query {
@@ -125,7 +125,7 @@ class SangriaGraphQlSchemaExecutionTest extends AssertionsForJUnit with ScalaFut
 
   @Test
   def parseAliases(): Unit = {
-    val schema = builder.generateSchema().asInstanceOf[Schema[SangriaGraphQlContext, Any]]
+    val schema = builder.generateSchema().data.asInstanceOf[Schema[SangriaGraphQlContext, Any]]
     val query =
       """
       query {
@@ -172,7 +172,7 @@ class SangriaGraphQlSchemaExecutionTest extends AssertionsForJUnit with ScalaFut
 
   @Test
   def parseUnions(): Unit = {
-    val schema = builder.generateSchema().asInstanceOf[Schema[SangriaGraphQlContext, Any]]
+    val schema = builder.generateSchema().data.asInstanceOf[Schema[SangriaGraphQlContext, Any]]
     val query =
       """
       query {
@@ -213,7 +213,7 @@ class SangriaGraphQlSchemaExecutionTest extends AssertionsForJUnit with ScalaFut
 
   @Test
   def parseDataMapTypes(): Unit = {
-    val schema = builder.generateSchema().asInstanceOf[Schema[SangriaGraphQlContext, Any]]
+    val schema = builder.generateSchema().data.asInstanceOf[Schema[SangriaGraphQlContext, Any]]
     val query =
       """
       query {
@@ -251,7 +251,7 @@ class SangriaGraphQlSchemaExecutionTest extends AssertionsForJUnit with ScalaFut
 
   @Test
   def errorHandling_get_404(): Unit = {
-    val schema = builder.generateSchema().asInstanceOf[Schema[SangriaGraphQlContext, Any]]
+    val schema = builder.generateSchema().data.asInstanceOf[Schema[SangriaGraphQlContext, Any]]
     val query =
       """
       query {
@@ -295,7 +295,7 @@ class SangriaGraphQlSchemaExecutionTest extends AssertionsForJUnit with ScalaFut
 
   @Test
   def complexityCalculation(): Unit = {
-    val schema = builder.generateSchema().asInstanceOf[Schema[SangriaGraphQlContext, Any]]
+    val schema = builder.generateSchema().data.asInstanceOf[Schema[SangriaGraphQlContext, Any]]
     val query =
       """
       query {

--- a/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/controllers/filters/FilterTest.scala
+++ b/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/controllers/filters/FilterTest.scala
@@ -60,7 +60,7 @@ trait FilterTest
   val builder = new SangriaGraphQlSchemaBuilder(allResources, schemaTypes)
 
 
-  val schema = builder.generateSchema().asInstanceOf[Schema[SangriaGraphQlContext, Any]]
+  val schema = builder.generateSchema().data.asInstanceOf[Schema[SangriaGraphQlContext, Any]]
   when(graphqlSchemaProvider.schema).thenReturn(schema)
 
   def generateIncomingQuery(query: String = defaultQuery) = {

--- a/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/schema/NaptimePaginatedResourceFieldTest.scala
+++ b/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/schema/NaptimePaginatedResourceFieldTest.scala
@@ -16,6 +16,7 @@
 
 package org.coursera.naptime.ari.graphql.schema
 
+import org.coursera.naptime.ResourceName
 import org.coursera.naptime.ari.Response
 import org.coursera.naptime.ari.graphql.Models
 import org.coursera.naptime.ari.graphql.SangriaGraphQlContext
@@ -28,11 +29,11 @@ import org.scalatest.mock.MockitoSugar
 class NaptimePaginatedResourceFieldTest extends AssertionsForJUnit with MockitoSugar {
 
   val fieldName = "relatedIds"
-  val resourceName = "courses.v1"
+  val resourceName = ResourceName("courses", 1)
   val context = SangriaGraphQlContext(Response.empty)
 
-  val schemaMetadata = mock[SchemaMetadata]
-  val resource = Models.courseResource
+  private[this] val schemaMetadata = mock[SchemaMetadata]
+  private[this] val resource = Models.courseResource
   when(schemaMetadata.getResourceOpt(resourceName)).thenReturn(Some(resource))
   when(schemaMetadata.getSchema(resource)).thenReturn(Some(null))
 
@@ -43,16 +44,20 @@ class NaptimePaginatedResourceFieldTest extends AssertionsForJUnit with MockitoS
 
     val argDefinitions = NaptimePaginationField.paginationArguments
 
-    val limitTen = field.get.complexity.get.apply(context, ArgumentBuilder.buildArgs(argDefinitions, Map("limit" -> Some(10))), 1)
+    val limitTen = field.right.get.complexity.get.apply(context,
+      ArgumentBuilder.buildArgs(argDefinitions, Map("limit" -> Some(10))), 1)
     assert(limitTen === 1 * NaptimePaginatedResourceField.COMPLEXITY_COST * 1)
 
-    val limitFifty = field.get.complexity.get.apply(context, ArgumentBuilder.buildArgs(argDefinitions, Map("limit" -> Some(50))), 1)
+    val limitFifty = field.right.get.complexity.get.apply(context,
+      ArgumentBuilder.buildArgs(argDefinitions, Map("limit" -> Some(50))), 1)
     assert(limitFifty === 5 * NaptimePaginatedResourceField.COMPLEXITY_COST * 1)
 
-    val limitZero = field.get.complexity.get.apply(context, ArgumentBuilder.buildArgs(argDefinitions, Map("limit" -> Some(1))), 1)
+    val limitZero = field.right.get.complexity.get.apply(context,
+      ArgumentBuilder.buildArgs(argDefinitions, Map("limit" -> Some(1))), 1)
     assert(limitZero === 1 * NaptimePaginatedResourceField.COMPLEXITY_COST * 1)
 
-    val childScoreFive = field.get.complexity.get.apply(context, ArgumentBuilder.buildArgs(argDefinitions, Map("limit" -> Some(1))), 5)
+    val childScoreFive = field.right.get.complexity.get.apply(context,
+      ArgumentBuilder.buildArgs(argDefinitions, Map("limit" -> Some(1))), 5)
     assert(childScoreFive === 1 * NaptimePaginatedResourceField.COMPLEXITY_COST * 5)
 
   }

--- a/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/schema/NaptimePaginationFieldTest.scala
+++ b/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/schema/NaptimePaginationFieldTest.scala
@@ -62,15 +62,15 @@ class NaptimePaginationFieldTest extends AssertionsForJUnit with MockitoSugar {
   }
 
   val fieldName = "relatedIds"
-  val resourceName = "courses.v1"
+  val resourceName = ResourceName("courses", 1)
   val resourceContext = SangriaGraphQlContext(Response(
     Map(TopLevelRequest(
-      ResourceName.parse(resourceName).get,
+      resourceName,
       RequestField("", None, Set.empty, List.empty)) ->
     TopLevelResponse(
       ids = new DataList(List("1").asJava),
       pagination = ResponsePagination(None))),
-    Map(ResourceName.parse(resourceName).get -> Map("1" -> new DataMap()))))
+    Map(resourceName -> Map("1" -> new DataMap()))))
 
   @Test
   def resolveNestedEmptyList(): Unit = {

--- a/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/schema/NaptimeResourceFieldTest.scala
+++ b/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/schema/NaptimeResourceFieldTest.scala
@@ -1,6 +1,7 @@
 package org.coursera.naptime.ari.graphql.schema
 
 import com.linkedin.data.schema.RecordDataSchema
+import org.coursera.naptime.ResourceName
 import org.coursera.naptime.ari.graphql.Models
 import org.coursera.naptime.ari.graphql.models.MergedMultigetFreeEntity
 import org.coursera.naptime.ari.graphql.models.MergedPartner
@@ -21,7 +22,7 @@ class NaptimeResourceFieldTest extends AssertionsForJUnit with MockitoSugar {
   val pointerSchema = MergedPointerEntity.SCHEMA
   val filteredResource = Models.multigetFreeEntity
   val filteredSchema = MergedMultigetFreeEntity.SCHEMA
-  val resourceName = "myTestResource"
+  val resourceName = ResourceName("testResource", 1)
   val field = mock[RecordDataSchema.Field]
 
 
@@ -33,7 +34,8 @@ class NaptimeResourceFieldTest extends AssertionsForJUnit with MockitoSugar {
     when(schemaMetadata.getSchema(partnerResource)).thenReturn(Some(partnerSchema))
     when(field.getDoc).thenReturn("")
     when(field.getName).thenReturn(testFieldName)
-    val generatedFieldOpt = NaptimeResourceField.generateField(field, schemaMetadata, partnerResource, partnerSchema)
+    val generatedFieldOpt = NaptimeResourceField
+      .generateField(field, schemaMetadata, partnerResource, partnerSchema)
     assert(generatedFieldOpt.isDefined)
     val generatedField = generatedFieldOpt.get
     assert(generatedField.name === testFieldName)
@@ -45,9 +47,11 @@ class NaptimeResourceFieldTest extends AssertionsForJUnit with MockitoSugar {
 
     when(field.getDoc).thenReturn("")
     when(field.getName).thenReturn("testName")
-    when(field.getProperties).thenReturn(Map("related" -> testFieldName .asInstanceOf[AnyRef]).asJava)
-    when(schemaMetadata.getResource(testFieldName)).thenReturn(filteredResource)
-    val generatedField = NaptimeResourceField.generateField(field, schemaMetadata, pointerResource, pointerSchema)
+    when(field.getProperties)
+      .thenReturn(Map("related" -> testFieldName.asInstanceOf[AnyRef]).asJava)
+    when(schemaMetadata.getResource(resourceName)).thenReturn(filteredResource)
+    val generatedField = NaptimeResourceField
+      .generateField(field, schemaMetadata, pointerResource, pointerSchema)
     assert(generatedField.isEmpty)
   }
 }

--- a/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/schema/NaptimeUnionFieldTest.scala
+++ b/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/schema/NaptimeUnionFieldTest.scala
@@ -26,6 +26,7 @@ import org.junit.Test
 import org.scalatest.junit.AssertionsForJUnit
 import org.scalatest.mock.MockitoSugar
 import com.linkedin.data.schema.UnionDataSchema
+import org.coursera.naptime.ResourceName
 import org.coursera.naptime.ari.graphql.Models
 import org.mockito.Mockito.when
 import sangria.schema.IntType
@@ -36,7 +37,7 @@ import scala.collection.JavaConverters._
 
 class NaptimeUnionFieldTest extends AssertionsForJUnit with MockitoSugar {
 
-  private[this] val resourceName = "courses.v1"
+  private[this] val resourceName = ResourceName("courses", 1)
   private[this]val schemaMetadata = mock[SchemaMetadata]
   private[this]val resource = Models.courseResource
   when(schemaMetadata.getResourceOpt(resourceName)).thenReturn(Some(resource))
@@ -49,12 +50,16 @@ class NaptimeUnionFieldTest extends AssertionsForJUnit with MockitoSugar {
     val union = new UnionDataSchema()
     val stringBuilder = new java.lang.StringBuilder()
     union.setTypes(types.asJava, stringBuilder)
-    val unionProperties = Map("typedDefinition" -> typedDefinitions.asJava.asInstanceOf[AnyRef]) ++ properties
+    val unionProperties =
+      Map("typedDefinition" -> typedDefinitions.asJava.asInstanceOf[AnyRef]) ++ properties
     union.setProperties(unionProperties.asJava)
     union
   }
 
-  private[this] def buildRecordField(name: String, fields: List[Field], namespace: String = "org.coursera.naptime") = {
+  private[this] def buildRecordField(
+      name: String,
+      fields: List[Field],
+      namespace: String = "org.coursera.naptime") = {
     val fullName = new Name(name, namespace, new java.lang.StringBuilder())
     val recordDataSchema = new RecordDataSchema(fullName, RecordType.RECORD)
     fields.foreach(_.setRecord(recordDataSchema))
@@ -71,9 +76,9 @@ class NaptimeUnionFieldTest extends AssertionsForJUnit with MockitoSugar {
     val field = NaptimeUnionField.build(schemaMetadata, union, fieldName, None, resourceName)
 
     val expectedUnionTypes = List(
-      ObjectType("courses_v1_intMember", List(
+      ObjectType("CoursesV1_intMember", List(
         FieldBuilder.buildPrimitiveField(fieldName, new IntegerDataSchema(), IntType))))
-    val expectedField = UnionType("courses_v1_intOnlyUnion", None, expectedUnionTypes)
+    val expectedField = UnionType("CoursesV1_intOnlyUnion", None, expectedUnionTypes)
     assert(field.fieldType.toString === expectedField.toString)
   }
 
@@ -93,21 +98,21 @@ class NaptimeUnionFieldTest extends AssertionsForJUnit with MockitoSugar {
     val field = NaptimeUnionField.build(schemaMetadata, union, fieldName, None, resourceName)
 
     val expectedUnionTypes = List(
-      ObjectType("courses_v1_easyMember", List(
+      ObjectType("CoursesV1_easyMember", List(
         NaptimeRecordField.build(
           schemaMetadata,
           simpleFieldDataSchema,
           "easy",
           Some("org.coursera.naptime"),
           resourceName))),
-      ObjectType("courses_v1_hardMember", List(
+      ObjectType("CoursesV1_hardMember", List(
         NaptimeRecordField.build(
           schemaMetadata,
           complexFieldDataSchema,
           "hard",
           Some("org.coursera.naptime"),
           resourceName))))
-    val expectedField = UnionType("courses_v1_typedDefinitionTestField", None, expectedUnionTypes)
+    val expectedField = UnionType("CoursesV1_typedDefinitionTestField", None, expectedUnionTypes)
     assert(field.fieldType.toString === expectedField.toString)
   }
 
@@ -128,21 +133,21 @@ class NaptimeUnionFieldTest extends AssertionsForJUnit with MockitoSugar {
     val field = NaptimeUnionField.build(schemaMetadata, union, fieldName, None, resourceName)
 
     val expectedUnionTypes = List(
-      ObjectType("courses_v1_easyMember", List(
+      ObjectType("CoursesV1_easyMember", List(
         NaptimeRecordField.build(
           schemaMetadata,
           simpleFieldDataSchema,
           "easy",
           Some("org.coursera.naptime"),
           resourceName))),
-      ObjectType("courses_v1_hardMember", List(
+      ObjectType("CoursesV1_hardMember", List(
         NaptimeRecordField.build(
           schemaMetadata,
           complexFieldDataSchema,
           "hard",
           Some("org.coursera.naptime"),
           resourceName))))
-    val expectedField = UnionType("courses_v1_typedDefinitionTestField", None, expectedUnionTypes)
+    val expectedField = UnionType("CoursesV1_typedDefinitionTestField", None, expectedUnionTypes)
     assert(field.fieldType.toString === expectedField.toString)
   }
 
@@ -163,21 +168,21 @@ class NaptimeUnionFieldTest extends AssertionsForJUnit with MockitoSugar {
     val field = NaptimeUnionField.build(schemaMetadata, union, fieldName, None, resourceName)
 
     val expectedUnionTypes = List(
-      ObjectType("courses_v1_org_coursera_awaketime_simpleFieldMember", List(
+      ObjectType("CoursesV1_org_coursera_awaketime_simpleFieldMember", List(
         NaptimeRecordField.build(
           schemaMetadata,
           simpleFieldDataSchema,
           "easy",
           Some("org.coursera.awaketime"),
           resourceName))),
-      ObjectType("courses_v1_hardMember", List(
+      ObjectType("CoursesV1_hardMember", List(
         NaptimeRecordField.build(
           schemaMetadata,
           complexFieldDataSchema,
           "hard",
           Some("org.coursera.naptime"),
           resourceName))))
-    val expectedField = UnionType("courses_v1_typedDefinitionTestField", None, expectedUnionTypes)
+    val expectedField = UnionType("CoursesV1_typedDefinitionTestField", None, expectedUnionTypes)
 
     assert(field.fieldType.toString === expectedField.toString)
   }

--- a/naptime/src/main/scala/org/coursera/naptime/models.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/models.scala
@@ -19,6 +19,7 @@ package org.coursera.naptime
 import com.linkedin.data.DataMap
 import org.coursera.naptime.QueryStringParser.NaptimeParseError
 import org.coursera.naptime.schema.RelationType
+import org.coursera.naptime.schema.Resource
 import org.coursera.naptime.schema.ReverseRelationAnnotation
 import play.api.http.Status
 import play.api.i18n.Lang
@@ -437,6 +438,10 @@ object ResourceName {
         }.toOption
       case _ => None
     }
+  }
+
+  def fromResource(resource: Resource): ResourceName = {
+    ResourceName(resource.name, resource.version.getOrElse(0L).toInt)
   }
 }
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.6.10"
+version in ThisBuild := "0.6.11"


### PR DESCRIPTION
**This is a pretty large refactor that does the following:**
- Instead of simply logging errors (or throwing exceptions that can be caught later on), most methods were refactored to return SchemaErrors when applicable. There are two ways that this is done:
  - Some methods return a type wrapped with `WithSchemaErrors[T]`, which converts that type into a case class that also includes a list of SchemaErrors generated during the invocation of that call. There are many instances where we want to return some value _and_ a list of errors generated along the way.
  - For cases where its either Error or Value, these have been transformed to use `Either`s instead. Most of these expressions could be represented by an `Either[SchemaError, T]` rather than an `Option[T]`.
- Change resourceNames to be represented by the `ResourceName` class more consistently. This was a requirement for SchemaErrors, since they take in a `ResourceName`, and is generally better than passing Strings everywhere
- Pull a lot of logic around generating TopLevelResourceFields out from the SchemaBuilder, and move it into a new TopLevelResourceField object.
- Some other work to avoid throwing exceptions whenever possible

PTAL @yifan-coursera and @vishalkuo 