### PR TITLE
Add testActionPassAuth to facilitate testing with trivial auth mocks

### DIFF
--- a/naptime-testing/src/main/scala/org/coursera/naptime/actions/RestActionTester.scala
+++ b/naptime-testing/src/main/scala/org/coursera/naptime/actions/RestActionTester.scala
@@ -95,5 +95,15 @@ trait RestActionTester { this: ScalaFutures =>
           }.get
       }
     }
+
+    def testActionPassAuth(ctx: RestContext[AuthType, BodyType]): RestResponse[ResponseType] = {
+      val responseFuture = action.safeApply(ctx).recover {
+        case e: NaptimeActionException => RestError(e)
+      }
+
+      Try(responseFuture.futureValue).recover {
+        case e: TestFailedException => e.cause.map(throw _).getOrElse(throw e)
+      }.get
+    }
   }
 }

--- a/naptime/src/main/scala/org/coursera/naptime/router2/MacroImpls.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/router2/MacroImpls.scala
@@ -88,7 +88,8 @@ class MacroImpls(val c: blackbox.Context) {
    * @tparam Resource The resource type that we are specializing.
    * @return A [[c.Tree]] corresponding to a [[ResourceRouterBuilder]].
    */
-  def build[Resource <: CollectionResource[_, _, _]](implicit wtt: WeakTypeTag[Resource]): c.Tree = {
+  def build[Resource <: CollectionResource[_, _, _]](
+      implicit wtt: WeakTypeTag[Resource]): c.Tree = {
     Nested.buildRouter[Resource]
   }
 
@@ -120,9 +121,7 @@ class MacroImpls(val c: blackbox.Context) {
       val methodsByRestActionCategory = try {
         naptimeMethods.groupBy { method =>
           method.typeSignature.resultType.typeArgs.headOption.getOrElse {
-            c.error(
-              method.pos,
-              "Method did not have type argument in result type?! Macro bug :'-(")
+            c.error(method.pos, "Method did not have type argument in result type?! Macro bug :'-(")
             throw MacroImpls.MacroBugException(s"Method: $method at pos: ${method.pos}")
           }
         }.toList
@@ -694,13 +693,12 @@ class MacroImpls(val c: blackbox.Context) {
     private[this] def buildPatchTree(methods: Iterable[c.universe.MethodSymbol]): OptionalTree =
       buildSingleElementActionTree(PatchRestActionCategory, "executePatch", methods)
 
-    private[this] def buildMultiGetTree(methods: Iterable[c.universe.MethodSymbol]): OptionalTree = {
+    private[this] def buildMultiGetTree(
+        methods: Iterable[c.universe.MethodSymbol]): OptionalTree = {
       methods match {
         case methodSymbol :: Nil =>
           if (methodSymbol.paramLists.length != 1) {
-            Left(
-              methodSymbol.pos,
-              "MultiGet requires a single parameter list, with at least 'ids'")
+            Left(methodSymbol.pos, "MultiGet requires a single parameter list, with at least 'ids'")
           } else {
             var hasSeenIds = false
             val params = for {
@@ -769,8 +767,7 @@ class MacroImpls(val c: blackbox.Context) {
       Right(tree -> methodBranches.map(_._2))
     }
 
-    private[this] def buildActionTree(
-        methods: Iterable[c.universe.MethodSymbol]): OptionalTree = {
+    private[this] def buildActionTree(methods: Iterable[c.universe.MethodSymbol]): OptionalTree = {
       val methodBranches =
         methods.map(buildSingleNamedActionTree(ActionRestActionCategory))
       val tree = q"""


### PR DESCRIPTION
Years ago, it was common practice to write resource-level unit tests for Coursera APIs - there are 555 usages of the existing `testAction` method in our codebase. As authorization logic became more complicated, teams increasingly moved away from resource testing because it was cumbersome to mock or fake auths. 

The irony here is that `testAction` itself requires the caller define a RestContext with authorization data, and tests only execute the authorizer's test-only `check` method. Needing to define a fully functional authorizer for testing is silly, because the bulk of its machinery won't even be exercised within a `testAction` execution. 

This revision adds a new test method that skips the `check` step of `testAction`. This makes it possible to construct test resources with trivial authorizers - e.g. `mock[<AuthorizerType]`. While we don't add very many _new_ resource-level tests, the option to switch to `testActionPassAuth` when refactoring tests for legacy code will make it _much_ easier to migrate authorizer definitions for legacy code. 