### PR TITLE
Materialize model during JSON deserialization

### DIFF
--- a/naptime-models/src/main/scala/org/coursera/naptime/courier/CourierFormats.scala
+++ b/naptime-models/src/main/scala/org/coursera/naptime/courier/CourierFormats.scala
@@ -53,12 +53,8 @@ import com.typesafe.scalalogging.StrictLogging
 import org.coursera.common.stringkey.StringKey
 import org.coursera.common.stringkey.StringKeyFormat
 import org.coursera.courier.templates.DataValidationException
-import org.coursera.courier.templates.ScalaArrayTemplate
 import org.coursera.courier.templates.ScalaEnumTemplate
 import org.coursera.courier.templates.ScalaEnumTemplateSymbol
-import org.coursera.courier.templates.ScalaRecordTemplate
-import org.coursera.courier.templates.ScalaTemplate
-import org.coursera.courier.templates.ScalaUnionTemplate
 import org.coursera.naptime.courier.CourierUtils._
 import org.coursera.naptime.courier.Exceptions._
 import play.api.libs.json.JsonValidationError

--- a/naptime-models/src/test/pegasus/org/coursera/naptime/courier/TestPositiveIntMoreComplex.courier
+++ b/naptime-models/src/test/pegasus/org/coursera/naptime/courier/TestPositiveIntMoreComplex.courier
@@ -1,0 +1,8 @@
+namespace org.coursera.naptime.courier
+
+import org.coursera.naptime.courier.TestPositiveIntPair
+
+record TestPositiveIntMoreComplex {
+  mapField: map[TestPositiveIntPair, map[TestPositiveIntPair, TestPositiveIntPair]]
+  unionField: union[TestPositiveIntPair]
+}

--- a/naptime-models/src/test/pegasus/org/coursera/naptime/courier/TestPositiveIntPairMapRecord.courier
+++ b/naptime-models/src/test/pegasus/org/coursera/naptime/courier/TestPositiveIntPairMapRecord.courier
@@ -1,0 +1,5 @@
+namespace org.coursera.naptime.courier
+
+record TestPositiveIntPairMapRecord {
+  mapField: map[TestPositiveIntPair, map[TestPositiveIntPair, TestPositiveIntPair]]
+}

--- a/naptime-models/src/test/pegasus/org/coursera/naptime/courier/TestPositiveIntPairUnion.courier
+++ b/naptime-models/src/test/pegasus/org/coursera/naptime/courier/TestPositiveIntPairUnion.courier
@@ -1,0 +1,3 @@
+namespace org.coursera.naptime.courier
+
+typeref TestPositiveIntPairUnion = union[TestPositiveIntPair, TestPositiveInt]


### PR DESCRIPTION
Previously, deserializing JSON to a courier model resulted in a model that would have lazily initialized fields. This means that if one of the fields was a custom Scala class with custom validation logic in the constructor or coercer, that validation logic would be ignored during deserialization time. Instead, it would run the first time the field was accessed, leading to exceptions thrown at unexpected places. This change forces materialization of the entire model during JSON deserialization time, and causes JSON deserialization to fail if an exception is thrown by the Scala constructor or coercer.