### PR TITLE
wrap thrown NaptimeActionExceptions in errorHandler and log RestError…

### DIFF
--- a/naptime/src/main/scala/org/coursera/naptime/actions/RestAction.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/actions/RestAction.scala
@@ -91,10 +91,10 @@ trait RestAction[RACType, AuthType, BodyType, KeyType, ResourceType, ResponseTyp
       .recover(errorHandler)
       .recover {
         case e: NaptimeActionException =>
-          // Wrap thrown NaptimeActionExceptions in errorHandler
-          //
-          // It is quite a common pattern to throw a NaptimeActionException instead of returning RestError(new NaptimeActionException()).
-          // Wrapping the thrown exception consolidates the codepaths for handling NaptimeActionExceptions.
+          // Chain this recover because it is quite a common pattern to throw a NaptimeActionException in the
+          // errorHandler instead of returning RestError. This recover should wrap those thrown
+          // NaptimeActionExceptions into RestErrors. This consolidates the code paths for handling
+          // NaptimeActionExceptions.
           RestError(e)
       }
   }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.9.2-alpha22"
+version in ThisBuild := "0.9.2-alpha23"


### PR DESCRIPTION
…s with code >=500

This also refactors `safeApply` to be more readable