### PR TITLE
Rename fields that were previously of type CustomBodyType

### DIFF
--- a/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/DefaultGraphqlSchemaProviderTest.scala
+++ b/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/DefaultGraphqlSchemaProviderTest.scala
@@ -83,8 +83,8 @@ object DefaultGraphqlSchemaProviderTest extends MockitoSugar {
     name = "get",
     parameters =
       List(Parameter(name = "id", `type` = "int", attributes = List.empty, default = None)),
-    inputBody = None,
-    customOutputBody = None,
+    inputBodyType = None,
+    customOutputBodyType = None,
     attributes = List.empty)
 
   val MULTIGET_HANDLER = Handler(
@@ -92,8 +92,8 @@ object DefaultGraphqlSchemaProviderTest extends MockitoSugar {
     name = "multiGet",
     parameters =
       List(Parameter(name = "ids", `type` = "List[int]", attributes = List.empty, default = None)),
-    inputBody = None,
-    customOutputBody = None,
+    inputBodyType = None,
+    customOutputBodyType = None,
     attributes = List.empty)
 
   val COURSES_RESOURCE_ID = ResourceName("courses", 1)

--- a/naptime-testing/src/test/scala/org/coursera/naptime/CustomRequestResponseMacroTests.scala
+++ b/naptime-testing/src/test/scala/org/coursera/naptime/CustomRequestResponseMacroTests.scala
@@ -101,28 +101,28 @@ class CustomRequestResponseMacroTests
   @Test
   def updateTypes(): Unit = {
     val handler = schema.handlers.find(_.name === "update").get
-    assert(handler.inputBody.contains("org.coursera.naptime.CustomRequest"))
-    assert(handler.customOutputBody.isEmpty)
+    assert(handler.inputBodyType.contains("org.coursera.naptime.CustomRequest"))
+    assert(handler.customOutputBodyType.isEmpty)
   }
   @Test
   def createTest(): Unit = {
     val handler = schema.handlers.find(_.name === "create").get
-    assert(handler.inputBody.contains("org.coursera.naptime.CustomRequest"))
-    assert(handler.customOutputBody.isEmpty)
+    assert(handler.inputBodyType.contains("org.coursera.naptime.CustomRequest"))
+    assert(handler.customOutputBodyType.isEmpty)
   }
 
   @Test
   def actionTest(): Unit = {
     val handler = schema.handlers.find(_.name === "action").get
-    assert(handler.inputBody.contains("org.coursera.naptime.CustomRequest"))
-    assert(handler.customOutputBody.contains("org.coursera.naptime.CustomResponse"))
+    assert(handler.inputBodyType.contains("org.coursera.naptime.CustomRequest"))
+    assert(handler.customOutputBodyType.contains("org.coursera.naptime.CustomResponse"))
   }
 
   @Test
   def deleteTest(): Unit = {
     val handler = schema.handlers.find(_.name === "delete").get
-    assert(handler.inputBody.contains("org.coursera.naptime.CustomRequest"))
-    assert(handler.customOutputBody.isEmpty)
+    assert(handler.inputBodyType.contains("org.coursera.naptime.CustomRequest"))
+    assert(handler.customOutputBodyType.isEmpty)
   }
 
 }

--- a/naptime-testing/src/test/scala/org/coursera/naptime/NestedMacroTests.scala
+++ b/naptime-testing/src/test/scala/org/coursera/naptime/NestedMacroTests.scala
@@ -654,8 +654,8 @@ class NestedMacroTests extends AssertionsForJUnit with MockitoSugar with Resourc
         Set("parameterless", "batchModify"))
     assert(schema.handlers.count(_.kind == HandlerKind.MULTI_GET) === 1)
     val multiGetSchema = schema.handlers.find(_.kind == HandlerKind.MULTI_GET).get
-    assert(multiGetSchema.customOutputBody === None)
-    assert(multiGetSchema.inputBody === None)
+    assert(multiGetSchema.customOutputBodyType === None)
+    assert(multiGetSchema.inputBodyType === None)
     assert(multiGetSchema.parameters.length === 1)
     val multiGetSetParameter = multiGetSchema.parameters.head
     assert(multiGetSetParameter.name === "ids")

--- a/naptime-testing/src/test/scala/org/coursera/naptime/NonNestedMacroTests.scala
+++ b/naptime-testing/src/test/scala/org/coursera/naptime/NonNestedMacroTests.scala
@@ -174,8 +174,8 @@ class NonNestedMacroTests extends AssertionsForJUnit with MockitoSugar with Reso
 
   private[this] def noCustomInputOutputAuthTypes(methodName: String): Unit = {
     val handler = Resource.routerBuilder.schema.handlers.find(_.name === methodName).get
-    assert(handler.inputBody.isEmpty)
-    assert(handler.customOutputBody.isEmpty)
+    assert(handler.inputBodyType.isEmpty)
+    assert(handler.customOutputBodyType.isEmpty)
     assert(handler.authType.isEmpty)
   }
 

--- a/naptime/src/main/pegasus/org/coursera/naptime/schema/Handler.courier
+++ b/naptime/src/main/pegasus/org/coursera/naptime/schema/Handler.courier
@@ -23,13 +23,13 @@ record Handler {
   /**
    * If the handler consumes a request body, the type is specified here.
    */
-  inputBody: TypeName?
+  inputBodyType: TypeName?
 
   /**
    * If the handler produces a custom response body that is not the expected based on the Resource,
    * the type is specified here.
    */
-  customOutputBody: TypeName?
+  customOutputBodyType: TypeName?
 
   /**
    * If the handler includes an authorization context, the type is specified here.

--- a/naptime/src/main/scala/org/coursera/naptime/access/HeaderAccessControl.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/access/HeaderAccessControl.scala
@@ -67,7 +67,8 @@ object HeaderAccessControl extends AnyOf with And with EitherOf with SuccessfulO
   import scala.language.implicitConversions
   implicit def accessControlGenerator[BodyType, T](
       accessControl: HeaderAccessControl[T]): (BodyType => HeaderAccessControl[T]) = {
-    (b: BodyType) => accessControl
+    (b: BodyType) =>
+      accessControl
   }
 
 }

--- a/naptime/src/main/scala/org/coursera/naptime/router2/MacroImpls.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/router2/MacroImpls.scala
@@ -469,7 +469,7 @@ class MacroImpls(val c: blackbox.Context) {
       // undefined. Rather then reporting these types in the inputBody and customOutputBody
       // fields of our schema, we filter them and report `None`.
       val vagueTypes = List("Unit", "play.api.mvc.AnyContent", "Any")
-      val inputBody = category match {
+      val inputBodyType = category match {
         case CreateRestActionCategory | UpdateRestActionCategory | ActionRestActionCategory |
             DeleteRestActionCategory =>
           q"""
@@ -479,7 +479,7 @@ class MacroImpls(val c: blackbox.Context) {
         case _ => q"None"
       }
 
-      val customOutputBody = category match {
+      val customOutputBodyType = category match {
         case ActionRestActionCategory =>
           q"""
            val paramName = ${method.returnType.typeArgs(5).toString}
@@ -501,8 +501,8 @@ class MacroImpls(val c: blackbox.Context) {
         parameters = List(..$parameterTrees),
         attributes = org.coursera.naptime.router2.AttributesProvider
             .getMethodAttributes(resourceClass.getName, ${method.name.toString}),
-        inputBody = $inputBody,
-        customOutputBody = $customOutputBody,
+        inputBodyType = $inputBodyType,
+        customOutputBodyType = $customOutputBodyType,
         authType = $authType)
       """
     }

--- a/naptime/src/test/scala/org/coursera/naptime/router2/NaptimePlayRouterTest.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/router2/NaptimePlayRouterTest.scala
@@ -57,8 +57,8 @@ class NaptimePlayRouterTest extends AssertionsForJUnit with MockitoSugar {
         name = "get",
         parameters =
           List(Parameter(name = "id", `type` = "String", attributes = List.empty, default = None)),
-        inputBody = None,
-        customOutputBody = None,
+        inputBodyType = None,
+        customOutputBodyType = None,
         attributes = List.empty)),
     className = "org.coursera.naptime.FakeResource",
     attributes = List.empty)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.9.2-alpha12"
+version in ThisBuild := "0.9.2-alpha13"


### PR DESCRIPTION
A [previous PR](https://github.com/coursera/naptime/commit/b3bd4b8a38c0106df6a833f38204c0e52284063a#diff-330091af95c9f8acd5f10a962600b245R26) simplified the representation of two unused schema fields. In spite of the fact these fields were unused, changing the representation of their underlying data type (from a union record to a simple string), was a backward-incompatible change to the model's transport format, and caused issues when deployed. 

This revision renames these fields to make object serialization backward-compatible. Legacy receivers will receive empty data for legacy field names, but since legacy receivers aren't using this data in the first place, that shouldn't cause any issues. 