### PR TITLE
Add body-dependent authorization capability to Rest action handler

### DIFF
--- a/naptime-testing/src/main/scala/org/coursera/naptime/actions/RestActionTester.scala
+++ b/naptime-testing/src/main/scala/org/coursera/naptime/actions/RestActionTester.scala
@@ -81,7 +81,10 @@ trait RestActionTester { this: ScalaFutures =>
       action: RestAction[_, AuthType, BodyType, _, _, ResponseType]) {
 
     def testAction(ctx: RestContext[AuthType, BodyType]): RestResponse[ResponseType] = {
-      val updatedAuthEither = action.authGeneratorOrAuth.check(ctx.auth)
+      val updatedAuthEither = action.authGeneratorOrAuth match {
+        case Left(generator) => generator.apply(ctx.body).check(ctx.auth)
+        case Right(auth)     => auth.check(ctx.auth)
+      }
 
       updatedAuthEither match {
         case Left(error) => RestError(error)

--- a/naptime-testing/src/main/scala/org/coursera/naptime/actions/RestActionTester.scala
+++ b/naptime-testing/src/main/scala/org/coursera/naptime/actions/RestActionTester.scala
@@ -81,7 +81,7 @@ trait RestActionTester { this: ScalaFutures =>
       action: RestAction[_, AuthType, BodyType, _, _, ResponseType]) {
 
     def testAction(ctx: RestContext[AuthType, BodyType]): RestResponse[ResponseType] = {
-      val updatedAuthEither = action.restAuth.check(ctx.auth)
+      val updatedAuthEither = action.authGeneratorOrAuth.check(ctx.auth)
 
       updatedAuthEither match {
         case Left(error) => RestError(error)

--- a/naptime-testing/src/main/scala/org/coursera/naptime/actions/RestActionTester.scala
+++ b/naptime-testing/src/main/scala/org/coursera/naptime/actions/RestActionTester.scala
@@ -81,7 +81,7 @@ trait RestActionTester { this: ScalaFutures =>
       action: RestAction[_, AuthType, BodyType, _, _, ResponseType]) {
 
     def testAction(ctx: RestContext[AuthType, BodyType]): RestResponse[ResponseType] = {
-      val updatedAuthEither = action.authGeneratorOrAuth match {
+      val updatedAuthEither = action.restAuthGeneratorOrAuth match {
         case Left(generator) => generator.apply(ctx.body).check(ctx.auth)
         case Right(auth)     => auth.check(ctx.auth)
       }

--- a/naptime-testing/src/test/scala/org/coursera/naptime/AuthBuilderTest.scala
+++ b/naptime-testing/src/test/scala/org/coursera/naptime/AuthBuilderTest.scala
@@ -136,7 +136,7 @@ object AuthBuilderTest {
     def createBodyAuthNamedBrennan() =
       Nap
         .jsonBody[Engineer]
-        .bodyAuth(acceptIfEngineerHasName(_, "Brennan"))
+        .auth(acceptIfEngineerHasName(_, "Brennan"))
         .create { ctx =>
           Ok(Keyed(1, Some(ctx.body)))
         }
@@ -144,7 +144,7 @@ object AuthBuilderTest {
     def createBodyAuthNamedFrank() =
       Nap
         .jsonBody[Engineer]
-        .bodyAuth(acceptIfEngineerHasName(_, "Frank"))
+        .auth(acceptIfEngineerHasName(_, "Frank"))
         .create { ctx =>
           Ok(Keyed(1, Some(ctx.body)))
         }

--- a/naptime-testing/src/test/scala/org/coursera/naptime/AuthBuilderTest.scala
+++ b/naptime-testing/src/test/scala/org/coursera/naptime/AuthBuilderTest.scala
@@ -1,0 +1,153 @@
+package org.coursera.naptime
+
+import akka.stream.Materializer
+import org.coursera.naptime.access.HeaderAccessControl
+import org.coursera.naptime.actions.RestActionTester
+import org.coursera.naptime.model.KeyFormat
+import org.coursera.naptime.model.Keyed
+import org.coursera.naptime.resources.TopLevelCollectionResource
+import org.junit.Test
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.junit.AssertionsForJUnit
+import play.api.libs.json.Json
+import play.api.libs.json.OFormat
+import play.api.mvc.RequestHeader
+import play.api.test.FakeRequest
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+class AuthBuilderTest extends AssertionsForJUnit with ScalaFutures with RestActionTester {
+
+  import AuthBuilderTest._
+
+  val resource = new EngineersResource()
+
+  def makeRequestContext(body: Engineer) =
+    buildRestContext((), body, FakeRequest().withBody(body), RequestPagination(1, None, true))
+  @Test
+  def create_HeaderAuths_AuthWorks(): Unit = {
+    assert(
+      resource
+        .createNoAuth()
+        .testAction(makeRequestContext(Engineer("Anybody")))
+        .isOk)
+    assert(
+      resource
+        .createHeaderAuthAccept()
+        .testAction(makeRequestContext(Engineer("Anybody")))
+        .isOk)
+    assert(
+      resource
+        .createHeaderAuthReject()
+        .testAction(makeRequestContext(Engineer("Anybody")))
+        .isError)
+  }
+
+  @Test
+  def create_BodyAuthMatching_Ok(): Unit = {
+    assert(
+      resource
+        .createBodyAuthNamedBrennan()
+        .testAction(makeRequestContext(Engineer("Brennan")))
+        .isOk)
+    assert(
+      resource
+        .createBodyAuthNamedFrank()
+        .testAction(makeRequestContext(Engineer("Frank")))
+        .isOk)
+  }
+
+  @Test
+  def create_BodyAuthNonMatching_Rejects(): Unit = {
+    assert(
+      resource
+        .createBodyAuthNamedBrennan()
+        .testAction(makeRequestContext(Engineer("Abbot")))
+        .isError)
+    assert(
+      resource
+        .createBodyAuthNamedFrank()
+        .testAction(makeRequestContext(Engineer("Costello")))
+        .isError)
+  }
+}
+
+object AuthBuilderTest {
+
+  case class Engineer(name: String)
+
+  object Engineer {
+    implicit val fmt: OFormat[Engineer] = Json.format[Engineer]
+  }
+
+  case object AlwaysAccept extends HeaderAccessControl[Unit] {
+    override def run(requestHeader: RequestHeader)(
+        implicit executionContext: ExecutionContext): Future[Either[NaptimeActionException, Unit]] =
+      Future.successful(Right(()))
+
+    override private[naptime] def check(authInfo: Unit) = Right(authInfo)
+  }
+
+  case object AlwaysReject extends HeaderAccessControl[Unit] {
+    override def run(requestHeader: RequestHeader)(
+        implicit executionContext: ExecutionContext): Future[Either[NaptimeActionException, Unit]] =
+      Future.successful(Left(Errors.Forbidden()))
+
+    override private[naptime] def check(authInfo: Unit) = Left(Errors.Forbidden())
+  }
+
+  def acceptIfEngineerHasName(thing: Engineer, name: String) = {
+    if (thing.name == name) AlwaysAccept else AlwaysReject
+  }
+
+  class EngineersResource(implicit ec: ExecutionContext, mat: Materializer)
+      extends TopLevelCollectionResource[Int, Engineer] {
+    override val keyFormat: KeyFormat[Int] = KeyFormat.intKeyFormat
+    override val resourceName: String = "tests"
+    override val resourceFormat = Json.format[Engineer]
+    implicit val fields = Fields
+    override val executionContext = implicitly[ExecutionContext]
+    override val materializer = implicitly[Materializer]
+
+    def createNoAuth() =
+      Nap
+        .jsonBody[Engineer]
+        .create { ctx =>
+          Ok(Keyed(1, Some(ctx.body)))
+        }
+
+    def createHeaderAuthAccept() =
+      Nap
+        .jsonBody[Engineer]
+        .auth(AlwaysAccept)
+        .create { ctx =>
+          Ok(Keyed(1, Some(ctx.body)))
+        }
+
+    def createHeaderAuthReject() =
+      Nap
+        .jsonBody[Engineer]
+        .auth(AlwaysReject)
+        .create { ctx =>
+          Ok(Keyed(1, Some(ctx.body)))
+        }
+
+    def createBodyAuthNamedBrennan() =
+      Nap
+        .jsonBody[Engineer]
+        .bodyAuth(acceptIfEngineerHasName(_, "Brennan"))
+        .create { ctx =>
+          Ok(Keyed(1, Some(ctx.body)))
+        }
+
+    def createBodyAuthNamedFrank() =
+      Nap
+        .jsonBody[Engineer]
+        .bodyAuth(acceptIfEngineerHasName(_, "Frank"))
+        .create { ctx =>
+          Ok(Keyed(1, Some(ctx.body)))
+        }
+  }
+
+}

--- a/naptime/src/main/scala/org/coursera/naptime/access/HeaderAccessControl.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/access/HeaderAccessControl.scala
@@ -64,4 +64,10 @@ object HeaderAccessControl extends AnyOf with And with EitherOf with SuccessfulO
     StructuredAccessControl(Authenticator(parser, Decorator.identity[Unit]), authorizer)
   }
 
+  import scala.language.implicitConversions
+  implicit def accessControlGenerator[BodyType, T](
+      accessControl: HeaderAccessControl[T]): (BodyType => HeaderAccessControl[T]) = {
+    (b: BodyType) => accessControl
+  }
+
 }

--- a/naptime/src/main/scala/org/coursera/naptime/actions/DefinedBodyTypeRestActionBuilder.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/actions/DefinedBodyTypeRestActionBuilder.scala
@@ -38,7 +38,7 @@ class DefinedBodyTypeRestActionBuilder[
     ResourceKeyType,
     ResourceType,
     ResponseType] private[actions] (
-    authGeneratorOrAuth: AuthGeneratorOrAuth[BodyType, AuthType],
+    authGeneratorOrAuth: AuthGenerator[BodyType, AuthType],
     bodyParser: BodyParser[BodyType],
     errorHandler: PartialFunction[Throwable, RestError])(
     implicit keyFormat: KeyFormat[ResourceKeyType],
@@ -54,21 +54,9 @@ class DefinedBodyTypeRestActionBuilder[
       ResponseType] {
 
   /**
-   * Set the authentication framework.
-   */
-  def auth[NewAuthType](auth: HeaderAccessControl[NewAuthType]): DefinedBodyTypeRestActionBuilder[
-    RACType,
-    NewAuthType,
-    BodyType,
-    ResourceKeyType,
-    ResourceType,
-    ResponseType] =
-    new DefinedBodyTypeRestActionBuilder(Right(auth), bodyParser, errorHandler)
-
-  /**
    * Like [[auth]] above, but with a body-aware generator function.
    */
-  def bodyAuth[NewAuthType](authGenerator: BodyType => HeaderAccessControl[NewAuthType])
+  def auth[NewAuthType](authGenerator: BodyType => HeaderAccessControl[NewAuthType])
     : DefinedBodyTypeRestActionBuilder[
       RACType,
       NewAuthType,
@@ -76,7 +64,7 @@ class DefinedBodyTypeRestActionBuilder[
       ResourceKeyType,
       ResourceType,
       ResponseType] =
-    new DefinedBodyTypeRestActionBuilder(Left(authGenerator), bodyParser, errorHandler)
+    new DefinedBodyTypeRestActionBuilder(authGenerator, bodyParser, errorHandler)
 
   /**
    * Adds an error handling function to allow exceptions to generate custom errors.

--- a/naptime/src/main/scala/org/coursera/naptime/actions/DefinedBodyTypeRestActionBuilder.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/actions/DefinedBodyTypeRestActionBuilder.scala
@@ -68,7 +68,7 @@ class DefinedBodyTypeRestActionBuilder[
   /**
    * Like [[auth]] above, but with a body-aware generator function.
    */
-  def auth[NewAuthType](authGenerator: BodyType => HeaderAccessControl[NewAuthType])
+  def bodyAuth[NewAuthType](authGenerator: BodyType => HeaderAccessControl[NewAuthType])
     : DefinedBodyTypeRestActionBuilder[
       RACType,
       NewAuthType,
@@ -77,25 +77,6 @@ class DefinedBodyTypeRestActionBuilder[
       ResourceType,
       ResponseType] =
     new DefinedBodyTypeRestActionBuilder(Left(authGenerator), bodyParser, errorHandler)
-
-  /**
-   * Like [[auth]] above, but with a body-aware generator function.
-   *
-   * The `bodyTransform` argument is intended to support reuse `authGenerator` functions across
-   * handlers with different body types, but whose bodies contain compatible projections.
-   */
-  def auth[NewAuthType, C](bodyTransform: BodyType => C)(
-      authGenerator: C => HeaderAccessControl[NewAuthType]): DefinedBodyTypeRestActionBuilder[
-    RACType,
-    NewAuthType,
-    BodyType,
-    ResourceKeyType,
-    ResourceType,
-    ResponseType] =
-    new DefinedBodyTypeRestActionBuilder(
-      Left(authGenerator.compose(bodyTransform)),
-      bodyParser,
-      errorHandler)
 
   /**
    * Adds an error handling function to allow exceptions to generate custom errors.

--- a/naptime/src/main/scala/org/coursera/naptime/actions/DefinedBodyTypeRestActionBuilder.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/actions/DefinedBodyTypeRestActionBuilder.scala
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2016 Coursera Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.coursera.naptime.actions
+
+import akka.stream.Materializer
+import org.coursera.naptime.RestError
+import org.coursera.naptime.access.HeaderAccessControl
+import org.coursera.naptime.model.KeyFormat
+import play.api.libs.json.OFormat
+import play.api.mvc.BodyParser
+
+import scala.concurrent.ExecutionContext
+
+/**
+ * See [[RestActionBuilder]].
+ *
+ * This builder can hold body-dependent authorization definitions. In order to do this, the
+ * builder must forbid changes to body type, and does so by omitting body-related builder methods.
+ */
+class DefinedBodyTypeRestActionBuilder[
+    RACType,
+    AuthType,
+    BodyType,
+    ResourceKeyType,
+    ResourceType,
+    ResponseType] private[actions] (
+    auth: Either[BodyType => HeaderAccessControl[AuthType], HeaderAccessControl[AuthType]],
+    bodyParser: BodyParser[BodyType],
+    errorHandler: PartialFunction[Throwable, RestError])(
+    implicit keyFormat: KeyFormat[ResourceKeyType],
+    resourceFormat: OFormat[ResourceType],
+    ec: ExecutionContext,
+    mat: Materializer)
+    extends RestActionBuilderTerminators[
+      RACType,
+      AuthType,
+      BodyType,
+      ResourceKeyType,
+      ResourceType,
+      ResponseType] {
+
+  /**
+   * Set the authentication framework.
+   */
+  def auth[NewAuthType](auth: HeaderAccessControl[NewAuthType]): DefinedBodyTypeRestActionBuilder[
+    RACType,
+    NewAuthType,
+    BodyType,
+    ResourceKeyType,
+    ResourceType,
+    ResponseType] =
+    new DefinedBodyTypeRestActionBuilder(Right(auth), bodyParser, errorHandler)
+
+  /**
+   * Set the authentication framework.
+   */
+  def auth[NewAuthType](
+      bodyAuthFn: BodyType => HeaderAccessControl[NewAuthType]): DefinedBodyTypeRestActionBuilder[
+    RACType,
+    NewAuthType,
+    BodyType,
+    ResourceKeyType,
+    ResourceType,
+    ResponseType] =
+    new DefinedBodyTypeRestActionBuilder(Left(bodyAuthFn), bodyParser, errorHandler)
+
+  /**
+   * Set the authentication framework.
+   */
+  def auth[NewAuthType, C](bodyTransformFn: BodyType => C)(
+      authFn: C => HeaderAccessControl[NewAuthType]): DefinedBodyTypeRestActionBuilder[
+    RACType,
+    NewAuthType,
+    BodyType,
+    ResourceKeyType,
+    ResourceType,
+    ResponseType] =
+    new DefinedBodyTypeRestActionBuilder(
+      Left(authFn.compose(bodyTransformFn)),
+      bodyParser,
+      errorHandler)
+
+  /**
+   * Adds an error handling function to allow exceptions to generate custom errors.
+   *
+   * Note: all of the partial functions are stacked, with later functions getting an earlier crack
+   * at an exception to handle it.
+   *
+   * @param errorHandler Error handling partial function.
+   * @return the immutable RestActionBuilder to be used to build the naptime resource action.
+   */
+  def catching(
+      errorHandler: PartialFunction[Throwable, RestError]): DefinedBodyTypeRestActionBuilder[
+    RACType,
+    AuthType,
+    BodyType,
+    ResourceKeyType,
+    ResourceType,
+    ResponseType] =
+    new DefinedBodyTypeRestActionBuilder(auth, bodyParser, errorHandler.orElse(this.errorHandler))
+
+  /**
+   * Set the response type.
+   * TODO: is this necessary?
+   */
+  def returning[NewResponseType](): DefinedBodyTypeRestActionBuilder[
+    RACType,
+    AuthType,
+    BodyType,
+    ResourceKeyType,
+    ResourceType,
+    NewResponseType] =
+    new DefinedBodyTypeRestActionBuilder(auth, bodyParser, errorHandler)
+
+  override protected def bodyBuilder[Category, Response](): BodyBuilder[Category, Response] = {
+    new RestActionBodyBuilder[
+      Category,
+      AuthType,
+      BodyType,
+      ResourceKeyType,
+      ResourceType,
+      Response](auth, bodyParser, errorHandler)
+  }
+
+}

--- a/naptime/src/main/scala/org/coursera/naptime/actions/DefinedBodyTypeRestActionBuilder.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/actions/DefinedBodyTypeRestActionBuilder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Coursera Inc.
+ * Copyright 2018 Coursera Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/naptime/src/main/scala/org/coursera/naptime/actions/DefinedBodyTypeRestActionBuilder.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/actions/DefinedBodyTypeRestActionBuilder.scala
@@ -54,7 +54,7 @@ class DefinedBodyTypeRestActionBuilder[
       ResponseType] {
 
   /**
-   * Like [[auth]] above, but with a body-aware generator function.
+   * Like [[RestActionBuilder.auth]], but with a body-aware generator function.
    */
   def auth[NewAuthType](authGenerator: BodyType => HeaderAccessControl[NewAuthType])
     : DefinedBodyTypeRestActionBuilder[

--- a/naptime/src/main/scala/org/coursera/naptime/actions/DefinedBodyTypeRestActionBuilder.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/actions/DefinedBodyTypeRestActionBuilder.scala
@@ -66,7 +66,7 @@ class DefinedBodyTypeRestActionBuilder[
     new DefinedBodyTypeRestActionBuilder(Right(auth), bodyParser, errorHandler)
 
   /**
-   * Set the authentication framework.
+   * Like [[auth]] above, but with a body-aware generator function.
    */
   def auth[NewAuthType](authGenerator: BodyType => HeaderAccessControl[NewAuthType])
     : DefinedBodyTypeRestActionBuilder[
@@ -79,7 +79,10 @@ class DefinedBodyTypeRestActionBuilder[
     new DefinedBodyTypeRestActionBuilder(Left(authGenerator), bodyParser, errorHandler)
 
   /**
-   * Set the authentication framework.
+   * Like [[auth]] above, but with a body-aware generator function.
+   *
+   * The `bodyTransform` argument is intended to support reuse `authGenerator` functions across
+   * handlers with different body types, but whose bodies contain compatible projections.
    */
   def auth[NewAuthType, C](bodyTransform: BodyType => C)(
       authGenerator: C => HeaderAccessControl[NewAuthType]): DefinedBodyTypeRestActionBuilder[

--- a/naptime/src/main/scala/org/coursera/naptime/actions/RestActionBodyBuilder.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/actions/RestActionBodyBuilder.scala
@@ -42,7 +42,7 @@ class RestActionBodyBuilder[
     ResourceKeyType,
     ResourceType,
     ResponseType](
-    authGeneratorOrAuth: AuthGeneratorOrAuth[BodyType, AuthType],
+    authGeneratorOrAuth: AuthGenerator[BodyType, AuthType],
     bodyParser: BodyParser[BodyType],
     errorHandler: PartialFunction[Throwable, RestError])(
     implicit keyFormat: KeyFormat[ResourceKeyType],
@@ -85,7 +85,7 @@ class RestActionBodyBuilder[
       _paginationConfiguration: PaginationConfiguration): BuiltAction = {
 
     new RestAction[RACType, AuthType, BodyType, ResourceKeyType, ResourceType, ResponseType] {
-      override def restAuthGeneratorOrAuth = authGeneratorOrAuth
+      override def restAuthGenerator = authGeneratorOrAuth
       override def restBodyParser = bodyParser
       override def restEngine = category
       override def fieldsEngine = fields

--- a/naptime/src/main/scala/org/coursera/naptime/actions/RestActionBodyBuilder.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/actions/RestActionBodyBuilder.scala
@@ -43,7 +43,7 @@ class RestActionBodyBuilder[
     ResourceKeyType,
     ResourceType,
     ResponseType](
-    auth: HeaderAccessControl[AuthType],
+    auth: Either[BodyType => HeaderAccessControl[AuthType], HeaderAccessControl[AuthType]],
     bodyParser: BodyParser[BodyType],
     errorHandler: PartialFunction[Throwable, RestError])(
     implicit keyFormat: KeyFormat[ResourceKeyType],

--- a/naptime/src/main/scala/org/coursera/naptime/actions/RestActionBodyBuilder.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/actions/RestActionBodyBuilder.scala
@@ -85,7 +85,7 @@ class RestActionBodyBuilder[
       _paginationConfiguration: PaginationConfiguration): BuiltAction = {
 
     new RestAction[RACType, AuthType, BodyType, ResourceKeyType, ResourceType, ResponseType] {
-      override def authGeneratorOrAuth = authGeneratorOrAuth
+      override def restAuthGeneratorOrAuth = authGeneratorOrAuth
       override def restBodyParser = bodyParser
       override def restEngine = category
       override def fieldsEngine = fields

--- a/naptime/src/main/scala/org/coursera/naptime/actions/RestActionBodyBuilder.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/actions/RestActionBodyBuilder.scala
@@ -24,7 +24,6 @@ import org.coursera.naptime.PaginationConfiguration
 import org.coursera.naptime.RestContext
 import org.coursera.naptime.RestError
 import org.coursera.naptime.RestResponse
-import org.coursera.naptime.access.HeaderAccessControl
 import play.api.libs.json.OFormat
 import play.api.mvc.BodyParser
 
@@ -43,7 +42,7 @@ class RestActionBodyBuilder[
     ResourceKeyType,
     ResourceType,
     ResponseType](
-    auth: Either[BodyType => HeaderAccessControl[AuthType], HeaderAccessControl[AuthType]],
+    authGeneratorOrAuth: AuthGeneratorOrAuth[BodyType, AuthType],
     bodyParser: BodyParser[BodyType],
     errorHandler: PartialFunction[Throwable, RestError])(
     implicit keyFormat: KeyFormat[ResourceKeyType],
@@ -86,7 +85,7 @@ class RestActionBodyBuilder[
       _paginationConfiguration: PaginationConfiguration): BuiltAction = {
 
     new RestAction[RACType, AuthType, BodyType, ResourceKeyType, ResourceType, ResponseType] {
-      override def restAuth = auth
+      override def authGeneratorOrAuth = authGeneratorOrAuth
       override def restBodyParser = bodyParser
       override def restEngine = category
       override def fieldsEngine = fields

--- a/naptime/src/main/scala/org/coursera/naptime/actions/RestActionBuilder.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/actions/RestActionBuilder.scala
@@ -85,7 +85,10 @@ class RestActionBuilder[RACType, AuthType, BodyType, ResourceKeyType, ResourceTy
     new RestActionBuilder(auth, bodyParser, errorHandler)
 
   /**
-   * Set the authentication framework.
+   * Like [[auth]] above, but with a body-aware generator function.
+   *
+   * Note that this version of [[auth]] converts the builder into a
+   * [[DefinedBodyTypeRestActionBuilder]], which forbids request body definition changes.
    */
   def auth[NewAuthType](authGenerator: BodyType => HeaderAccessControl[NewAuthType])
     : DefinedBodyTypeRestActionBuilder[
@@ -98,7 +101,13 @@ class RestActionBuilder[RACType, AuthType, BodyType, ResourceKeyType, ResourceTy
     new DefinedBodyTypeRestActionBuilder(Left(authGenerator), bodyParser, errorHandler)
 
   /**
-   * Set the authentication framework.
+   * Like [[auth]] above, but with a body-aware generator function.
+   *
+   * The `bodyTransform` argument is intended to support reuse `authGenerator` functions across
+   * handlers with different body types, but whose bodies contain compatible projections.
+   *
+   * Note that this version of [[auth]] converts the builder into a
+   * [[DefinedBodyTypeRestActionBuilder]], which forbids request body definition changes.
    */
   def auth[NewAuthType, C](bodyTransform: BodyType => C)(
       authGenerator: C => HeaderAccessControl[NewAuthType]): DefinedBodyTypeRestActionBuilder[

--- a/naptime/src/main/scala/org/coursera/naptime/actions/RestActionBuilder.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/actions/RestActionBuilder.scala
@@ -46,7 +46,7 @@ import scala.util.control.NonFatal
  * A builder that helps build Rest Actions.
  */
 class RestActionBuilder[RACType, AuthType, BodyType, ResourceKeyType, ResourceType, ResponseType](
-    auth: HeaderAccessControl[AuthType],
+    auth: Either[BodyType => HeaderAccessControl[AuthType], HeaderAccessControl[AuthType]],
     bodyParser: BodyParser[BodyType],
     errorHandler: PartialFunction[Throwable, RestError])(
     implicit keyFormat: KeyFormat[ResourceKeyType],
@@ -64,7 +64,7 @@ class RestActionBuilder[RACType, AuthType, BodyType, ResourceKeyType, ResourceTy
     ResourceKeyType,
     ResourceType,
     ResponseType] =
-    new RestActionBuilder(auth, bodyParser, errorHandler)
+    new RestActionBuilder(Right(auth), bodyParser, errorHandler)
 
   /**
    * Set the body type.

--- a/naptime/src/main/scala/org/coursera/naptime/actions/RestActionBuilder.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/actions/RestActionBuilder.scala
@@ -20,7 +20,6 @@ import akka.stream.Materializer
 import akka.util.ByteString
 import com.typesafe.scalalogging.StrictLogging
 import org.coursera.naptime.model.KeyFormat
-import org.coursera.naptime.model.Keyed
 import org.coursera.naptime.NaptimeActionException
 import org.coursera.naptime.RestError
 import org.coursera.naptime.access.HeaderAccessControl
@@ -46,13 +45,32 @@ import scala.util.control.NonFatal
  * A builder that helps build Rest Actions.
  */
 class RestActionBuilder[RACType, AuthType, BodyType, ResourceKeyType, ResourceType, ResponseType](
-    auth: Either[BodyType => HeaderAccessControl[AuthType], HeaderAccessControl[AuthType]],
+    auth: HeaderAccessControl[AuthType],
     bodyParser: BodyParser[BodyType],
     errorHandler: PartialFunction[Throwable, RestError])(
     implicit keyFormat: KeyFormat[ResourceKeyType],
     resourceFormat: OFormat[ResourceType],
     ec: ExecutionContext,
-    mat: Materializer) {
+    mat: Materializer)
+    extends RestActionBuilderTerminators[
+      RACType,
+      AuthType,
+      BodyType,
+      ResourceKeyType,
+      ResourceType,
+      ResponseType] {
+
+  /**
+   * Set the body type.
+   */
+  def body[NewBodyType](bodyParser: BodyParser[NewBodyType]): DefinedBodyTypeRestActionBuilder[
+    RACType,
+    AuthType,
+    NewBodyType,
+    ResourceKeyType,
+    ResourceType,
+    ResponseType] =
+    new DefinedBodyTypeRestActionBuilder(Right(auth), bodyParser, errorHandler)
 
   /**
    * Set the authentication framework.
@@ -64,19 +82,36 @@ class RestActionBuilder[RACType, AuthType, BodyType, ResourceKeyType, ResourceTy
     ResourceKeyType,
     ResourceType,
     ResponseType] =
-    new RestActionBuilder(Right(auth), bodyParser, errorHandler)
+    new RestActionBuilder(auth, bodyParser, errorHandler)
 
   /**
-   * Set the body type.
+   * Set the authentication framework.
    */
-  def body[NewBodyType](bodyParser: BodyParser[NewBodyType]): RestActionBuilder[
+  def auth[NewAuthType](
+      bodyAuthFn: BodyType => HeaderAccessControl[NewAuthType]): DefinedBodyTypeRestActionBuilder[
     RACType,
-    AuthType,
-    NewBodyType,
+    NewAuthType,
+    BodyType,
     ResourceKeyType,
     ResourceType,
     ResponseType] =
-    new RestActionBuilder(auth, bodyParser, errorHandler)
+    new DefinedBodyTypeRestActionBuilder(Left(bodyAuthFn), bodyParser, errorHandler)
+
+  /**
+   * Set the authentication framework.
+   */
+  def auth[NewAuthType, C](bodyTransformFn: BodyType => C)(
+      authFn: C => HeaderAccessControl[NewAuthType]): DefinedBodyTypeRestActionBuilder[
+    RACType,
+    NewAuthType,
+    BodyType,
+    ResourceKeyType,
+    ResourceType,
+    ResponseType] =
+    new DefinedBodyTypeRestActionBuilder(
+      Left(authFn.compose(bodyTransformFn)),
+      bodyParser,
+      errorHandler)
 
   /**
    * Adds an error handling function to allow exceptions to generate custom errors.
@@ -106,7 +141,7 @@ class RestActionBuilder[RACType, AuthType, BodyType, ResourceKeyType, ResourceTy
 
   def rawJsonBody(maxLength: Int = 100 * 1024) = body(BodyParsers.parse.tolerantJson(maxLength))
 
-  def jsonBody[NewBodyType](implicit reads: Reads[NewBodyType]): RestActionBuilder[
+  def jsonBody[NewBodyType](implicit reads: Reads[NewBodyType]): DefinedBodyTypeRestActionBuilder[
     RACType,
     AuthType,
     NewBodyType,
@@ -117,7 +152,7 @@ class RestActionBuilder[RACType, AuthType, BodyType, ResourceKeyType, ResourceTy
   }
 
   def jsonBody[NewBodyType](maxLength: Int = 100 * 1024)(
-      implicit reads: Reads[NewBodyType]): RestActionBuilder[
+      implicit reads: Reads[NewBodyType]): DefinedBodyTypeRestActionBuilder[
     RACType,
     AuthType,
     NewBodyType,
@@ -173,186 +208,14 @@ class RestActionBuilder[RACType, AuthType, BodyType, ResourceKeyType, ResourceTy
     body(parser)
   }
 
-  type BodyBuilder[Category, Response] =
-    RestActionBodyBuilder[Category, AuthType, BodyType, ResourceKeyType, ResourceType, Response]
-
-  private[this] def bodyBuilder[Category, Response](): BodyBuilder[Category, Response] = {
+  override protected def bodyBuilder[Category, Response](): BodyBuilder[Category, Response] = {
     new RestActionBodyBuilder[
       Category,
       AuthType,
       BodyType,
       ResourceKeyType,
       ResourceType,
-      Response](auth, bodyParser, errorHandler)
+      Response](Right(auth), bodyParser, errorHandler)
   }
-
-  // Define all the available REST action types and categories.
-  /**
-   * Gets a resource by ID
-   *
-   * Example:
-   * {{{
-   * def get(id: Int) = Rest.get { ctx =>
-   *   Ok(Keyed(id, MyResource(name=s"Resource-$id")))
-   * }
-   * }}}
-   *
-   * Underlying HTTP request (id = "1"):
-   * {{{ GET /api/myResource/1 }}}
-   */
-  type GetBuilder = BodyBuilder[GetRestActionCategory, Keyed[ResourceKeyType, ResourceType]]
-  def get: GetBuilder = bodyBuilder()
-
-  /**
-   * Gets a batch of resources from this collection.
-   *
-   * Example:
-   * {{{
-   * def multiGet(ids: Seq[Int]) = Rest.multiGet { ctx =>
-   *   Ok(ids.map(id => Keyed(id, MyResource(name=s"Resource-$id"))))
-   * }
-   * }}}
-   *
-   * Underlying HTTP request (ids = "1,2,3,4")
-   * {{{ GET /api/myResource?ids=1,2,3,4 }}}
-   */
-  type MultiGetBuilder =
-    BodyBuilder[MultiGetRestActionCategory, Seq[Keyed[ResourceKeyType, ResourceType]]]
-  def multiGet: MultiGetBuilder = bodyBuilder()
-
-  /**
-   * Gets all elements in a collection. Note: please use paging to avoid OOM-ing.
-   *
-   * Example:
-   * {{{
-   * def getAll = Rest.getAll { ctx =>
-   *   val results = store.getAll(start=ctx.paging.start, limit=ctx.paging.limit)
-   *   Ok(results)
-   * }
-   * }}}
-   *
-   * Underlying HTTP request (pagination: start=10, limit=5)
-   * {{{ GET /api/myResource?start=10&limit=5 }}}
-   */
-  type GetAllBuilder =
-    BodyBuilder[GetAllRestActionCategory, Seq[Keyed[ResourceKeyType, ResourceType]]]
-  def getAll: GetAllBuilder = bodyBuilder()
-
-  /**
-   * Creates a new resource given an input.
-   *
-   * Example:
-   * {{{
-   * def create = Rest.create { ctx =>
-   *   val newElement = createResourceFromBody(ctx.body)
-   *   val newId = store.save(newOne)
-   *   Ok(Keyed(newId, Some(newElement)))
-   * }
-   * }}}
-   *
-   * Underlying HTTP request (body elided):
-   * {{{ POST /api/myResource }}}
-   */
-  type CreateBuilder =
-    BodyBuilder[CreateRestActionCategory, Keyed[ResourceKeyType, Option[ResourceType]]]
-  def create: CreateBuilder = bodyBuilder()
-
-  /**
-   * Updates a resource with a new copy of the resource.
-   *
-   * Example:
-   * {{{
-   * def update(id: Int) = Rest.update { ctx =>
-   *   val newVersion = validateBody(ctx.body)
-   *   store.save(id, newVersion)
-   *   Ok(Keyed(id, newVersion))
-   * }
-   * }}}
-   *
-   * Underlying HTTP request (body elided, id=2):
-   * {{{ PUT /api/myResource/2 }}}
-   */
-  type UpdateBuilder =
-    BodyBuilder[UpdateRestActionCategory, Option[Keyed[ResourceKeyType, ResourceType]]]
-  def update: UpdateBuilder = bodyBuilder()
-
-  /**
-   * Deletes an element from a collection.
-   *
-   * Example:
-   * {{{
-   * def delete(id: Int) = Rest.delete { ctx =>
-   *   store.delete(id)
-   *   Ok()
-   * }
-   * }}}
-   *
-   * Underlying HTTP request (id=4):
-   * {{{ DELETE /api/myResource/4 }}}
-   */
-  type DeleteBuilder = BodyBuilder[DeleteRestActionCategory, Unit]
-  def delete: DeleteBuilder = bodyBuilder()
-
-  /**
-   * Patch (or partial update) a resource.
-   *
-   * Example:
-   * {{{
-   * def patch(id: Int) = Rest.patch { ctx =>
-   *   val oldObj = store.get(id)
-   *   val newObj = PatchEngine.patch(oldObj, ctx.body)
-   *   store.save(id, newObj)
-   *   Ok(Keyed(id, newObj))
-   * }
-   * }}}
-   *
-   * Underlying HTTP request (id=10, body elided):
-   * {{{ PATCH /api/myResource/10 }}}
-   */
-  type PatchBuilder = BodyBuilder[PatchRestActionCategory, Keyed[ResourceKeyType, ResourceType]]
-  def patch: PatchBuilder = bodyBuilder()
-
-  /**
-   * Retrieval by any method other than retrival by Id [primary key]. (For example, alternate key
-   * lookup, or full text search. This is intentionally a flexible API and can be used appropriately
-   * in many contexts. A finder MUST NOT have side effects, and must be idempotent.
-   *
-   * Example:
-   * {{{
-   * def alternateKey(name: String) = Rest.finder { ctx =>
-   *   val results = store.lookupByName(name=name)
-   *   Ok(results.toSeq)
-   * }
-   * }}}
-   *
-   * Underlying HTTP request (finder name='alternateKey', name='hogwarts'):
-   * {{{ GET /api/myResource?q=alternateKey&name=hogwarts }}}
-   */
-  type FinderResponseType = Seq[Keyed[ResourceKeyType, ResourceType]]
-  type FinderBuilder = BodyBuilder[FinderRestActionCategory, FinderResponseType]
-  def finder: FinderBuilder = bodyBuilder()
-
-  /**
-   * Arbitrary actions on objects that are not standard CRUD operations. This is very flexible, and
-   * must be carefully used only for good (and not evil). Actions may have side effects and may not
-   * be idempotent.
-   *
-   * Example:
-   * {{{
-   * def convertToHtml(ids: Seq[Int]) = Rest.action { ctx =>
-   *   val pages = store.multiGet(ids)
-   *   val htmlIfied = pages.map { page =>
-   *     MarkdownEngine.toHtml(page)
-   *   }
-   *   store.multiSave(htmlIfied)
-   *   Ok(htmlIfied)
-   * }
-   * }}}
-   *
-   * Underlying HTTP request (ids=1,2,3,5,8,13):
-   * {{{ POST /api/myResource?action=convertToHtml&ids=1,2,3,5,8,13 }}}
-   */
-  type ActionBuilder[A] = BodyBuilder[ActionRestActionCategory, A]
-  def action[A]: ActionBuilder[A] = bodyBuilder()
 
 }

--- a/naptime/src/main/scala/org/coursera/naptime/actions/RestActionBuilder.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/actions/RestActionBuilder.scala
@@ -87,21 +87,21 @@ class RestActionBuilder[RACType, AuthType, BodyType, ResourceKeyType, ResourceTy
   /**
    * Set the authentication framework.
    */
-  def auth[NewAuthType](
-      bodyAuthFn: BodyType => HeaderAccessControl[NewAuthType]): DefinedBodyTypeRestActionBuilder[
-    RACType,
-    NewAuthType,
-    BodyType,
-    ResourceKeyType,
-    ResourceType,
-    ResponseType] =
-    new DefinedBodyTypeRestActionBuilder(Left(bodyAuthFn), bodyParser, errorHandler)
+  def auth[NewAuthType](authGenerator: BodyType => HeaderAccessControl[NewAuthType])
+    : DefinedBodyTypeRestActionBuilder[
+      RACType,
+      NewAuthType,
+      BodyType,
+      ResourceKeyType,
+      ResourceType,
+      ResponseType] =
+    new DefinedBodyTypeRestActionBuilder(Left(authGenerator), bodyParser, errorHandler)
 
   /**
    * Set the authentication framework.
    */
-  def auth[NewAuthType, C](bodyTransformFn: BodyType => C)(
-      authFn: C => HeaderAccessControl[NewAuthType]): DefinedBodyTypeRestActionBuilder[
+  def auth[NewAuthType, C](bodyTransform: BodyType => C)(
+      authGenerator: C => HeaderAccessControl[NewAuthType]): DefinedBodyTypeRestActionBuilder[
     RACType,
     NewAuthType,
     BodyType,
@@ -109,7 +109,7 @@ class RestActionBuilder[RACType, AuthType, BodyType, ResourceKeyType, ResourceTy
     ResourceType,
     ResponseType] =
     new DefinedBodyTypeRestActionBuilder(
-      Left(authFn.compose(bodyTransformFn)),
+      Left(authGenerator.compose(bodyTransform)),
       bodyParser,
       errorHandler)
 

--- a/naptime/src/main/scala/org/coursera/naptime/actions/RestActionBuilder.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/actions/RestActionBuilder.scala
@@ -70,7 +70,7 @@ class RestActionBuilder[RACType, AuthType, BodyType, ResourceKeyType, ResourceTy
     ResourceKeyType,
     ResourceType,
     ResponseType] =
-    new DefinedBodyTypeRestActionBuilder(Right(auth), bodyParser, errorHandler)
+    new DefinedBodyTypeRestActionBuilder(auth, bodyParser, errorHandler)
 
   /**
    * Set the authentication framework.
@@ -83,44 +83,6 @@ class RestActionBuilder[RACType, AuthType, BodyType, ResourceKeyType, ResourceTy
     ResourceType,
     ResponseType] =
     new RestActionBuilder(auth, bodyParser, errorHandler)
-
-  /**
-   * Like [[auth]] above, but with a body-aware generator function.
-   *
-   * Note that this version of [[auth]] converts the builder into a
-   * [[DefinedBodyTypeRestActionBuilder]], which forbids request body definition changes.
-   */
-  def bodyAuth[NewAuthType](authGenerator: BodyType => HeaderAccessControl[NewAuthType])
-    : DefinedBodyTypeRestActionBuilder[
-      RACType,
-      NewAuthType,
-      BodyType,
-      ResourceKeyType,
-      ResourceType,
-      ResponseType] =
-    new DefinedBodyTypeRestActionBuilder(Left(authGenerator), bodyParser, errorHandler)
-
-  /**
-   * Like [[auth]] above, but with a body-aware generator function.
-   *
-   * The `bodyTransform` argument is intended to support reuse `authGenerator` functions across
-   * handlers with different body types, but whose bodies contain compatible projections.
-   *
-   * Note that this version of [[auth]] converts the builder into a
-   * [[DefinedBodyTypeRestActionBuilder]], which forbids request body definition changes.
-   */
-  def bodyAuth[NewAuthType, C](bodyTransform: BodyType => C)(
-      authGenerator: C => HeaderAccessControl[NewAuthType]): DefinedBodyTypeRestActionBuilder[
-    RACType,
-    NewAuthType,
-    BodyType,
-    ResourceKeyType,
-    ResourceType,
-    ResponseType] =
-    new DefinedBodyTypeRestActionBuilder(
-      Left(authGenerator.compose(bodyTransform)),
-      bodyParser,
-      errorHandler)
 
   /**
    * Adds an error handling function to allow exceptions to generate custom errors.
@@ -224,7 +186,7 @@ class RestActionBuilder[RACType, AuthType, BodyType, ResourceKeyType, ResourceTy
       BodyType,
       ResourceKeyType,
       ResourceType,
-      Response](Right(auth), bodyParser, errorHandler)
+      Response](auth, bodyParser, errorHandler)
   }
 
 }

--- a/naptime/src/main/scala/org/coursera/naptime/actions/RestActionBuilder.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/actions/RestActionBuilder.scala
@@ -90,7 +90,7 @@ class RestActionBuilder[RACType, AuthType, BodyType, ResourceKeyType, ResourceTy
    * Note that this version of [[auth]] converts the builder into a
    * [[DefinedBodyTypeRestActionBuilder]], which forbids request body definition changes.
    */
-  def auth[NewAuthType](authGenerator: BodyType => HeaderAccessControl[NewAuthType])
+  def bodyAuth[NewAuthType](authGenerator: BodyType => HeaderAccessControl[NewAuthType])
     : DefinedBodyTypeRestActionBuilder[
       RACType,
       NewAuthType,
@@ -109,7 +109,7 @@ class RestActionBuilder[RACType, AuthType, BodyType, ResourceKeyType, ResourceTy
    * Note that this version of [[auth]] converts the builder into a
    * [[DefinedBodyTypeRestActionBuilder]], which forbids request body definition changes.
    */
-  def auth[NewAuthType, C](bodyTransform: BodyType => C)(
+  def bodyAuth[NewAuthType, C](bodyTransform: BodyType => C)(
       authGenerator: C => HeaderAccessControl[NewAuthType]): DefinedBodyTypeRestActionBuilder[
     RACType,
     NewAuthType,

--- a/naptime/src/main/scala/org/coursera/naptime/actions/RestActionBuilderTerminators.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/actions/RestActionBuilderTerminators.scala
@@ -1,0 +1,185 @@
+package org.coursera.naptime.actions
+
+import org.coursera.naptime.model.Keyed
+
+/**
+ * Defines terminal-position builder methods for [[RestActionBuilder]]
+ */
+trait RestActionBuilderTerminators[
+    RACType, AuthType, BodyType, ResourceKeyType, ResourceType, ResponseType] {
+
+  type BodyBuilder[Category, Response] =
+    RestActionBodyBuilder[Category, AuthType, BodyType, ResourceKeyType, ResourceType, Response]
+
+  protected def bodyBuilder[Category, Response](): BodyBuilder[Category, Response]
+
+  // Define all the available REST action types and categories.
+  /**
+   * Gets a resource by ID
+   *
+   * Example:
+   * {{{
+   * def get(id: Int) = Rest.get { ctx =>
+   *   Ok(Keyed(id, MyResource(name=s"Resource-$id")))
+   * }
+   * }}}
+   *
+   * Underlying HTTP request (id = "1"):
+   * {{{ GET /api/myResource/1 }}}
+   */
+  type GetBuilder = BodyBuilder[GetRestActionCategory, Keyed[ResourceKeyType, ResourceType]]
+  def get: GetBuilder = bodyBuilder()
+
+  /**
+   * Gets a batch of resources from this collection.
+   *
+   * Example:
+   * {{{
+   * def multiGet(ids: Seq[Int]) = Rest.multiGet { ctx =>
+   *   Ok(ids.map(id => Keyed(id, MyResource(name=s"Resource-$id"))))
+   * }
+   * }}}
+   *
+   * Underlying HTTP request (ids = "1,2,3,4")
+   * {{{ GET /api/myResource?ids=1,2,3,4 }}}
+   */
+  type MultiGetBuilder =
+    BodyBuilder[MultiGetRestActionCategory, Seq[Keyed[ResourceKeyType, ResourceType]]]
+  def multiGet: MultiGetBuilder = bodyBuilder()
+
+  /**
+   * Gets all elements in a collection. Note: please use paging to avoid OOM-ing.
+   *
+   * Example:
+   * {{{
+   * def getAll = Rest.getAll { ctx =>
+   *   val results = store.getAll(start=ctx.paging.start, limit=ctx.paging.limit)
+   *   Ok(results)
+   * }
+   * }}}
+   *
+   * Underlying HTTP request (pagination: start=10, limit=5)
+   * {{{ GET /api/myResource?start=10&limit=5 }}}
+   */
+  type GetAllBuilder =
+    BodyBuilder[GetAllRestActionCategory, Seq[Keyed[ResourceKeyType, ResourceType]]]
+  def getAll: GetAllBuilder = bodyBuilder()
+
+  /**
+   * Creates a new resource given an input.
+   *
+   * Example:
+   * {{{
+   * def create = Rest.create { ctx =>
+   *   val newElement = createResourceFromBody(ctx.body)
+   *   val newId = store.save(newOne)
+   *   Ok(Keyed(newId, Some(newElement)))
+   * }
+   * }}}
+   *
+   * Underlying HTTP request (body elided):
+   * {{{ POST /api/myResource }}}
+   */
+  type CreateBuilder =
+    BodyBuilder[CreateRestActionCategory, Keyed[ResourceKeyType, Option[ResourceType]]]
+  def create: CreateBuilder = bodyBuilder()
+
+  /**
+   * Updates a resource with a new copy of the resource.
+   *
+   * Example:
+   * {{{
+   * def update(id: Int) = Rest.update { ctx =>
+   *   val newVersion = validateBody(ctx.body)
+   *   store.save(id, newVersion)
+   *   Ok(Keyed(id, newVersion))
+   * }
+   * }}}
+   *
+   * Underlying HTTP request (body elided, id=2):
+   * {{{ PUT /api/myResource/2 }}}
+   */
+  type UpdateBuilder =
+    BodyBuilder[UpdateRestActionCategory, Option[Keyed[ResourceKeyType, ResourceType]]]
+  def update: UpdateBuilder = bodyBuilder()
+
+  /**
+   * Deletes an element from a collection.
+   *
+   * Example:
+   * {{{
+   * def delete(id: Int) = Rest.delete { ctx =>
+   *   store.delete(id)
+   *   Ok()
+   * }
+   * }}}
+   *
+   * Underlying HTTP request (id=4):
+   * {{{ DELETE /api/myResource/4 }}}
+   */
+  type DeleteBuilder = BodyBuilder[DeleteRestActionCategory, Unit]
+  def delete: DeleteBuilder = bodyBuilder()
+
+  /**
+   * Patch (or partial update) a resource.
+   *
+   * Example:
+   * {{{
+   * def patch(id: Int) = Rest.patch { ctx =>
+   *   val oldObj = store.get(id)
+   *   val newObj = PatchEngine.patch(oldObj, ctx.body)
+   *   store.save(id, newObj)
+   *   Ok(Keyed(id, newObj))
+   * }
+   * }}}
+   *
+   * Underlying HTTP request (id=10, body elided):
+   * {{{ PATCH /api/myResource/10 }}}
+   */
+  type PatchBuilder = BodyBuilder[PatchRestActionCategory, Keyed[ResourceKeyType, ResourceType]]
+  def patch: PatchBuilder = bodyBuilder()
+
+  /**
+   * Retrieval by any method other than retrival by Id [primary key]. (For example, alternate key
+   * lookup, or full text search. This is intentionally a flexible API and can be used appropriately
+   * in many contexts. A finder MUST NOT have side effects, and must be idempotent.
+   *
+   * Example:
+   * {{{
+   * def alternateKey(name: String) = Rest.finder { ctx =>
+   *   val results = store.lookupByName(name=name)
+   *   Ok(results.toSeq)
+   * }
+   * }}}
+   *
+   * Underlying HTTP request (finder name='alternateKey', name='hogwarts'):
+   * {{{ GET /api/myResource?q=alternateKey&name=hogwarts }}}
+   */
+  type FinderResponseType = Seq[Keyed[ResourceKeyType, ResourceType]]
+  type FinderBuilder = BodyBuilder[FinderRestActionCategory, FinderResponseType]
+  def finder: FinderBuilder = bodyBuilder()
+
+  /**
+   * Arbitrary actions on objects that are not standard CRUD operations. This is very flexible, and
+   * must be carefully used only for good (and not evil). Actions may have side effects and may not
+   * be idempotent.
+   *
+   * Example:
+   * {{{
+   * def convertToHtml(ids: Seq[Int]) = Rest.action { ctx =>
+   *   val pages = store.multiGet(ids)
+   *   val htmlIfied = pages.map { page =>
+   *     MarkdownEngine.toHtml(page)
+   *   }
+   *   store.multiSave(htmlIfied)
+   *   Ok(htmlIfied)
+   * }
+   * }}}
+   *
+   * Underlying HTTP request (ids=1,2,3,5,8,13):
+   * {{{ POST /api/myResource?action=convertToHtml&ids=1,2,3,5,8,13 }}}
+   */
+  type ActionBuilder[A] = BodyBuilder[ActionRestActionCategory, A]
+  def action[A]: ActionBuilder[A] = bodyBuilder()
+
+}

--- a/naptime/src/main/scala/org/coursera/naptime/actions/RestActionBuilderTerminators.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/actions/RestActionBuilderTerminators.scala
@@ -5,7 +5,7 @@ import org.coursera.naptime.model.Keyed
 /**
  * Defines terminal-position builder methods for [[RestActionBuilder]]
  */
-trait RestActionBuilderTerminators[
+private[actions] trait RestActionBuilderTerminators[
     RACType, AuthType, BodyType, ResourceKeyType, ResourceType, ResponseType] {
 
   type BodyBuilder[Category, Response] =
@@ -14,6 +14,7 @@ trait RestActionBuilderTerminators[
   protected def bodyBuilder[Category, Response](): BodyBuilder[Category, Response]
 
   // Define all the available REST action types and categories.
+
   /**
    * Gets a resource by ID
    *

--- a/naptime/src/main/scala/org/coursera/naptime/actions/RestActionBuilderTerminators.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/actions/RestActionBuilderTerminators.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Coursera Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.coursera.naptime.actions
 
 import org.coursera.naptime.model.Keyed

--- a/naptime/src/main/scala/org/coursera/naptime/actions/package.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/actions/package.scala
@@ -20,8 +20,7 @@ import org.coursera.naptime.access.HeaderAccessControl
 
 package object actions {
 
-  type AuthGeneratorOrAuth[BodyType, AuthType] =
-    Either[BodyType => HeaderAccessControl[AuthType], HeaderAccessControl[AuthType]]
+  type AuthGenerator[BodyType, AuthType] = BodyType => HeaderAccessControl[AuthType]
 
   /**
    * Defines the allowed types of API endpoints.

--- a/naptime/src/main/scala/org/coursera/naptime/actions/package.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/actions/package.scala
@@ -16,7 +16,12 @@
 
 package org.coursera.naptime
 
+import org.coursera.naptime.access.HeaderAccessControl
+
 package object actions {
+
+  type AuthGeneratorOrAuth[BodyType, AuthType] =
+    Either[BodyType => HeaderAccessControl[AuthType], HeaderAccessControl[AuthType]]
 
   /**
    * Defines the allowed types of API endpoints.

--- a/naptime/src/main/scala/org/coursera/naptime/router2/MacroImpls.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/router2/MacroImpls.scala
@@ -88,7 +88,8 @@ class MacroImpls(val c: blackbox.Context) {
    * @tparam Resource The resource type that we are specializing.
    * @return A [[c.Tree]] corresponding to a [[ResourceRouterBuilder]].
    */
-  def build[Resource <: CollectionResource[_, _, _]](implicit wtt: WeakTypeTag[Resource]): c.Tree = {
+  def build[Resource <: CollectionResource[_, _, _]](
+      implicit wtt: WeakTypeTag[Resource]): c.Tree = {
     Nested.buildRouter[Resource]
   }
 
@@ -120,9 +121,7 @@ class MacroImpls(val c: blackbox.Context) {
       val methodsByRestActionCategory = try {
         naptimeMethods.groupBy { method =>
           method.typeSignature.resultType.typeArgs.headOption.getOrElse {
-            c.error(
-              method.pos,
-              "Method did not have type argument in result type?! Macro bug :'-(")
+            c.error(method.pos, "Method did not have type argument in result type?! Macro bug :'-(")
             throw MacroImpls.MacroBugException(s"Method: $method at pos: ${method.pos}")
           }
         }.toList
@@ -694,13 +693,12 @@ class MacroImpls(val c: blackbox.Context) {
     private[this] def buildPatchTree(methods: Iterable[c.universe.MethodSymbol]): OptionalTree =
       buildSingleElementActionTree(PatchRestActionCategory, "executePatch", methods)
 
-    private[this] def buildMultiGetTree(methods: Iterable[c.universe.MethodSymbol]): OptionalTree = {
+    private[this] def buildMultiGetTree(
+        methods: Iterable[c.universe.MethodSymbol]): OptionalTree = {
       methods match {
         case methodSymbol :: Nil =>
           if (methodSymbol.paramLists.length != 1) {
-            Left(
-              methodSymbol.pos,
-              "MultiGet requires a single parameter list, with at least 'ids'")
+            Left(methodSymbol.pos, "MultiGet requires a single parameter list, with at least 'ids'")
           } else {
             var hasSeenIds = false
             val params = for {
@@ -769,8 +767,7 @@ class MacroImpls(val c: blackbox.Context) {
       Right(tree -> methodBranches.map(_._2))
     }
 
-    private[this] def buildActionTree(
-        methods: Iterable[c.universe.MethodSymbol]): OptionalTree = {
+    private[this] def buildActionTree(methods: Iterable[c.universe.MethodSymbol]): OptionalTree = {
       val methodBranches =
         methods.map(buildSingleNamedActionTree(ActionRestActionCategory))
       val tree = q"""

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.9.2-alpha10"
+version in ThisBuild := "0.9.2-alpha12"


### PR DESCRIPTION
Coursera authorization rules are often context-dependent. For example, only university staff can create and modify courses for a particular university. When this context is present as a rest handler method argument (e.g. `get(id: CourseId) = Rest ...` or `update(id: CourseId) = Rest ...`), it's straightforward to define context-aware authorizers (e.g. `Rest.auth(canManageCourse(id)...`). Unfortunately, however, we frequently put necessary authorization context data into request bodies (e.g. `create() = Rest.jsonBody[Course].create { ... }`), and in these cases authorization logic must be implemented within handler bodies. 

In the Coursera code base there are 207 applications for `runAndCheck` (authorizers used outside of an `auth` block) and 307 instances of `throw Errors.Forbidden` (ad-hoc authorization application). These non-standard usages are problematic because they make it harder to know what a resource's behavior will be from outside, both as a developer and for automated tooling.

This revision modifies `RestAction` to accept either a simple `HeaderAccessControl[AuthType]` authorizer, or a body-dependent `BodyType => HeaderAccessControl[AuthType]` authorization expressions. This should make it possible for us to standardize many of our non-standard auth applications.

Note that, at least for Coursera, this change is not backward compatible, since our private code base has its own implementations of `RestActionBuilder`, which will need to be updated. 