### PR TITLE
Add sangria-slowlog middleware to allow for GraphQL slow logging

### DIFF
--- a/naptime-graphql/build.sbt
+++ b/naptime-graphql/build.sbt
@@ -4,6 +4,7 @@ libraryDependencies ++= Seq(
   courierRuntime,
   playJson,
   sangria,
+  sangriaSlowLog,
   scalaLogging,
   junit,
   junitInterface,

--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/GraphqlSchemaProvider.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/GraphqlSchemaProvider.scala
@@ -85,7 +85,7 @@ class DefaultGraphqlSchemaProvider @Inject() (schemaProvider: SchemaProvider)
     try {
       val builder = new SangriaGraphQlSchemaBuilder(latestSchema.resources, types)
       val schemaAndErrors = builder.generateSchema()
-      val graphQlSchema = schemaAndErrors.data.asInstanceOf[Schema[SangriaGraphQlContext, Any]]
+      val graphQlSchema = schemaAndErrors.data.asInstanceOf[Schema[SangriaGraphQlContext, Any]].copy(additionalTypes = sangria.schema.BuiltinScalars)
       fullSchema = latestSchema
       cachedSchema = graphQlSchema
 
@@ -122,7 +122,9 @@ object DefaultGraphqlSchemaProvider {
       "ArbitraryField",
       StringType,
       resolve = context => null))
-  val EMPTY_SCHEMA = Schema[SangriaGraphQlContext, Any](query = ObjectType[SangriaGraphQlContext, Any](name = "root", fields = EMPTY_FIELDS))
+  val EMPTY_SCHEMA = Schema[SangriaGraphQlContext, Any](
+    query = ObjectType[SangriaGraphQlContext, Any](name = "root", fields = EMPTY_FIELDS),
+    additionalTypes = sangria.schema.BuiltinScalars)
 
 }
 

--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/controllers/middleware/MetricsCollectionMiddleware.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/controllers/middleware/MetricsCollectionMiddleware.scala
@@ -2,9 +2,9 @@ package org.coursera.naptime.ari.graphql.controllers.middleware
 
 import com.typesafe.scalalogging.StrictLogging
 import org.coursera.naptime.ari.graphql.SangriaGraphQlContext
+import sangria.execution.BeforeFieldResult
 import sangria.execution.MiddlewareErrorField
 import sangria.execution.MiddlewareQueryContext
-import sangria.schema.Action
 import sangria.schema.Context
 
 class MetricsCollectionMiddleware(
@@ -23,8 +23,8 @@ class MetricsCollectionMiddleware(
   override def beforeField(
       queryVal: Unit,
       mctx: MiddlewareQueryContext[SangriaGraphQlContext, _, _],
-      ctx: Context[SangriaGraphQlContext, _]): (Unit, Option[Action[SangriaGraphQlContext, _]]) =
-    (Unit, None)
+      ctx: Context[SangriaGraphQlContext, _]): BeforeFieldResult[SangriaGraphQlContext, FieldVal] =
+    BeforeFieldResult(Unit, None)
 
   override def fieldError(
       queryVal: QueryVal,

--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/controllers/middleware/ResponseMetadataMiddleware.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/controllers/middleware/ResponseMetadataMiddleware.scala
@@ -18,6 +18,7 @@ import play.api.libs.json.JsObject
 import play.api.libs.json.JsString
 import play.api.libs.json.JsValue
 import play.api.libs.json.Json
+import sangria.execution.BeforeFieldResult
 import sangria.execution.MiddlewareErrorField
 
 import scala.collection.JavaConverters._
@@ -48,8 +49,8 @@ class ResponseMetadataMiddleware
   override def beforeField(
       queryVal: Unit,
       mctx: MiddlewareQueryContext[SangriaGraphQlContext, _, _],
-      ctx: Context[SangriaGraphQlContext, _]): (Unit, Option[Action[SangriaGraphQlContext, _]]) =
-    (Unit, None)
+      ctx: Context[SangriaGraphQlContext, _]): BeforeFieldResult[SangriaGraphQlContext, FieldVal] =
+    BeforeFieldResult(Unit, None)
 
   override def afterField(
       queryVal: Unit,

--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/controllers/middleware/SlowLogMiddleware.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/controllers/middleware/SlowLogMiddleware.scala
@@ -1,0 +1,81 @@
+package org.coursera.naptime.ari.graphql.controllers.middleware
+
+import com.typesafe.scalalogging.Logger
+import org.coursera.naptime.ari.graphql.SangriaGraphQlContext
+import sangria.execution.BeforeFieldResult
+import sangria.execution.Extension
+import sangria.execution.Middleware
+import sangria.execution.MiddlewareAfterField
+import sangria.execution.MiddlewareExtension
+import sangria.execution.MiddlewareQueryContext
+import sangria.schema.Context
+import sangria.execution.MiddlewareErrorField
+import sangria.slowlog.SlowLog
+import sangria.slowlog.QueryMetrics
+
+import scala.concurrent.duration._
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
+
+/**
+ * Why is this wrapper on sangria.slowlog.SlowLog necessary? It's type signature is
+ * `Middleware[Any] with MiddlewareAfterField[Any] with MiddlewareErrorField[Any] with MiddlewareExtension[Any]`
+ * where `Any` refers to the "userContext". This prevents more specific userContext types
+ * such as `SangriaGraphQlContext` from directly working.
+ *
+ * Once the library is updated to support parametric types, we should get rid of this delegate
+ * and instantiate the SlowLog directly to pass into `Executor.execute`
+ */
+class SlowLogMiddleware(logger: Logger, isDebugMode: Boolean)
+  extends Middleware[SangriaGraphQlContext]
+  with MiddlewareExtension[SangriaGraphQlContext]
+  with MiddlewareAfterField[SangriaGraphQlContext]
+  with MiddlewareErrorField[SangriaGraphQlContext] {
+
+  type QueryVal = QueryMetrics
+  type FieldVal = Long
+
+  private[this] val underlying = {
+    if (isDebugMode) {
+      SlowLog.extension
+    } else {
+      SlowLog(logger.underlying, threshold = 6 seconds)
+    }
+  }
+
+  override def beforeQuery(context: MiddlewareQueryContext[SangriaGraphQlContext, _, _]): QueryMetrics =
+    underlying.beforeQuery(context)
+
+  override def afterQuery(queryVal: QueryMetrics, context: MiddlewareQueryContext[SangriaGraphQlContext, _, _]): Unit =
+    underlying.afterQuery(queryVal, context)
+
+  override def afterQueryExtensions(queryVal: QueryMetrics, context: MiddlewareQueryContext[SangriaGraphQlContext, _, _]): Vector[Extension[_]] =
+    underlying.afterQueryExtensions(queryVal, context)
+
+  // The next 2 functions are parametrized on `SangriaGraphQlContext` which makes them not usable
+  // when directly passed into the delegate. Instead, we have to do a (safe) typecast. It is
+  // wrapped as a `Try` to avoid future runtime errors.
+  override def afterField(queryVal: QueryMetrics, fieldVal: Long, value: Any, mctx: MiddlewareQueryContext[SangriaGraphQlContext, _, _], ctx: Context[SangriaGraphQlContext, _]): Option[Any] = {
+    val safeContext = Try(ctx.asInstanceOf[Context[Any, _]])
+    safeContext match {
+      case Success(c) => underlying.afterField(queryVal, fieldVal, value, mctx, c)
+      case Failure(_) => None
+    }
+  }
+
+  override def fieldError(queryVal: QueryMetrics, fieldVal: Long, error: Throwable, mctx: MiddlewareQueryContext[SangriaGraphQlContext, _, _], ctx: Context[SangriaGraphQlContext, _]): Unit = {
+    val safeContext = Try(ctx.asInstanceOf[Context[Any, _]])
+    safeContext match {
+      case Success(c) =>
+        underlying.fieldError(queryVal, fieldVal, error, mctx, c)
+      case Failure(_) => ()
+    }
+  }
+
+  // We cannot use the same type casting method as the above 2 classes because the return type
+  // is parametrized, so we just copy the underlying impl. It is very straightforward [just
+  // recording the timestamp] so we don't think it will change.
+  override def beforeField(queryVal: QueryMetrics, mctx: MiddlewareQueryContext[SangriaGraphQlContext, _, _], ctx: Context[SangriaGraphQlContext, _]): BeforeFieldResult[SangriaGraphQlContext, Long] =
+    continue(System.nanoTime())
+}

--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/NaptimeUnionField.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/NaptimeUnionField.scala
@@ -49,24 +49,24 @@ object NaptimeUnionField {
       resourceName: ResourceName,
       currentPath: List[String]): UnionType[SangriaGraphQlContext] = {
 
-    val objects = unionDataSchema.getTypes.asScala.map { subType =>
+    val objects = unionDataSchema.getTypes.asScala.map { unionMember =>
 
       val typedDefinitions = getTypedDefinition(unionDataSchema).getOrElse(Map[String, String]())
 
-      val unionMemberKey = subType match {
-        case _ if typedDefinitions.contains(subType.getUnionMemberKey) =>
-          typedDefinitions(subType.getUnionMemberKey)
+      val unionMemberKey = unionMember match {
+        case _ if typedDefinitions.contains(unionMember.getUnionMemberKey) =>
+          typedDefinitions(unionMember.getUnionMemberKey)
         case namedType: NamedDataSchema
           if typedDefinitions.contains(namedType.getName)
             && unionDataSchema.getProperties.get(NAMESPACE_KEY) == namedType.getNamespace =>
           typedDefinitions(namedType.getName)
-        case _ => subType.getUnionMemberKey
+        case _ => unionMember.getUnionMemberKey
       }
 
       val unionMemberFieldName = FieldBuilder.formatName(unionMemberKey)
       val subTypeField = FieldBuilder.buildField(
         schemaMetadata,
-        new RecordDataSchemaField(subType),
+        new RecordDataSchemaField(unionMember),
         namespace,
         Some(unionMemberKey),
         resourceName = resourceName,

--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/types/NaptimeTypes.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/types/NaptimeTypes.scala
@@ -30,7 +30,7 @@ object NaptimeTypes {
       case _ => Left(DataMapCoercionViolation)
     },
     coerceInput = {
-      case StringValue(string, _, _) => stringToDataMapEither(string)
+      case StringValue(string, _, _, _, _) => stringToDataMapEither(string)
       case _ => Left(DataMapCoercionViolation)
     })
 }

--- a/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/DefaultGraphqlSchemaProviderTest.scala
+++ b/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/DefaultGraphqlSchemaProviderTest.scala
@@ -150,6 +150,7 @@ object DefaultGraphqlSchemaProviderTest extends MockitoSugar {
     MergedInstructor.SCHEMA.getFullName -> MergedInstructor.SCHEMA,
     MergedPartner.SCHEMA.getFullName -> MergedPartner.SCHEMA)
 
+  // REFER TO https://github.com/sangria-graphql/sangria/blob/v1.4.0/src/main/scala/sangria/schema/package.scala#L175
   val DEFAULT_TYPES = Set(
     "ID",
     "root",

--- a/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/middleware/UrlLoggingMiddlewareTest.scala
+++ b/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/middleware/UrlLoggingMiddlewareTest.scala
@@ -86,6 +86,7 @@ class UrlLoggingMiddlewareTest extends AssertionsForJUnit with MockitoSugar {
       field = courseField,
       parentType = mock[ObjectType[SangriaGraphQlContext, Any]],
       marshaller = mock[ResultMarshaller],
+      query = Document.emptyStub,
       sourceMapper = None,
       deprecationTracker = DeprecationTracker.empty,
       astFields = Vector.empty,

--- a/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/schema/PrimitiveFieldTest.scala
+++ b/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/schema/PrimitiveFieldTest.scala
@@ -24,6 +24,7 @@ import org.coursera.naptime.ari.graphql.helpers.ArgumentBuilder
 import org.junit.Test
 import org.scalatest.junit.AssertionsForJUnit
 import org.scalatest.mockito.MockitoSugar
+import sangria.ast.Document
 import sangria.execution.DeprecationTracker
 import sangria.execution.ExecutionPath
 import sangria.marshalling.ResultMarshaller
@@ -52,6 +53,7 @@ class PrimitiveFieldTest extends AssertionsForJUnit with MockitoSugar {
       field = mock[Field[SangriaGraphQlContext, Val]],
       parentType = mock[ObjectType[SangriaGraphQlContext, Any]],
       marshaller = mock[ResultMarshaller],
+      query = Document.emptyStub,
       sourceMapper = None,
       deprecationTracker = DeprecationTracker.empty,
       astFields = Vector.empty,

--- a/project/NamedDependencies.scala
+++ b/project/NamedDependencies.scala
@@ -34,7 +34,8 @@ trait NamedDependencies { this: PluginVersionProvider =>
   val playJson = "com.typesafe.play" %% "play-json" % playJsonVersion
   val playTestCompile = ("com.typesafe.play" %% "play-test" % playVersion)
     .excludeAll(new ExclusionRule(organization="org.specs2"))
-  val sangria = "org.sangria-graphql" %% "sangria" % "1.2.2"
+  val sangria = "org.sangria-graphql" %% "sangria" % "1.4.0"
+  val sangriaSlowLog = "org.sangria-graphql" %% "sangria-slowlog" % "0.1.5"
   val scalaGuice = "net.codingwell" %% "scala-guice" % "4.1.1"
   val scalaLogging = "com.typesafe.scala-logging" %% "scala-logging" % "3.7.2"
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,2 +1,2 @@
-version in ThisBuild := "0.9.0-alpha5"
+version in ThisBuild := "0.9.1"
 


### PR DESCRIPTION
1. Upgrade sangria to 1.4.0 in order to sangria-slowlog
This resulted in some.. interesting findings
  a. In [1.2.2](https://github.com/sangria-graphql/sangria/blob/v1.2.2/src/main/scala/sangria/schema/Schema.scala#L822), sangria had some default types in the Schema class that went away in [1.4.0](https://github.com/sangria-graphql/sangria/blob/v1.4.0/src/main/scala/sangria/schema/Schema.scala#L816)
  b. In [1.2.2](https://github.com/sangria-graphql/sangria/blob/v1.2.2/src/main/scala/sangria/schema/Schema.scala#L219), the `ObjectType` constructor called `Named.checkObjFieldsFn(name, fields)` on the passed in field list. This went away in [1.4.0](https://github.com/sangria-graphql/sangria/blob/v1.4.0/src/main/scala/sangria/schema/Schema.scala#L190).

Both resulted in bizarre test failures that I fixed. In fixing the `NaptimeUnionFieldTest` test, I realized the previous assertions were misleading so I tried to clarify them with what I know, but I could be saying nonsense, so please give it a read.

2. Use approach specified in https://github.com/coursera/naptime/pull/222 because sangria-slowlog is not type parameterized so we have to wrap it in our own middleware.

All the unit tests now pass but I'd really appreciate it if someone can help me with pushing the jar and testing assembler locally with these changes. 