### PR TITLE
Fix requests with empty multiget lists

### DIFF
--- a/naptime/src/main/scala/org/coursera/naptime/ari/engine/Utilities.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/ari/engine/Utilities.scala
@@ -296,6 +296,23 @@ object Utilities extends StrictLogging {
     }
   }
 
+  def jsValueIsEmpty(value: JsValue): Boolean = {
+    value match {
+      case JsArray(arrayElements) =>
+        arrayElements.isEmpty || arrayElements.forall(jsValueIsEmpty)
+      case stringValue: JsString =>
+        stringValue.value.isEmpty
+      case _: JsNumber =>
+        false
+      case _: JsBoolean =>
+        false
+      case _: JsObject =>
+        false
+      case JsNull =>
+        true
+    }
+  }
+
   /**
     * Merges all sub-selections of a request into a single selection
     * @param fields list of selections to merge

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.7.0"
+version in ThisBuild := "0.7.1"


### PR DESCRIPTION
When requesting a multiget with an empty list, the generated url was invalid, and caused no requests to be returned.

This fix removes empty parameters, and also short-circuits forward relations when there are no ids available.