### PR TITLE
Allow public access to typeref union CourierFormats methods

### DIFF
--- a/naptime-models/src/main/scala/org/coursera/naptime/courier/CourierFormats.scala
+++ b/naptime-models/src/main/scala/org/coursera/naptime/courier/CourierFormats.scala
@@ -404,6 +404,13 @@ object CourierFormats extends StrictLogging {
     }
   }
 
+  def typerefUnionToJsObject(
+      typerefSchema: TyperefDataSchema,
+      dataMap: DataMap,
+      unionSchema: UnionDataSchema): JsObject = {
+    typerefUnionToJsObject(emptyPath, typerefSchema, dataMap, unionSchema)
+  }
+
   private[this] def typerefUnionToJsObject(
       schemaPath: SchemaPath,
       typerefSchema: TyperefDataSchema,
@@ -608,11 +615,18 @@ object CourierFormats extends StrictLogging {
     }
   }
 
+  def jsObjectToTyperefUnion(
+      typerefSchema: TyperefDataSchema,
+      jsObject: JsObject,
+      unionSchema: UnionDataSchema): DataMap = {
+    jsObjectToTyperefUnion(emptyPath, typerefSchema, jsObject, unionSchema)
+  }
+
   private[this] def jsObjectToTyperefUnion(
       schemaPath: SchemaPath,
       typerefSchema: TyperefDataSchema,
       jsObject: JsObject,
-      unionSchema: UnionDataSchema): AnyRef = {
+      unionSchema: UnionDataSchema): DataMap = {
     getTypedDefinition(typerefSchema) match {
       case None =>
         jsObjectToUnion(schemaPath, jsObject, unionSchema)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.9.2-alpha15"
+version in ThisBuild := "0.9.2-alpha16"


### PR DESCRIPTION
- also normalize `jsObjectToTypeRefUnion` to be more specific by returning a DataMap instead of AnyRef