### PR TITLE
Upgrade Sangria to 1.4.2 and slowlog to 0.1.8, add opentracing hook

### DIFF
--- a/naptime-graphql/build.sbt
+++ b/naptime-graphql/build.sbt
@@ -9,7 +9,8 @@ libraryDependencies ++= Seq(
   junit,
   junitInterface,
   scalatest,
-  mockito
+  mockito,
+  opentracing
 )
 
 org.coursera.courier.sbt.CourierPlugin.courierSettings

--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/TracerWrapper.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/TracerWrapper.scala
@@ -1,0 +1,9 @@
+package org.coursera.naptime.ari.graphql
+
+import io.opentracing.Tracer
+
+/**
+ * Wraps an optional opentracing.Tracer, which if provided, will be used to trace
+ * GraphQL query executions using sangria-slowlog.
+ */
+case class TracerWrapper(tracer: Option[Tracer])

--- a/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/helpers/ArgumentBuilder.scala
+++ b/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/helpers/ArgumentBuilder.scala
@@ -2,8 +2,7 @@ package org.coursera.naptime.ari.graphql.helpers
 
 import sangria.schema.Args
 import sangria.schema.Argument
-
-import scala.collection.concurrent.TrieMap
+import sangria.util.Cache
 
 object ArgumentBuilder {
   def buildArgs(argumentDefinitions: List[Argument[_]], argumentInputs: Map[String, Any]): Args = {
@@ -19,8 +18,7 @@ object ArgumentBuilder {
       case definition if argsWithDefault.contains(definition.name) =>
         definition.name -> definition.defaultValue.get._1
     }
-    val defaultMap = TrieMap() ++= defaultInfo
-
+    val defaultMap = Cache(defaultInfo: _*)
     Args(argumentInputs, argsWithDefault, optionalArgs, undefinedArgs, defaultMap)
   }
 }

--- a/project/NamedDependencies.scala
+++ b/project/NamedDependencies.scala
@@ -34,10 +34,11 @@ trait NamedDependencies { this: PluginVersionProvider =>
   val playJson = "com.typesafe.play" %% "play-json" % playJsonVersion
   val playTestCompile = ("com.typesafe.play" %% "play-test" % playVersion)
     .excludeAll(new ExclusionRule(organization="org.specs2"))
-  val sangria = "org.sangria-graphql" %% "sangria" % "1.4.0"
-  val sangriaSlowLog = "org.sangria-graphql" %% "sangria-slowlog" % "0.1.5"
+  val sangria = "org.sangria-graphql" %% "sangria" % "1.4.2"
+  val sangriaSlowLog = "org.sangria-graphql" %% "sangria-slowlog" % "0.1.8"
   val scalaGuice = "net.codingwell" %% "scala-guice" % "4.1.1"
   val scalaLogging = "com.typesafe.scala-logging" %% "scala-logging" % "3.7.2"
+  val opentracing = "io.opentracing" % "opentracing-api" % "0.32.0"
 
   // Test dependencies
   val junitCompile = "junit" % "junit" % "4.11"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.9.2-alpha26"
+version in ThisBuild := "0.9.2-alpha27"


### PR DESCRIPTION
Opentracing integration to slowlog only came with 0.1.7 which only works with Sangria 1.4.1 and greater.

I looked at the changelog (https://github.com/sangria-graphql/sangria/blob/master/CHANGELOG.md#v141-2018-05-12) and everything looks backwards compatible. There is this note: `breaking change. All additional error object fields that were provided via HandledException are now added to the extensions field` but we don't use the other `errors` fields on the client (we do use the `.message` field, which is unchanged), so this is a good thing as well as it gets us closer to graphql spec compliance. 

The integration point is a wrapper class, `TracerWrapper`, that allows the resource (assembler) to optionally provide this class as a module. 