### PR TITLE
Make middlewares injectable and remove hard coded opentracing integration

### DIFF
--- a/naptime-graphql/build.sbt
+++ b/naptime-graphql/build.sbt
@@ -9,8 +9,7 @@ libraryDependencies ++= Seq(
   junit,
   junitInterface,
   scalatest,
-  mockito,
-  opentracing
+  mockito
 )
 
 org.coursera.courier.sbt.CourierPlugin.courierSettings

--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/TracerWrapper.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/TracerWrapper.scala
@@ -1,9 +1,0 @@
-package org.coursera.naptime.ari.graphql
-
-import io.opentracing.Tracer
-
-/**
- * Wraps an optional opentracing.Tracer, which if provided, will be used to trace
- * GraphQL query executions using sangria-slowlog.
- */
-case class TracerWrapper(tracer: Option[Tracer])

--- a/project/NamedDependencies.scala
+++ b/project/NamedDependencies.scala
@@ -38,7 +38,6 @@ trait NamedDependencies { this: PluginVersionProvider =>
   val sangriaSlowLog = "org.sangria-graphql" %% "sangria-slowlog" % "0.1.8"
   val scalaGuice = "net.codingwell" %% "scala-guice" % "4.1.1"
   val scalaLogging = "com.typesafe.scala-logging" %% "scala-logging" % "3.7.2"
-  val opentracing = "io.opentracing" % "opentracing-api" % "0.32.0"
 
   // Test dependencies
   val junitCompile = "junit" % "junit" % "4.11"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.9.2-alpha27"
+version in ThisBuild := "0.9.2-alpha28"


### PR DESCRIPTION
To support something like https://phabricator.dkandu.me/D88490 for assembler, we need to be able to inject middlewares. This change makes that behavior possible, and gets rid of the hard coded opentracing middleware.

PTAL @amory-coursera, @dguo-coursera 