### PR TITLE
Fix null ResponsePagination objects and unions

### DIFF
--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/NaptimePaginatedResourceField.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/NaptimePaginatedResourceField.scala
@@ -194,16 +194,10 @@ object NaptimePaginatedResourceField extends StrictLogging {
             Field.apply[SangriaGraphQlContext, NaptimeResponse, Any, Any](
               name = "paging",
               fieldType = NaptimePaginationField.getField(resourceName, fieldName),
-              resolve = _.value.pagination.map {
-                case rp: ResponsePagination =>
-                  rp
-                case other: Any =>
-                  logger.error(s"Expected ResponsePagination but got $other")
-                  None
-                case null =>
-                  logger.error("Expected ResponsePagination but got null")
-                  None
-              }.getOrElse(ResponsePagination.empty)))
+              resolve = (ctx) => {
+                val pagination = ctx.value.pagination.getOrElse(ResponsePagination.empty)
+                Value(pagination)
+              }))
         }.getOrElse(List.empty)
       })
   }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.7.2"
+version in ThisBuild := "0.7.3"


### PR DESCRIPTION
This commit fixes two issues:
- First, a case when the union object itself is null, we'd throw a NPE while parsing to get the type of the union. Now we handle that case better.
- There seems to be a weird interaction when handling some DeferredActions and regular Actions in sangria, leading to confusion. This makes the types more explicit to avoid errors