### PR TITLE
Add sangria-slowlog middleware to allow for GraphQL slow logging

### DIFF
--- a/naptime-graphql/build.sbt
+++ b/naptime-graphql/build.sbt
@@ -4,6 +4,7 @@ libraryDependencies ++= Seq(
   courierRuntime,
   playJson,
   sangria,
+  "org.sangria-graphql" %% "sangria-slowlog" % "0.1.5",
   scalaLogging,
   junit,
   junitInterface,

--- a/version.sbt
+++ b/version.sbt
@@ -1,2 +1,2 @@
-version in ThisBuild := "0.9.0-alpha5"
+version in ThisBuild := "0.9.0-alpha6"
 


### PR DESCRIPTION
cc @dguo-coursera, @yifan-coursera 

Use https://github.com/sangria-graphql/sangria-slowlog as right now it's impossible to understand what's making my queries take a long time.

Any idea how to test this change with assembler locally?