### PR TITLE
Require bindings for Resource types

### DIFF
--- a/naptime-testing/src/test/scala/org/coursera/naptime/NaptimeModuleTest.scala
+++ b/naptime-testing/src/test/scala/org/coursera/naptime/NaptimeModuleTest.scala
@@ -14,6 +14,7 @@ import org.coursera.naptime.model.KeyFormat
 import org.coursera.naptime.resources.TopLevelCollectionResource
 import org.coursera.naptime.router2.NaptimeRoutes
 import org.junit.Test
+import org.mockito.Mockito.mock
 import org.scalatest.junit.AssertionsForJUnit
 import play.api.libs.json.Json
 import play.api.libs.json.OFormat
@@ -37,6 +38,7 @@ object NaptimeModuleTest {
   object MyFakeModule extends NaptimeModule {
     override def configure(): Unit = {
       bindResource[MyResource]
+      bind[MyResource].toInstance(mock(classOf[MyResource]))
       bindSchemaType[Date](DataSchemaUtil.dataSchemaTypeToPrimitiveDataSchema(DataSchema.Type.LONG))
     }
   }

--- a/naptime/src/main/scala/org/coursera/naptime/NaptimeModule.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/NaptimeModule.scala
@@ -110,7 +110,8 @@ private[naptime] object NaptimeModuleHelpers {
     (implicit wtt: c.WeakTypeTag[Resource]): c.Tree = {
     import c.universe._
     val routerObject = typeOf[Router.type]
-    q"bindResourceRouterBuilder($routerObject.build[$wtt])"
+    q"""bindResourceRouterBuilder($routerObject.build[$wtt])
+       requireBinding(classOf[$wtt])"""
   }
 
 }


### PR DESCRIPTION
Resource classes are dynamically injected via `Injector.getInstance` calls in `org.coursera.naptime.router2.Router`. This means that the injector does no know about the existence of resource classes and cannot eagerly instantiate singletons when running in production. This change uses `AbstractModule.getBinding` to inform Guice that the resource class binding is required, which allows Guice to eagerly instantiate singletons when running in production