### PR TITLE
Introduce Related Resource Auth Override

### DIFF
--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/NaptimePaginatedResourceField.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/NaptimePaginatedResourceField.scala
@@ -92,6 +92,8 @@ object NaptimePaginatedResourceField extends StrictLogging {
         val providedArguments =
           fieldRelationOpt.map(_.arguments.keySet).getOrElse(Set[String]())
 
+        val authOverride = fieldRelationOpt.flatMap(_.authOverride)
+
         val arguments = NaptimeResourceUtils
           .generateHandlerArguments(handler, includePagination = true)
           .filterNot(_.name == "ids")
@@ -168,7 +170,8 @@ object NaptimePaginatedResourceField extends StrictLogging {
                   resourceName,
                   updatedArgs,
                   resourceMergedType,
-                  paginationOverride))
+                  paginationOverride,
+                  authOverride))
                 .map {
                   case Left(error) =>
                     NaptimeResponse(

--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/NaptimeResourceField.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/NaptimeResourceField.scala
@@ -119,9 +119,8 @@ object NaptimeResourceField extends StrictLogging {
           .getOrElse {
             Set("ids" -> NaptimeResourceUtils.parseToJson(context.arg("id")))
           }
-        val args = context.args.raw
-          .mapValues(NaptimeResourceUtils.parseToJson)
-          .toSet ++ extraArguments
+        val args = context.args.raw.mapValues(NaptimeResourceUtils.parseToJson).toSet ++
+          extraArguments
         val idArg = args.find(_._1 == "ids").map(_._2)
         val nonIdArgs = args.filter(_._1 != "ids")
 
@@ -134,10 +133,18 @@ object NaptimeResourceField extends StrictLogging {
             fieldRelationOpt.isEmpty) &&
             idArg.forall(Utilities.jsValueIsEmpty)
 
+        val authOverride = fieldRelationOpt.flatMap(_.authOverride)
+
         if (isForwardRelationButMissingId) {
           Value(null)
         } else {
-          DeferredValue(DeferredNaptimeElement(resourceName, idArg, nonIdArgs, resourceMergedType))
+          DeferredValue(
+            DeferredNaptimeElement(
+              resourceName,
+              idArg,
+              nonIdArgs,
+              resourceMergedType,
+              authOverride))
             .map {
               case Left(error) =>
                 throw NaptimeResolveException(error)

--- a/naptime-testing/src/test/scala/org/coursera/naptime/NestedMacroCourierTests.scala
+++ b/naptime-testing/src/test/scala/org/coursera/naptime/NestedMacroCourierTests.scala
@@ -166,7 +166,8 @@ class NestedMacroCourierTests
     val request = Request(
       requestHeader = FakeRequest(),
       resource = CoursesResource.ID,
-      arguments = Set("id" -> JsString("abc")))
+      arguments = Set("id" -> JsString("abc")),
+      authOverride = None)
 
     val response = fetcher.data(request, isDebugMode = false).futureValue
 
@@ -188,7 +189,8 @@ class NestedMacroCourierTests
     val request = Request(
       requestHeader = FakeRequest(),
       resource = CoursesResource.ID,
-      arguments = Set("ids" -> JsString("abc,qrs")))
+      arguments = Set("ids" -> JsString("abc,qrs")),
+      authOverride = None)
 
     val response = fetcher.data(request, isDebugMode = false).futureValue
 
@@ -208,7 +210,8 @@ class NestedMacroCourierTests
     val request = Request(
       requestHeader = FakeRequest(),
       resource = CoursesResource.ID,
-      arguments = Set("q" -> JsString("search"), "query" -> JsString("xyz")))
+      arguments = Set("q" -> JsString("search"), "query" -> JsString("xyz")),
+      authOverride = None)
 
     val response = fetcher.data(request, isDebugMode = false).futureValue
 

--- a/naptime/src/main/pegasus/org/coursera/naptime/schema/AuthOverride.courier
+++ b/naptime/src/main/pegasus/org/coursera/naptime/schema/AuthOverride.courier
@@ -1,0 +1,6 @@
+namespace org.coursera.naptime.schema
+
+typeref AuthOverride = union [
+  record InternalAuth {}
+]
+

--- a/naptime/src/main/pegasus/org/coursera/naptime/schema/ReverseRelationAnnotation.courier
+++ b/naptime/src/main/pegasus/org/coursera/naptime/schema/ReverseRelationAnnotation.courier
@@ -20,4 +20,10 @@ record ReverseRelationAnnotation {
    */
   relationType: enum RelationType { FINDER, MULTI_GET, GET, SINGLE_ELEMENT_FINDER }
 
+  /**
+   * This is an optional field which will override the normal auth strategy used to make the
+   * related resource request if present.
+   */
+  authOverride: AuthOverride?
+
 }

--- a/naptime/src/main/scala/org/coursera/naptime/ari/models.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/ari/models.scala
@@ -21,6 +21,7 @@ import com.linkedin.data.schema.DataSchema
 import com.linkedin.data.schema.RecordDataSchema
 import org.coursera.naptime.ResourceName
 import org.coursera.naptime.ResponsePagination
+import org.coursera.naptime.schema.AuthOverride
 import org.coursera.naptime.schema.Resource
 import play.api.libs.json.JsValue
 import play.api.mvc.RequestHeader
@@ -84,7 +85,8 @@ object FullSchema {
 case class Request(
     requestHeader: RequestHeader,
     resource: ResourceName,
-    arguments: Set[(String, JsValue)])
+    arguments: Set[(String, JsValue)],
+    authOverride: Option[AuthOverride])
 
 /**
  * This model represents a response from a [[Request]], including elements and pagination

--- a/naptime/src/main/scala/org/coursera/naptime/models.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/models.scala
@@ -18,6 +18,7 @@ package org.coursera.naptime
 
 import com.linkedin.data.DataMap
 import org.coursera.naptime.QueryStringParser.NaptimeParseError
+import org.coursera.naptime.schema.AuthOverride
 import org.coursera.naptime.schema.RelationType
 import org.coursera.naptime.schema.Resource
 import org.coursera.naptime.schema.ReverseRelationAnnotation
@@ -629,6 +630,7 @@ trait ReverseRelation {
   val resourceName: ResourceName
   val arguments: Map[String, String]
   val description: String
+  val authOverride: Option[AuthOverride]
 
   def toAnnotation: ReverseRelationAnnotation
 }
@@ -637,46 +639,8 @@ case class FinderReverseRelation(
     resourceName: ResourceName,
     finderName: String,
     arguments: Map[String, String] = Map.empty,
-    description: String = "")
-    extends ReverseRelation {
-
-  def toAnnotation: ReverseRelationAnnotation = {
-    val mergedArguments = arguments + ("q" -> finderName)
-    ReverseRelationAnnotation(resourceName.identifier, mergedArguments, RelationType.FINDER)
-  }
-}
-
-case class MultiGetReverseRelation(
-    resourceName: ResourceName,
-    ids: String,
-    arguments: Map[String, String] = Map.empty,
-    description: String = "")
-    extends ReverseRelation {
-
-  def toAnnotation: ReverseRelationAnnotation = {
-    val mergedArguments = arguments + ("ids" -> ids)
-    ReverseRelationAnnotation(resourceName.identifier, mergedArguments, RelationType.MULTI_GET)
-  }
-}
-
-case class GetReverseRelation(
-    resourceName: ResourceName,
-    id: String,
-    arguments: Map[String, String] = Map.empty,
-    description: String = "")
-    extends ReverseRelation {
-
-  def toAnnotation: ReverseRelationAnnotation = {
-    val mergedArguments = arguments + ("ids" -> id)
-    ReverseRelationAnnotation(resourceName.identifier, mergedArguments, RelationType.GET)
-  }
-}
-
-case class SingleElementFinderReverseRelation(
-    resourceName: ResourceName,
-    finderName: String,
-    arguments: Map[String, String] = Map.empty,
-    description: String = "")
+    description: String = "",
+    authOverride: Option[AuthOverride] = None)
     extends ReverseRelation {
 
   def toAnnotation: ReverseRelationAnnotation = {
@@ -684,6 +648,61 @@ case class SingleElementFinderReverseRelation(
     ReverseRelationAnnotation(
       resourceName.identifier,
       mergedArguments,
-      RelationType.SINGLE_ELEMENT_FINDER)
+      RelationType.FINDER,
+      authOverride)
+  }
+}
+
+case class MultiGetReverseRelation(
+    resourceName: ResourceName,
+    ids: String,
+    arguments: Map[String, String] = Map.empty,
+    description: String = "",
+    authOverride: Option[AuthOverride] = None)
+    extends ReverseRelation {
+
+  def toAnnotation: ReverseRelationAnnotation = {
+    val mergedArguments = arguments + ("ids" -> ids)
+    ReverseRelationAnnotation(
+      resourceName.identifier,
+      mergedArguments,
+      RelationType.MULTI_GET,
+      authOverride)
+  }
+}
+
+case class GetReverseRelation(
+    resourceName: ResourceName,
+    id: String,
+    arguments: Map[String, String] = Map.empty,
+    description: String = "",
+    authOverride: Option[AuthOverride] = None)
+    extends ReverseRelation {
+
+  def toAnnotation: ReverseRelationAnnotation = {
+    val mergedArguments = arguments + ("ids" -> id)
+    ReverseRelationAnnotation(
+      resourceName.identifier,
+      mergedArguments,
+      RelationType.GET,
+      authOverride)
+  }
+}
+
+case class SingleElementFinderReverseRelation(
+    resourceName: ResourceName,
+    finderName: String,
+    arguments: Map[String, String] = Map.empty,
+    description: String = "",
+    authOverride: Option[AuthOverride] = None)
+    extends ReverseRelation {
+
+  def toAnnotation: ReverseRelationAnnotation = {
+    val mergedArguments = arguments + ("q" -> finderName)
+    ReverseRelationAnnotation(
+      resourceName.identifier,
+      mergedArguments,
+      RelationType.SINGLE_ELEMENT_FINDER,
+      authOverride)
   }
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.9.2-alpha9"
+version in ThisBuild := "0.9.2-alpha8"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.9.2-alpha7"
+version in ThisBuild := "0.9.2-alpha9"


### PR DESCRIPTION
- This change allows API developers to create related resources that are fetched with “internal” auths. 

- This is done by adding an authOverride value to the reverse relation definition on the primary resource. This will show up in the naptime resource schema and will be interpreted by assembler in order to request with the proper auth request headers.

- The purpose of this is to give developers the option to do authentication in only one place, the entry/parent resource, and use internal auth for all the related/child resources. This allows the child resources to be a bit more re-usable in that they can be attached to multiple parent resources that may all have different auth schemes.