### PR TITLE
Fix Re-ordering of Related Resource Ids

### DIFF
--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/resolvers/NaptimeResolver.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/resolvers/NaptimeResolver.scala
@@ -189,6 +189,7 @@ class NaptimeResolver extends DeferredResolver[SangriaGraphQlContext] with Stric
   }
 
   private[this] def parseIds(request: NaptimeRequest): Seq[JsValue] = {
+    // .toSeq here is to preserve id ordering in related resource id arrays
     request.arguments.toSeq.filter { case (key, _) => key == "ids" }.map(_._2)
       .flatMap {
         case JsArray(idValues) => idValues

--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/resolvers/NaptimeResolver.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/resolvers/NaptimeResolver.scala
@@ -188,15 +188,12 @@ class NaptimeResolver extends DeferredResolver[SangriaGraphQlContext] with Stric
     requests.flatMap(parseIds).distinct
   }
 
-  private[this] def parseIds(request: NaptimeRequest): Set[JsValue] = {
-    request.arguments
-      .collect {
-        case ("ids", ids) => ids
-      }
+  private[this] def parseIds(request: NaptimeRequest): Seq[JsValue] = {
+    request.arguments.toSeq.filter { case (key, _) => key == "ids"}.map(_._2)
       .flatMap {
         case JsArray(idValues) => idValues
         case value: JsValue => List(value)
-      }
+      }.distinct
   }
 
   /**

--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/resolvers/NaptimeResolver.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/resolvers/NaptimeResolver.scala
@@ -189,7 +189,7 @@ class NaptimeResolver extends DeferredResolver[SangriaGraphQlContext] with Stric
   }
 
   private[this] def parseIds(request: NaptimeRequest): Seq[JsValue] = {
-    request.arguments.toSeq.filter { case (key, _) => key == "ids"}.map(_._2)
+    request.arguments.toSeq.filter { case (key, _) => key == "ids" }.map(_._2)
       .flatMap {
         case JsArray(idValues) => idValues
         case value: JsValue => List(value)

--- a/version.sbt
+++ b/version.sbt
@@ -1,2 +1,2 @@
-version in ThisBuild := "0.9.2-alpha1"
+version in ThisBuild := "0.9.2-alpha2"
 


### PR DESCRIPTION
- After merging a recent fix that de-duplicated ids we found that related resource `elementIds` and `elements` arrays were being re-ordered in a non-deterministic way during every request. In particular our moduleIds were being re-ordered and the order has actual meaning. 

- It turns out that the previous de-duplication fix had introduced sets and hence this non-determinism. I’ve replaced the Set introduced in parseIds with a Seq and this has corrected the problem.

- I tested using prod-preview and now the problem has gone away.