### PR TITLE
	Add `debugMode` flag and only send sourceUrls if in debug mode

### DIFF
--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/SangriaGraphQlContext.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/SangriaGraphQlContext.scala
@@ -25,4 +25,5 @@ import scala.concurrent.ExecutionContext
 case class SangriaGraphQlContext(
     fetcher: FetcherApi,
     requestHeader: RequestHeader,
-    executionContext: ExecutionContext)
+    executionContext: ExecutionContext,
+    debugMode: Boolean)

--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/controllers/GraphQLController.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/controllers/GraphQLController.scala
@@ -116,7 +116,7 @@ class GraphQLController @Inject() (
       QueryParser.parse(query) match {
         case Success(queryAst) =>
           val baseFilter: IncomingQuery => Future[OutgoingQuery] = (incoming: IncomingQuery) => {
-            val context = SangriaGraphQlContext(fetcher, requestHeader, ec)
+            val context = SangriaGraphQlContext(fetcher, requestHeader, ec, incoming.debugMode)
             Executor.execute(
               graphqlSchemaProvider.schema,
               queryAst,
@@ -137,7 +137,8 @@ class GraphQLController @Inject() (
               logger.error("GraphQL execution error", error)
               OutgoingQuery(Json.obj("errors" -> Json.arr(error.getMessage)), None)
           }
-          val incomingQuery = IncomingQuery(queryAst, requestHeader, variables, operation)
+          val incomingQuery = IncomingQuery(
+            queryAst, requestHeader, variables, operation, debugMode = false)
 
           val filterFn = filterList.filters.reverse.foldLeft(baseFilter) {
             case (accumulatedFilters, filter) =>

--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/controllers/filters/QueryComplexityFilter.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/controllers/filters/QueryComplexityFilter.scala
@@ -69,7 +69,7 @@ class QueryComplexityFilter @Inject() (
     val executorFut = Executor.execute(
       graphqlSchemaProvider.schema,
       queryAst,
-      SangriaGraphQlContext(null, null, executionContext),
+      SangriaGraphQlContext(null, null, executionContext, debugMode = false),
       variables = variables,
       exceptionHandler = GraphQLController.exceptionHandler(logger),
       queryReducers = List(complReducer),

--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/controllers/filters/models.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/controllers/filters/models.scala
@@ -11,7 +11,8 @@ case class IncomingQuery(
     document: Document,
     requestHeader: RequestHeader,
     variables: JsObject,
-    operation: Option[String])
+    operation: Option[String],
+    debugMode: Boolean)
 
 case class OutgoingQuery(response: JsObject, ariResponse: Option[Response])
 

--- a/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/controllers/filters/FilterTest.scala
+++ b/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/controllers/filters/FilterTest.scala
@@ -68,7 +68,7 @@ trait FilterTest
     val header = FakeRequest("POST", s"/graphql").withBody(query)
     val variables = Json.obj()
     val operation = None
-    IncomingQuery(document, header, variables, operation)
+    IncomingQuery(document, header, variables, operation, debugMode = false)
   }
 
   def run(incomingQuery: IncomingQuery): Future[OutgoingQuery] = {

--- a/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/middleware/UrlLoggingMiddlewareTest.scala
+++ b/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/middleware/UrlLoggingMiddlewareTest.scala
@@ -76,21 +76,6 @@ class UrlLoggingMiddlewareTest extends AssertionsForJUnit with MockitoSugar {
     arguments = List.empty,
     resolve = _ => null)
 
-  private[this] val instructorField = Field[SangriaGraphQlContext, Any, Any, Any](
-    name = "instructor",
-    fieldType = mockSchema.outputTypes("Instructor"),
-    description = None,
-    arguments = List.empty,
-    resolve = _ => null)
-
-  val query = gql"""
-      query {
-        course {
-          slug
-        }
-      }
-    """
-
   def buildContext(
       ctx: SangriaGraphQlContext,
       executionPath: ExecutionPath): Context[SangriaGraphQlContext, _] = {

--- a/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/middleware/UrlLoggingMiddlewareTest.scala
+++ b/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/middleware/UrlLoggingMiddlewareTest.scala
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2016 Coursera Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.coursera.naptime.ari.graphql.middleware
+
+import org.coursera.naptime.ari.graphql.SangriaGraphQlContext
+import org.coursera.naptime.ari.graphql.controllers.middleware.UrlLoggingMiddleware
+import org.coursera.naptime.ari.graphql.marshaller.NaptimeMarshaller._
+import org.coursera.naptime.ari.graphql.resolvers.NaptimeResponse
+import org.junit.Test
+import org.scalatest.junit.AssertionsForJUnit
+import org.scalatest.mockito.MockitoSugar
+import play.api.libs.iteratee.Input
+import play.api.libs.json.Json
+import play.api.mvc.Headers
+import play.api.test.FakeRequest
+import sangria.ast.Document
+import sangria.execution.DeprecationTracker
+import sangria.execution.ExecutionPath
+import sangria.execution.MiddlewareQueryContext
+import sangria.execution.ResultResolver
+import sangria.execution.TimeMeasurement
+import sangria.macros._
+import sangria.marshalling.ResultMarshaller
+import sangria.schema.Args
+import sangria.schema.Context
+import sangria.schema.Field
+import sangria.schema.ObjectType
+import sangria.schema.Schema
+
+import scala.concurrent.ExecutionContext
+
+class UrlLoggingMiddlewareTest extends AssertionsForJUnit with MockitoSugar {
+
+  private[this] val mockAst = graphql"""
+    schema {
+      query: Root
+    }
+
+    type Root {
+      course: Course
+    }
+
+    type Course {
+      slug: String
+      instructor: Instructor
+    }
+
+    type Instructor {
+      name: String
+    }
+  """
+
+  private[this] val mockSchema: Schema[SangriaGraphQlContext, Any] =
+    Schema.buildFromAst(mockAst).asInstanceOf[Schema[SangriaGraphQlContext, Any]]
+
+  private[this] val rootType = mockSchema.query
+
+  private[this] val courseField = Field[SangriaGraphQlContext, Any, Any, Any](
+    name = "course",
+    fieldType = mockSchema.outputTypes("Course"),
+    description = None,
+    arguments = List.empty,
+    resolve = _ => null)
+
+  private[this] val instructorField = Field[SangriaGraphQlContext, Any, Any, Any](
+    name = "instructor",
+    fieldType = mockSchema.outputTypes("Instructor"),
+    description = None,
+    arguments = List.empty,
+    resolve = _ => null)
+
+  val query = gql"""
+      query {
+        course {
+          slug
+        }
+      }
+    """
+
+  def buildContext(
+      ctx: SangriaGraphQlContext,
+      executionPath: ExecutionPath): Context[SangriaGraphQlContext, _] = {
+    Context[SangriaGraphQlContext, Any](
+      value = null,
+      ctx = ctx,
+      args = Args.empty,
+      schema = mockSchema,
+      field = courseField,
+      parentType = mock[ObjectType[SangriaGraphQlContext, Any]],
+      marshaller = mock[ResultMarshaller],
+      sourceMapper = None,
+      deprecationTracker = DeprecationTracker.empty,
+      astFields = Vector.empty,
+      path = executionPath,
+      deferredResolverState = None)
+
+  }
+
+  def buildMiddlewareQueryContext(
+      ctx: SangriaGraphQlContext): MiddlewareQueryContext[SangriaGraphQlContext, _, _] = {
+    MiddlewareQueryContext[SangriaGraphQlContext, Any, Any](
+      ctx = ctx,
+      executor = null,
+      queryAst = Document(Vector.empty),
+      operationName = None,
+      variables = Input.Empty,
+      inputUnmarshaller = null,
+      validationTiming = TimeMeasurement.empty,
+      queryReducerTiming = TimeMeasurement.empty)
+  }
+
+  @Test
+  def urlsNotRecordWhenNotDebugging(): Unit = {
+    val middleware = new UrlLoggingMiddleware()
+    val request = FakeRequest(method = "GET", uri = "/graphql", headers = Headers(), body = "")
+    val ctx = SangriaGraphQlContext(null, request, ExecutionContext.global, debugMode = false)
+    val middlewareQueryContext = buildMiddlewareQueryContext(ctx)
+    val astField = sangria.ast.Field(None, "course", Vector.empty, Vector.empty, Vector.empty)
+    val path = ExecutionPath.empty.add(astField, rootType)
+    val context = buildContext(ctx, path)
+    middleware.afterField(
+      queryVal = (),
+      fieldVal = (),
+      value = NaptimeResponse(List.empty, None, "test url"),
+      mctx = middlewareQueryContext,
+      ctx = context)
+    val extensions = middleware.afterQueryExtensions((), middlewareQueryContext)
+    assert(extensions.isEmpty)
+  }
+
+  @Test
+  def urlsRecordedAfterEachField(): Unit = {
+    val middleware = new UrlLoggingMiddleware()
+    val request = FakeRequest(method = "GET", uri = "/graphql", headers = Headers(), body = "")
+    val ctx = SangriaGraphQlContext(null, request, ExecutionContext.global, debugMode = true)
+    val middlewareQueryContext = buildMiddlewareQueryContext(ctx)
+    val astField = sangria.ast.Field(None, "course", Vector.empty, Vector.empty, Vector.empty)
+    val path = ExecutionPath.empty.add(astField, rootType)
+    val context = buildContext(ctx, path)
+    middleware.afterField(
+      queryVal = (),
+      fieldVal = (),
+      value = NaptimeResponse(List.empty, None, "test url"),
+      mctx = middlewareQueryContext,
+      ctx = context)
+    val extensions = middleware.afterQueryExtensions((), middlewareQueryContext)
+    val marshalled =
+      ResultResolver.marshalExtensions(PlayJsonMarshallerForType.marshaller, extensions).get
+    val expected = Json.obj("sourceUrls" -> Json.obj("course" -> "test url"))
+    assert(marshalled === expected)
+
+  }
+
+}

--- a/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/schema/NaptimePaginatedResourceFieldTest.scala
+++ b/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/schema/NaptimePaginatedResourceFieldTest.scala
@@ -32,7 +32,7 @@ class NaptimePaginatedResourceFieldTest extends AssertionsForJUnit with MockitoS
 
   val fieldName = "relatedIds"
   val resourceName = ResourceName("courses", 1)
-  val context = SangriaGraphQlContext(null, null, ExecutionContext.global)
+  val context = SangriaGraphQlContext(null, null, ExecutionContext.global, debugMode = false)
 
   private[this] val schemaMetadata = mock[SchemaMetadata]
   private[this] val resource = Models.courseResource

--- a/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/schema/PrimitiveFieldTest.scala
+++ b/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/schema/PrimitiveFieldTest.scala
@@ -46,7 +46,7 @@ class PrimitiveFieldTest extends AssertionsForJUnit with MockitoSugar {
       (implicit ctxManifest: Manifest[SangriaGraphQlContext], valManifest: Manifest[Val]) = {
     Context[SangriaGraphQlContext, Val](
       value = value,
-      ctx = SangriaGraphQlContext(null, null, ExecutionContext.global),
+      ctx = SangriaGraphQlContext(null, null, ExecutionContext.global, debugMode = false),
       args = ArgumentBuilder.buildArgs(NaptimePaginationField.paginationArguments, args),
       schema = mock[Schema[SangriaGraphQlContext, Val]],
       field = mock[Field[SangriaGraphQlContext, Val]],

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.7.3"
+version in ThisBuild := "0.7.4"


### PR DESCRIPTION
Add `debugMode` flag and only send sourceUrls if in debug mode …We're currently sending the `sourceUrl` extension on every response. However, this ends up being a very large response that is for debugging purposes only.  This change adds a `debugMode` to the context, and we'll only send the sourceUrl data if the debug mode is enabled (it's disabled by default). Filters will be able to modify this flag, to allow for custom headers / authorization checking to enable debug mode.