### PR TITLE
Do not attempt to fetch GetAlls accidently by adding logic to not grab results when no id value is given

### DIFF
--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/NaptimeResourceField.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/NaptimeResourceField.scala
@@ -116,9 +116,15 @@ object NaptimeResourceField extends StrictLogging {
       val isForwardRelationButMissingId =
         fieldRelationOpt.exists(_.relationType == RelationType.GET) &&
           idArg.forall(Utilities.jsValueIsEmpty)
+      // This is possible if we are attempting to get the resolver for the root request, and we
+      // put in an empty string for the id. Naptime will translate this to a GETALL behind the
+      // scenes, which results in a very slow API returning non data.
+      val isRequestWithNoArgumentValues = args
+        .map { case (_, jsValue) => jsValue }
+        .forall(Utilities.jsValueIsEmpty)
 
 
-      if (isForwardRelationButMissingId) {
+      if (isForwardRelationButMissingId || isRequestWithNoArgumentValues) {
         Value(null)
       } else {
         DeferredValue(DeferredNaptimeElement(resourceName, idArg, nonIdArgs, resourceMergedType))

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.9.2-alpha3"
+version in ThisBuild := "0.9.2-alpha4"


### PR DESCRIPTION
Fairly self explanatory.

Looking at this search: https://service.sumologic.com/ui/bento.html#/search/e9Lw847lmxaCfsmyKMz5FgnsNi8APIniDhOJu3gP

more than half of all of our slow queries come from calling our `onDemandSpecializations.v1` GETALL, which is because the FE passes in an empty string as s12n id. Ideally the FE doesn't do this but to protect ourselves I think it's a good idea to never call a `getAll` from a `get` request.

For actual `getAll`s, we use `NaptimePaginatedResourceField` so there's no conflict here.