### PR TITLE
Remove AkkaHttp from dependencies

### DIFF
--- a/project/NaptimeBuild.scala
+++ b/project/NaptimeBuild.scala
@@ -19,7 +19,9 @@ import sbt.Keys
 import de.heikoseeberger.sbtheader.HeaderKey.headers
 import de.heikoseeberger.sbtheader.license.Apache2_0
 import play.sbt.PlayFilters
-
+import play.sbt.PlayAkkaHttpServer
+import play.sbt.PlayLayoutPlugin
+import play.sbt.PlayScala
 
 object NaptimeBuild extends Build with NamedDependencies with PluginVersionProvider {
 
@@ -77,8 +79,8 @@ object NaptimeBuild extends Build with NamedDependencies with PluginVersionProvi
 
   private[this] def configure(project: Project): Project = {
     project
-      .enablePlugins(play.sbt.PlayScala)
-      .disablePlugins(play.sbt.PlayLayoutPlugin, PlayFilters)
+      .enablePlugins(PlayScala)
+      .disablePlugins(PlayLayoutPlugin, PlayFilters, PlayAkkaHttpServer)
       .settings(testSettings)
       .settings(headerSettings)
       .settings(org.coursera.naptime.sbt.Sonatype.settings)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.9.2-alpha10"
+version in ThisBuild := "0.9.2-alpha11"


### PR DESCRIPTION
By default, Play includes AkkaHttp in its dependencies along w/ its jar. This can be inconvenient for switching to Netty since Play will override any choices based on whether or not AkkaHttp exists in the classpath.

Read more:
https://www.playframework.com/documentation/2.6.x/NettyServer