### PR TITLE
Deduplicate MultiGet Ids

### DIFF
--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/resolvers/NaptimeResolver.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/resolvers/NaptimeResolver.scala
@@ -180,11 +180,11 @@ class NaptimeResolver extends DeferredResolver[SangriaGraphQlContext] with Stric
         Request(
           header,
           resourceName,
-          nonIdArguments + ("ids" -> JsArray(mergeIds(innerRequests)))) -> innerRequests
+          nonIdArguments + ("ids" -> JsArray(parseAndMergeIds(innerRequests)))) -> innerRequests
       }
   }
 
-  private[this] def mergeIds(requests: Vector[NaptimeRequest]): Seq[JsValue] = {
+  private[this] def parseAndMergeIds(requests: Vector[NaptimeRequest]): Seq[JsValue] = {
     requests.flatMap(parseIds).distinct
   }
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,2 +1,2 @@
-version in ThisBuild := "0.9.2-alpha0"
+version in ThisBuild := "0.9.2-alpha1"
 


### PR DESCRIPTION
This solves a bug where the resolver fails to properly de-duplicate multiGet ids when combining multiGets from multiple child related elements.

Instead of breaking multiGet ids strings into their constituent ids and de-duplicating the individual ids, it was de-duplicating the entire multiget ids strings for all requests.

so for this request:
```
[
  {teamId: 1, memberIds: [1,2,3]},
  {teamId: 2, memberIds: [1,2,3]},
  {teamId: 3, memberIds: [2,3,4]}
]
```

it would have made these requests

```
members.v1?ids=1,2,3
members.v1?ids=1,2,3
members.v1?ids=2,3,4
```

but the resolver attempts to combine multiple multigets into a single multiget, which in this case produces the following (which is incorrect):

```
members.v1?ids=1,2,2,3,3,4
```

To it’s credit, the backend only return individual member elements, like:

```
[{memberId: 1},{memberId: 2}, {memberId: 3}. {memberId: 4}]
```

But the resolver then iterates over the previously combined id string 1,2,2,3,3,4 post-query to populate the child elements resulting in duplicates in the final response body:

```
[
  {
    "teamId": 1,
    "memberIds": [1,2,3],
    "members": [
      {"memberId": 1},
      {"memberId": 2},
      {"memberId": 2},
      {"memberId": 3},
      {"memberId": 3}
    ]
  },
  {
    "teamId": 2,
    "memberIds": [1,2,3],
    "members": [
      {"memberId": 1},
      {"memberId": 2},
      {"memberId": 2},
      {"memberId": 3},
      {"memberId": 3}
    ]
  },
  {
    "teamId": 3,
    "memberIds": [2,3,4],
    "members": [
      {"memberId": 2},
      {"memberId": 2},
      {"memberId": 3},
      {"memberId": 3},
      {"memberId": 4}
    ]
  }
]
```

This diff both de-dupes the ids before the request is made and de-dupes the ids again post-request to ensure that we end up with:  

```
members.v1?ids=1,2,3,4
```

```
[
  {
    "teamId": 1,
    "memberIds": [1,2,3],
    "members": [
      {"memberId": 1},
      {"memberId": 2},
      {"memberId": 3}
    ]
  },
  {
    "teamId": 2,
    "memberIds": [1,2,3],
    "members": [
      {"memberId": 1},
      {"memberId": 2},
      {"memberId": 3}
    ]
  },
  {
    "teamId": 3,
    "memberIds": [2,3,4],
    "members": [
      {"memberId": 2},
      {"memberId": 3},
      {"memberId": 4}
    ]
  }
]
```

Note: It’s likely not necessary to do the de-duping twice, but it mirrored the original implementation and seemed like it wouldn’t hurt.