### PR TITLE
Bump dependency versions

### DIFF
--- a/naptime-sbt-plugin/src/sbt-test/sbt-naptime/simple/build.sbt
+++ b/naptime-sbt-plugin/src/sbt-test/sbt-naptime/simple/build.sbt
@@ -5,7 +5,7 @@ routesGenerator := InjectedRoutesGenerator
 lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
 libraryDependencies ++= Seq(
-  "org.coursera.courier" %% "courier-runtime" % "2.0.2",
+  "org.coursera.courier" %% "courier-runtime" % "2.1.4",
   cache
 )
 

--- a/naptime-sbt-plugin/src/sbt-test/sbt-naptime/simple/project/plugins.sbt
+++ b/naptime-sbt-plugin/src/sbt-test/sbt-naptime/simple/project/plugins.sbt
@@ -6,7 +6,7 @@ addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.4.4")
 resolvers += Resolver.bintrayRepo("coursera", "sbt-plugins")
 
 // Courier binding generator plugin
-addSbtPlugin("org.coursera.courier" % "courier-sbt-plugin" % "2.1.1")
+addSbtPlugin("org.coursera.courier" % "courier-sbt-plugin" % "2.1.4")
 
 // From http://www.scala-sbt.org/0.13/docs/Testing-sbt-plugins.html#step+3%3A+src%2Fsbt-test
 sys.props.get("plugin.version") match {

--- a/project/NamedDependencies.scala
+++ b/project/NamedDependencies.scala
@@ -25,12 +25,12 @@ trait PluginVersionProvider {
 
 trait NamedDependencies { this: PluginVersionProvider =>
   val courierRuntime = "org.coursera.courier" %% "courier-runtime" % courierVersion
-  val courscala = "org.coursera" %% "courscala" % "0.1.2"
+  val courscala = "org.coursera" %% "courscala" % "0.1.3"
   val governator = "com.netflix.governator" % "governator" % "1.10.5"
   val guice = "com.google.inject" % "guice" % "4.1.0"
   val guiceMultibindings = "com.google.inject.extensions" % "guice-multibindings" % "4.1.0"
-  val jodaConvert = "org.joda" % "joda-convert" % "1.2"
-  val jodaTime = "joda-time" % "joda-time" % "2.2"
+  val jodaConvert = "org.joda" % "joda-convert" % "1.9.2"
+  val jodaTime = "joda-time" % "joda-time" % "2.9.9"
   val playJson = "com.typesafe.play" %% "play-json" % playJsonVersion
   val playTestCompile = ("com.typesafe.play" %% "play-test" % playVersion)
     .excludeAll(new ExclusionRule(organization="org.specs2"))

--- a/project/NaptimeBuild.scala
+++ b/project/NaptimeBuild.scala
@@ -25,7 +25,7 @@ object NaptimeBuild extends Build with NamedDependencies with PluginVersionProvi
 
   override def playVersion = "2.6.7" // Play version is defined here, and in project/plugins.sbt
   override def playJsonVersion = "2.6.7"
-  override def courierVersion = "2.1.3"
+  override def courierVersion = "2.1.4"
 
   lazy val root = project
     .in(file("."))

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.7")
 
 // Courier binding generator plugin
-addSbtPlugin("org.coursera.courier" % "courier-sbt-plugin" % "2.1.3")
+addSbtPlugin("org.coursera.courier" % "courier-sbt-plugin" % "2.1.4")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
 


### PR DESCRIPTION
Bump version number of courscala, courier, joda-convert, and joda-time dependencies.