### PR TITLE
Remove unused Play dependency

### DIFF
--- a/project/NaptimeBuild.scala
+++ b/project/NaptimeBuild.scala
@@ -48,8 +48,11 @@ object NaptimeBuild extends Build with NamedDependencies with PluginVersionProvi
     .in(file("naptime-testing"))
     .dependsOn(naptime % "test->test;compile->compile")
 
-  lazy val pegasus = configure(project)
+  lazy val pegasus = project
     .in(file("naptime-pegasus"))
+    .settings(testSettings)
+    .settings(headerSettings)
+    .settings(org.coursera.naptime.sbt.Sonatype.settings)
 
   lazy val examples = configure(project)
     .in(file("examples"))


### PR DESCRIPTION
`naptime-pegasus` should not depend on Scala Play because it is a pure Java project. In particular, this was adding dependencies on Scala 2.11 packages, which prevented it from being used in a project with any other Scala version.