### PR TITLE
Use Scala 2.12 by default

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-scalaVersion in ThisBuild := "2.11.11"
+scalaVersion in ThisBuild := "2.12.4"
 
 crossScalaVersions in ThisBuild := Seq("2.11.11", "2.12.4")
 


### PR DESCRIPTION
Use Scala 2.12.4 instead of Scala 2.11.11 by default.