### PR TITLE
Don't throw exception if materialization fails during JSON deserialization

### DIFF
--- a/naptime-models/src/main/scala/org/coursera/naptime/courier/CourierFormats.scala
+++ b/naptime-models/src/main/scala/org/coursera/naptime/courier/CourierFormats.scala
@@ -50,6 +50,7 @@ import com.linkedin.data.template.RecordTemplate
 import com.linkedin.data.template.TemplateOutputCastException
 import com.linkedin.data.template.UnionTemplate
 import com.typesafe.scalalogging.StrictLogging
+import org.apache.commons.lang3.exception.ExceptionUtils
 import org.coursera.common.stringkey.StringKey
 import org.coursera.common.stringkey.StringKeyFormat
 import org.coursera.courier.templates.DataValidationException
@@ -117,7 +118,13 @@ object CourierFormats extends StrictLogging {
                 case Left(validationResult) =>
                   toJsError(validationResult.getMessages.asScala.toSeq)
                 case Right(template) =>
-                  materialize(template)
+                  try {
+                    materialize(template)
+                  } catch {
+                    case e: TemplateOutputCastException =>
+                      logger.warn(
+                        s"Could not materialize ${clazz.getName}: ${ExceptionUtils.getStackTrace(e)}")
+                  }
                   JsSuccess(template)
               }
             } catch {
@@ -158,7 +165,13 @@ object CourierFormats extends StrictLogging {
                 case Left(validationResult) =>
                   toJsError(validationResult.getMessages.asScala.toSeq)
                 case Right(template) =>
-                  materialize(template)
+                  try {
+                    materialize(template)
+                  } catch {
+                    case castException: TemplateOutputCastException =>
+                      logger.warn(
+                        s"Could not materialize ${clazz.getName}: ${ExceptionUtils.getStackTrace(castException)}")
+                  }
                   JsSuccess(template)
               }
             } catch {
@@ -798,6 +811,7 @@ object CourierFormats extends StrictLogging {
   /**
    * Recursively force materialization of lazy vals that are typerefs by materializing the entire tree recursively.
    * This forces any validation logic in the typeref's custom Scala constructor or coercer to run.
+   * Throw TemplateOutputCastException if the materialization failed.
    */
   private[this] def materialize(template: DataTemplate[_]): Unit = {
     try {
@@ -817,10 +831,12 @@ object CourierFormats extends StrictLogging {
         case _: Any =>
       }
     } catch {
-      case e: TemplateOutputCastException =>
-        throw e
-      case e: Exception =>
-        throw new TemplateOutputCastException(s"${e.getClass.getSimpleName}: ${e.getMessage}", e)
+      case castException: TemplateOutputCastException =>
+        throw castException
+      case exception: Exception =>
+        throw new TemplateOutputCastException(
+          s"${exception.getClass.getSimpleName}: ${exception.getMessage}",
+          exception)
     }
   }
 

--- a/naptime-models/src/main/scala/org/coursera/naptime/courier/CourierFormats.scala
+++ b/naptime-models/src/main/scala/org/coursera/naptime/courier/CourierFormats.scala
@@ -811,7 +811,7 @@ object CourierFormats extends StrictLogging {
   /**
    * Recursively force materialization of lazy vals that are typerefs by materializing the entire tree recursively.
    * This forces any validation logic in the typeref's custom Scala constructor or coercer to run.
-   * Throw TemplateOutputCastException if the materialization failed.
+   * Throw [[TemplateOutputCastException]] if the materialization failed.
    */
   private[this] def materialize(template: DataTemplate[_]): Unit = {
     try {

--- a/naptime-models/src/test/scala/org/coursera/naptime/courier/CourierFormatsTest.scala
+++ b/naptime-models/src/test/scala/org/coursera/naptime/courier/CourierFormatsTest.scala
@@ -305,33 +305,43 @@ class CourierFormatsTest extends AssertionsForJUnit {
 
     val badRecordString =
       """{ "pair": { "first": -1, "second": 2 }, "elements": [ { "first": 3, "second": 4 } ] }"""
-    assertResult(
-      JsError("Pegasus template cast error: IllegalArgumentException: -1 is not positive"))(
-      Json.parse(badRecordString).validate[TestPositiveIntComplex])
+    assert(
+      Json
+        .parse(badRecordString)
+        .validate[TestPositiveIntComplex]
+        .isInstanceOf[JsSuccess[TestPositiveIntComplex]])
 
     val badArrayString =
       """{ "pair": { "first": 1, "second": 2 }, "elements": [ { "first": -3, "second": 4 } ] }"""
-    assertResult(
-      JsError("Pegasus template cast error: IllegalArgumentException: -3 is not positive"))(
-      Json.parse(badArrayString).validate[TestPositiveIntComplex])
+    assert(
+      Json
+        .parse(badArrayString)
+        .validate[TestPositiveIntComplex]
+        .isInstanceOf[JsSuccess[TestPositiveIntComplex]])
 
     val badStringMapKey =
       """{ "mapField": { "(first~1,second~2)": { "(first~-3,second~4)": { "first": 5, "second": 6 } } } }"""
-    assertResult(
-      JsError("Pegasus template cast error: IllegalArgumentException: -3 is not positive"))(
-      Json.parse(badStringMapKey).validate[TestPositiveIntPairMapRecord])
+    assert(
+      Json
+        .parse(badStringMapKey)
+        .validate[TestPositiveIntPairMapRecord]
+        .isInstanceOf[JsSuccess[TestPositiveIntPairMapRecord]])
 
     val badStringMapValue =
       """{ "mapField": { "(first~1,second~2)": { "(first~3,second~4)": { "first": -5, "second": 6 } } } }"""
-    assertResult(
-      JsError("Pegasus template cast error: IllegalArgumentException: -5 is not positive"))(
-      Json.parse(badStringMapValue).validate[TestPositiveIntPairMapRecord])
+    assert(
+      Json
+        .parse(badStringMapValue)
+        .validate[TestPositiveIntPairMapRecord]
+        .isInstanceOf[JsSuccess[TestPositiveIntPairMapRecord]])
 
     val badUnionString =
       """{ "org.coursera.naptime.courier.TestPositiveIntPair": { "first": -1, "second": 2 } }"""
-    assertResult(
-      JsError("Pegasus template cast error: IllegalArgumentException: -1 is not positive"))(
-      Json.parse(badUnionString).validate[TestPositiveIntPairUnion])
+    assert(
+      Json
+        .parse(badUnionString)
+        .validate[TestPositiveIntPairUnion]
+        .isInstanceOf[JsSuccess[TestPositiveIntPairUnion]])
   }
 
   @Test


### PR DESCRIPTION
Log a warning instead of throwing an exception if materialization fails during JSON deserialization. Throwing an exception is a breaking change that might change application behavior e.g. causing applications to eagerly fail if they were working with partially instantiated but invalid models previously. We plan to log warnings in this version and throw exceptions in the next version, so that developers have one version to fix their applications.