### PR TITLE
Fix flaky naptime test by adding IntegrationPatience

### DIFF
--- a/naptime-testing/src/test/scala/org/coursera/naptime/NestedMacroCourierTests.scala
+++ b/naptime-testing/src/test/scala/org/coursera/naptime/NestedMacroCourierTests.scala
@@ -19,6 +19,7 @@ import org.coursera.naptime.resources.CourierCollectionResource
 import org.coursera.naptime.router2.NaptimeRoutes
 import org.coursera.naptime.router2.Router
 import org.junit.Test
+import org.scalatest.concurrent.IntegrationPatience
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.junit.AssertionsForJUnit
 import play.api.libs.json.JsString
@@ -106,7 +107,8 @@ object NestedMacroCourierTests {
   val instructorRouter = Router.build[InstructorsResource]
 }
 
-class NestedMacroCourierTests extends AssertionsForJUnit with ScalaFutures with ResourceTestImplicits {
+class NestedMacroCourierTests extends AssertionsForJUnit with ScalaFutures with ResourceTestImplicits with IntegrationPatience {
+
 
   val implicitsModule = new Module {
     override def configure(binder: Binder): Unit = {


### PR DESCRIPTION
@yifan-coursera 

When I deliberately did a `Thread.sleep(50)` inside `LocalFetcher` the `coursesLocalFetcher_Finder` test failed, but with the `IntegrationPatience` the test did not fail, so I think it is doing as advertised.

This test looks like an integration test so I'm OK with adding the `IntegrationPatience` trait. 