### PR TITLE
Take in middleware factory rather than middleware

### DIFF
--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/controllers/GraphQLController.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/controllers/GraphQLController.scala
@@ -59,7 +59,7 @@ class GraphQLController @Inject()(
     fetcher: FetcherApi,
     filterList: FilterList,
     metricsCollector: GraphQLMetricsCollector,
-    additionalMiddlewares: List[Middleware[Any]])(implicit ec: ExecutionContext)
+    additionalMiddlewareFactories: List[() => Middleware[Any]])(implicit ec: ExecutionContext)
     extends InjectedController
     with StrictLogging {
 
@@ -129,6 +129,7 @@ class GraphQLController @Inject()(
         case Success(queryAst) =>
           val baseFilter: IncomingQuery => Future[OutgoingQuery] = (incoming: IncomingQuery) => {
             val context = SangriaGraphQlContext(fetcher, requestHeader, ec, incoming.debugMode)
+            val additionalMiddlewares = additionalMiddlewareFactories.map(factory => factory.apply)
             Executor
               .execute(
                 graphqlSchemaProvider.schema,

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.9.2-alpha28"
+version in ThisBuild := "0.9.2-alpha29"


### PR DESCRIPTION
PTAL @dguo-coursera, @amory-coursera - I think middlewares should be created per request rather than once on instantiation, as they hold execution state. This along with another change should unbreak the datadog tracing.