### PR TITLE
If no id is set for a forward relation, immediately mark as null

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.7.1"
+version in ThisBuild := "0.7.2"


### PR DESCRIPTION
There's currently a bug where if the id is an empty string / null, the forward relation will omit the "ids" parameter on the request, and end up requesting a getAll. Instead, if we see that we're making a forward relation and there's no id set, we should immediately just return null.