### PR TITLE
Throw exceptions on failures during JSON deserialization

### DIFF
--- a/naptime-models/src/main/scala/org/coursera/naptime/courier/CourierFormats.scala
+++ b/naptime-models/src/main/scala/org/coursera/naptime/courier/CourierFormats.scala
@@ -50,7 +50,6 @@ import com.linkedin.data.template.RecordTemplate
 import com.linkedin.data.template.TemplateOutputCastException
 import com.linkedin.data.template.UnionTemplate
 import com.typesafe.scalalogging.StrictLogging
-import org.apache.commons.lang3.exception.ExceptionUtils
 import org.coursera.common.stringkey.StringKey
 import org.coursera.common.stringkey.StringKeyFormat
 import org.coursera.courier.templates.DataValidationException
@@ -118,13 +117,7 @@ object CourierFormats extends StrictLogging {
                 case Left(validationResult) =>
                   toJsError(validationResult.getMessages.asScala.toSeq)
                 case Right(template) =>
-                  try {
-                    materialize(template)
-                  } catch {
-                    case e: TemplateOutputCastException =>
-                      logger.warn(
-                        s"Could not materialize ${clazz.getName}: ${ExceptionUtils.getStackTrace(e)}")
-                  }
+                  materialize(template)
                   JsSuccess(template)
               }
             } catch {
@@ -165,13 +158,7 @@ object CourierFormats extends StrictLogging {
                 case Left(validationResult) =>
                   toJsError(validationResult.getMessages.asScala.toSeq)
                 case Right(template) =>
-                  try {
-                    materialize(template)
-                  } catch {
-                    case castException: TemplateOutputCastException =>
-                      logger.warn(
-                        s"Could not materialize ${clazz.getName}: ${ExceptionUtils.getStackTrace(castException)}")
-                  }
+                  materialize(template)
                   JsSuccess(template)
               }
             } catch {
@@ -853,12 +840,10 @@ object CourierFormats extends StrictLogging {
         case _: Any =>
       }
     } catch {
-      case castException: TemplateOutputCastException =>
-        throw castException
-      case exception: Exception =>
-        throw new TemplateOutputCastException(
-          s"${exception.getClass.getSimpleName}: ${exception.getMessage}",
-          exception)
+      case e: TemplateOutputCastException =>
+        throw e
+      case e: Exception =>
+        throw new TemplateOutputCastException(s"${e.getClass.getSimpleName}: ${e.getMessage}", e)
     }
   }
 

--- a/naptime-models/src/test/scala/org/coursera/naptime/courier/CourierFormatsTest.scala
+++ b/naptime-models/src/test/scala/org/coursera/naptime/courier/CourierFormatsTest.scala
@@ -305,43 +305,33 @@ class CourierFormatsTest extends AssertionsForJUnit {
 
     val badRecordString =
       """{ "pair": { "first": -1, "second": 2 }, "elements": [ { "first": 3, "second": 4 } ] }"""
-    assert(
-      Json
-        .parse(badRecordString)
-        .validate[TestPositiveIntComplex]
-        .isInstanceOf[JsSuccess[TestPositiveIntComplex]])
+    assertResult(
+      JsError("Pegasus template cast error: IllegalArgumentException: -1 is not positive"))(
+      Json.parse(badRecordString).validate[TestPositiveIntComplex])
 
     val badArrayString =
       """{ "pair": { "first": 1, "second": 2 }, "elements": [ { "first": -3, "second": 4 } ] }"""
-    assert(
-      Json
-        .parse(badArrayString)
-        .validate[TestPositiveIntComplex]
-        .isInstanceOf[JsSuccess[TestPositiveIntComplex]])
+    assertResult(
+      JsError("Pegasus template cast error: IllegalArgumentException: -3 is not positive"))(
+      Json.parse(badArrayString).validate[TestPositiveIntComplex])
 
     val badStringMapKey =
       """{ "mapField": { "(first~1,second~2)": { "(first~-3,second~4)": { "first": 5, "second": 6 } } } }"""
-    assert(
-      Json
-        .parse(badStringMapKey)
-        .validate[TestPositiveIntPairMapRecord]
-        .isInstanceOf[JsSuccess[TestPositiveIntPairMapRecord]])
+    assertResult(
+      JsError("Pegasus template cast error: IllegalArgumentException: -3 is not positive"))(
+      Json.parse(badStringMapKey).validate[TestPositiveIntPairMapRecord])
 
     val badStringMapValue =
       """{ "mapField": { "(first~1,second~2)": { "(first~3,second~4)": { "first": -5, "second": 6 } } } }"""
-    assert(
-      Json
-        .parse(badStringMapValue)
-        .validate[TestPositiveIntPairMapRecord]
-        .isInstanceOf[JsSuccess[TestPositiveIntPairMapRecord]])
+    assertResult(
+      JsError("Pegasus template cast error: IllegalArgumentException: -5 is not positive"))(
+      Json.parse(badStringMapValue).validate[TestPositiveIntPairMapRecord])
 
     val badUnionString =
       """{ "org.coursera.naptime.courier.TestPositiveIntPair": { "first": -1, "second": 2 } }"""
-    assert(
-      Json
-        .parse(badUnionString)
-        .validate[TestPositiveIntPairUnion]
-        .isInstanceOf[JsSuccess[TestPositiveIntPairUnion]])
+    assertResult(
+      JsError("Pegasus template cast error: IllegalArgumentException: -1 is not positive"))(
+      Json.parse(badUnionString).validate[TestPositiveIntPairUnion])
   }
 
   @Test

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.9.2-alpha25"
+version in ThisBuild := "0.9.2-alpha26"


### PR DESCRIPTION
This reverts commit 8ee25943f23fb3606ceeb4486763545cf4598e07.

We want to roll this out as it's the safer default. We've had the warnings run in production for a while so we know what can break with these changes. Based on recent discussions, we believe the benefits outweigh the known breakage.

Privately tracked: https://coursera.atlassian.net/browse/DRAG-91 cc @firejade