### PR TITLE
Upgrade to Play 2.7

### DIFF
--- a/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/controllers/filters/QueryComplexityFilterTest.scala
+++ b/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/controllers/filters/QueryComplexityFilterTest.scala
@@ -1,9 +1,9 @@
 package org.coursera.naptime.ari.graphql.controllers.filters
 
-import org.coursera.naptime.ResourceTestImplicits
+import org.coursera.naptime.ImplicitTestApplication
 import org.junit.Test
 
-class QueryComplexityFilterTest extends FilterTest with ResourceTestImplicits {
+class QueryComplexityFilterTest extends FilterTest with ImplicitTestApplication {
 
   val config = ComplexityFilterConfiguration.DEFAULT
   val filter = new QueryComplexityFilter(graphqlSchemaProvider, config)

--- a/naptime-testing/src/main/resources/application.conf
+++ b/naptime-testing/src/main/resources/application.conf
@@ -1,0 +1,1 @@
+play.http.secret.key="testtesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttest"

--- a/naptime-testing/src/main/scala/org/coursera/naptime/actions/RestActionTester.scala
+++ b/naptime-testing/src/main/scala/org/coursera/naptime/actions/RestActionTester.scala
@@ -16,6 +16,8 @@
 
 package org.coursera.naptime.actions
 
+import java.io.File
+
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.stream.Materializer
@@ -30,6 +32,9 @@ import org.coursera.naptime.RestResponse
 import org.junit.After
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.exceptions.TestFailedException
+import play.api.Application
+import play.api.Mode
+import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.FakeRequest
 
 import scala.concurrent.ExecutionContext
@@ -46,6 +51,7 @@ trait RestActionTester { this: ScalaFutures =>
   implicit protected def actorSystem: ActorSystem = internalActorSystem
   implicit protected def executionContext: ExecutionContext = internalExecutionContext
   implicit protected def materializer: Materializer = internalMaterializer
+  implicit protected val application: Application = RestActionTester.application
 
   @After
   def shutDownActorSystem(): Unit = {
@@ -106,4 +112,13 @@ trait RestActionTester { this: ScalaFutures =>
       }.get
     }
   }
+}
+
+object RestActionTester {
+
+  val application: Application = GuiceApplicationBuilder()
+    .in(new File("."))
+    .in(Mode.Test)
+    .build()
+
 }

--- a/naptime-testing/src/test/resources/application.conf
+++ b/naptime-testing/src/test/resources/application.conf
@@ -1,1 +1,0 @@
-play.allowGlobalApplication = true

--- a/naptime-testing/src/test/resources/application.conf
+++ b/naptime-testing/src/test/resources/application.conf
@@ -1,0 +1,1 @@
+play.allowGlobalApplication = true

--- a/naptime-testing/src/test/scala/org/coursera/naptime/AuthBuilderTest.scala
+++ b/naptime-testing/src/test/scala/org/coursera/naptime/AuthBuilderTest.scala
@@ -102,17 +102,12 @@ object AuthBuilderTest {
     if (thing.name == name) AlwaysAccept else AlwaysReject
   }
 
-  class EngineersResource(
-      implicit ec: ExecutionContext,
-      mat: Materializer,
-      val application: Application)
+  class EngineersResource(implicit val application: Application)
       extends TopLevelCollectionResource[Int, Engineer] {
     override val keyFormat: KeyFormat[Int] = KeyFormat.intKeyFormat
     override val resourceName: String = "tests"
     override val resourceFormat = Json.format[Engineer]
     implicit val fields = Fields
-    override val executionContext = implicitly[ExecutionContext]
-    override val materializer = implicitly[Materializer]
 
     def createNoAuth() =
       Nap

--- a/naptime-testing/src/test/scala/org/coursera/naptime/AuthBuilderTest.scala
+++ b/naptime-testing/src/test/scala/org/coursera/naptime/AuthBuilderTest.scala
@@ -9,6 +9,7 @@ import org.coursera.naptime.resources.TopLevelCollectionResource
 import org.junit.Test
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.junit.AssertionsForJUnit
+import play.api.Application
 import play.api.libs.json.Json
 import play.api.libs.json.OFormat
 import play.api.mvc.RequestHeader
@@ -101,7 +102,10 @@ object AuthBuilderTest {
     if (thing.name == name) AlwaysAccept else AlwaysReject
   }
 
-  class EngineersResource(implicit ec: ExecutionContext, mat: Materializer)
+  class EngineersResource(
+      implicit ec: ExecutionContext,
+      mat: Materializer,
+      val application: Application)
       extends TopLevelCollectionResource[Int, Engineer] {
     override val keyFormat: KeyFormat[Int] = KeyFormat.intKeyFormat
     override val resourceName: String = "tests"

--- a/naptime-testing/src/test/scala/org/coursera/naptime/AuthMacroTest.scala
+++ b/naptime-testing/src/test/scala/org/coursera/naptime/AuthMacroTest.scala
@@ -60,7 +60,7 @@ object AuthorizedResource {
   val routerBuilder = Router.build[AuthorizedResource]
 }
 
-class AuthMacroTest extends AssertionsForJUnit with MockitoSugar with ResourceTestImplicits {
+class AuthMacroTest extends AssertionsForJUnit with MockitoSugar with ImplicitTestApplication {
 
   val schema = AuthorizedResource.routerBuilder.schema
 

--- a/naptime-testing/src/test/scala/org/coursera/naptime/AuthMacroTest.scala
+++ b/naptime-testing/src/test/scala/org/coursera/naptime/AuthMacroTest.scala
@@ -24,6 +24,7 @@ import org.coursera.naptime.router2._
 import org.junit.Test
 import org.scalatest.junit.AssertionsForJUnit
 import org.scalatest.mockito.MockitoSugar
+import play.api.Application
 import play.api.libs.json.OFormat
 import play.api.mvc.RequestHeader
 
@@ -38,7 +39,8 @@ object CustomAuthorizer extends HeaderAccessControl[CustomAuth] {
 
 class AuthorizedResource(
     implicit val executionContext: ExecutionContext,
-    val materializer: Materializer)
+    val materializer: Materializer,
+    val application: Application)
     extends TopLevelCollectionResource[String, Item] {
 
   override def keyFormat: KeyFormat[String] = KeyFormat.stringKeyFormat

--- a/naptime-testing/src/test/scala/org/coursera/naptime/AuthMacroTest.scala
+++ b/naptime-testing/src/test/scala/org/coursera/naptime/AuthMacroTest.scala
@@ -16,7 +16,6 @@
 
 package org.coursera.naptime
 
-import akka.stream.Materializer
 import org.coursera.naptime.access.HeaderAccessControl
 import org.coursera.naptime.model.KeyFormat
 import org.coursera.naptime.resources.TopLevelCollectionResource
@@ -37,10 +36,7 @@ object CustomAuthorizer extends HeaderAccessControl[CustomAuth] {
   override private[naptime] def check(authInfo: CustomAuth) = ???
 }
 
-class AuthorizedResource(
-    implicit val executionContext: ExecutionContext,
-    val materializer: Materializer,
-    val application: Application)
+class AuthorizedResource(implicit val application: Application)
     extends TopLevelCollectionResource[String, Item] {
 
   override def keyFormat: KeyFormat[String] = KeyFormat.stringKeyFormat

--- a/naptime-testing/src/test/scala/org/coursera/naptime/CustomRequestResponseMacroTests.scala
+++ b/naptime-testing/src/test/scala/org/coursera/naptime/CustomRequestResponseMacroTests.scala
@@ -16,7 +16,6 @@
 
 package org.coursera.naptime
 
-import akka.stream.Materializer
 import org.coursera.naptime.model.KeyFormat
 import org.coursera.naptime.resources.TopLevelCollectionResource
 import org.coursera.naptime.router2._
@@ -26,8 +25,6 @@ import org.scalatest.mockito.MockitoSugar
 import play.api.Application
 import play.api.libs.json.Json
 import play.api.libs.json.OFormat
-
-import scala.concurrent.ExecutionContext
 
 case class CustomRequest(request: String)
 
@@ -43,10 +40,7 @@ object CustomResponse {
     Json.format[CustomResponse]
 }
 
-class AsymmetricResource(
-    implicit val executionContext: ExecutionContext,
-    val materializer: Materializer,
-    val application: Application)
+class AsymmetricResource(implicit val application: Application)
     extends TopLevelCollectionResource[String, Item] {
 
   override def keyFormat: KeyFormat[String] = KeyFormat.stringKeyFormat

--- a/naptime-testing/src/test/scala/org/coursera/naptime/CustomRequestResponseMacroTests.scala
+++ b/naptime-testing/src/test/scala/org/coursera/naptime/CustomRequestResponseMacroTests.scala
@@ -90,7 +90,7 @@ object AsymmetricResource {
 class CustomRequestResponseMacroTests
     extends AssertionsForJUnit
     with MockitoSugar
-    with ResourceTestImplicits {
+    with ImplicitTestApplication {
 
   val schema = AsymmetricResource.routerBuilder.schema
 

--- a/naptime-testing/src/test/scala/org/coursera/naptime/CustomRequestResponseMacroTests.scala
+++ b/naptime-testing/src/test/scala/org/coursera/naptime/CustomRequestResponseMacroTests.scala
@@ -23,6 +23,7 @@ import org.coursera.naptime.router2._
 import org.junit.Test
 import org.scalatest.junit.AssertionsForJUnit
 import org.scalatest.mockito.MockitoSugar
+import play.api.Application
 import play.api.libs.json.Json
 import play.api.libs.json.OFormat
 
@@ -44,7 +45,8 @@ object CustomResponse {
 
 class AsymmetricResource(
     implicit val executionContext: ExecutionContext,
-    val materializer: Materializer)
+    val materializer: Materializer,
+    val application: Application)
     extends TopLevelCollectionResource[String, Item] {
 
   override def keyFormat: KeyFormat[String] = KeyFormat.stringKeyFormat

--- a/naptime-testing/src/test/scala/org/coursera/naptime/IdInferenceMacroTests.scala
+++ b/naptime-testing/src/test/scala/org/coursera/naptime/IdInferenceMacroTests.scala
@@ -2,10 +2,9 @@ package org.coursera.naptime
 
 import java.util.UUID
 
-import akka.stream.Materializer
+import org.coursera.common.jsonformat.JsonFormats.Implicits.dateTimeFormat
 import com.linkedin.data.schema.DataSchema
 import com.linkedin.data.schema.RecordDataSchema
-import org.coursera.common.jsonformat.JsonFormats.Implicits.dateTimeFormat
 import org.coursera.common.stringkey.StringKeyFormat
 import org.coursera.naptime.model.KeyFormat
 import org.coursera.naptime.resources.CourierCollectionResource
@@ -19,9 +18,8 @@ import play.api.libs.json.Json
 import play.api.libs.json.OFormat
 import play.api.libs.json.OWrites
 
-import scala.util.Try
 import scala.collection.JavaConverters._
-import scala.concurrent.ExecutionContext
+import scala.util.Try
 
 object IdInferenceMacroTests {
   sealed trait CourseId
@@ -36,10 +34,7 @@ object IdInferenceMacroTests {
   case class LegacyCourseId(id: Int) extends CourseId
   case class NewCourseId(id: String) extends CourseId
 
-  class CourseResource(
-      implicit override val executionContext: ExecutionContext,
-      override val materializer: Materializer,
-      val application: Application)
+  class CourseResource(implicit override val application: Application)
       extends CourierCollectionResource[CourseId, Course] {
     override def resourceName: String = "courses"
     def getAll = Nap.getAll(ctx => ???)
@@ -84,10 +79,7 @@ object IdInferenceMacroTests {
     implicit val jsonFormat = Json.format[Membership]
   }
 
-  class MembershipResource(
-      implicit val executionContext: ExecutionContext,
-      val materializer: Materializer,
-      val application: Application)
+  class MembershipResource(implicit val application: Application)
       extends TopLevelCollectionResource[MembershipId, Membership] {
     override def keyFormat: KeyFormat[KeyType] = MembershipId.keyFormat
     override implicit def resourceFormat: OFormat[Membership] = Membership.jsonFormat
@@ -107,10 +99,7 @@ object IdInferenceMacroTests {
     implicit val keyFormat: KeyFormat[PaymentId] = KeyFormat.idAsPrimitive(apply, unapply)
   }
 
-  class PaymentResource(
-      implicit val executionContext: ExecutionContext,
-      val materializer: Materializer,
-      val application: Application)
+  class PaymentResource(implicit val application: Application)
       extends TopLevelCollectionResource[PaymentId, Membership] {
     override def keyFormat: KeyFormat[KeyType] = PaymentId.keyFormat
     override implicit def resourceFormat: OFormat[Membership] = Membership.jsonFormat

--- a/naptime-testing/src/test/scala/org/coursera/naptime/IdInferenceMacroTests.scala
+++ b/naptime-testing/src/test/scala/org/coursera/naptime/IdInferenceMacroTests.scala
@@ -14,6 +14,7 @@ import org.coursera.naptime.router2.Router
 import org.joda.time.DateTime
 import org.junit.Test
 import org.scalatest.junit.AssertionsForJUnit
+import play.api.Application
 import play.api.libs.json.Json
 import play.api.libs.json.OFormat
 import play.api.libs.json.OWrites
@@ -37,7 +38,8 @@ object IdInferenceMacroTests {
 
   class CourseResource(
       implicit override val executionContext: ExecutionContext,
-      override val materializer: Materializer)
+      override val materializer: Materializer,
+      val application: Application)
       extends CourierCollectionResource[CourseId, Course] {
     override def resourceName: String = "courses"
     def getAll = Nap.getAll(ctx => ???)
@@ -84,7 +86,8 @@ object IdInferenceMacroTests {
 
   class MembershipResource(
       implicit val executionContext: ExecutionContext,
-      val materializer: Materializer)
+      val materializer: Materializer,
+      val application: Application)
       extends TopLevelCollectionResource[MembershipId, Membership] {
     override def keyFormat: KeyFormat[KeyType] = MembershipId.keyFormat
     override implicit def resourceFormat: OFormat[Membership] = Membership.jsonFormat
@@ -106,7 +109,8 @@ object IdInferenceMacroTests {
 
   class PaymentResource(
       implicit val executionContext: ExecutionContext,
-      val materializer: Materializer)
+      val materializer: Materializer,
+      val application: Application)
       extends TopLevelCollectionResource[PaymentId, Membership] {
     override def keyFormat: KeyFormat[KeyType] = PaymentId.keyFormat
     override implicit def resourceFormat: OFormat[Membership] = Membership.jsonFormat
@@ -120,7 +124,7 @@ object IdInferenceMacroTests {
   }
 }
 
-class IdInferenceMacroTests extends AssertionsForJUnit {
+class IdInferenceMacroTests extends AssertionsForJUnit with ResourceTestImplicits {
 
   @Test
   def coursesTypesGeneration(): Unit = {

--- a/naptime-testing/src/test/scala/org/coursera/naptime/IdInferenceMacroTests.scala
+++ b/naptime-testing/src/test/scala/org/coursera/naptime/IdInferenceMacroTests.scala
@@ -113,7 +113,7 @@ object IdInferenceMacroTests {
   }
 }
 
-class IdInferenceMacroTests extends AssertionsForJUnit with ResourceTestImplicits {
+class IdInferenceMacroTests extends AssertionsForJUnit with ImplicitTestApplication {
 
   @Test
   def coursesTypesGeneration(): Unit = {

--- a/naptime-testing/src/test/scala/org/coursera/naptime/NaptimeModuleTest.scala
+++ b/naptime-testing/src/test/scala/org/coursera/naptime/NaptimeModuleTest.scala
@@ -1,8 +1,8 @@
 package org.coursera.naptime
 
 import java.util.Date
-import javax.inject.Inject
 
+import javax.inject.Inject
 import akka.stream.Materializer
 import com.google.inject.Guice
 import com.google.inject.Stage
@@ -16,6 +16,7 @@ import org.coursera.naptime.router2.NaptimeRoutes
 import org.junit.Test
 import org.mockito.Mockito.mock
 import org.scalatest.junit.AssertionsForJUnit
+import play.api.Application
 import play.api.libs.json.Json
 import play.api.libs.json.OFormat
 
@@ -26,7 +27,10 @@ object NaptimeModuleTest {
   object User {
     implicit val oFormat: OFormat[User] = Json.format[User]
   }
-  class MyResource(implicit val executionContext: ExecutionContext, val materializer: Materializer)
+  class MyResource(
+      implicit val executionContext: ExecutionContext,
+      val materializer: Materializer,
+      val application: Application)
       extends TopLevelCollectionResource[String, User] {
     override implicit def resourceFormat: OFormat[User] = User.oFormat
     override def keyFormat: KeyFormat[KeyType] = KeyFormat.stringKeyFormat

--- a/naptime-testing/src/test/scala/org/coursera/naptime/NaptimeModuleTest.scala
+++ b/naptime-testing/src/test/scala/org/coursera/naptime/NaptimeModuleTest.scala
@@ -2,14 +2,13 @@ package org.coursera.naptime
 
 import java.util.Date
 
-import javax.inject.Inject
-import akka.stream.Materializer
 import com.google.inject.Guice
 import com.google.inject.Stage
 import com.linkedin.data.schema.DataSchema
 import com.linkedin.data.schema.DataSchemaUtil
 import com.linkedin.data.schema.PrimitiveDataSchema
 import com.linkedin.data.schema.RecordDataSchema
+import javax.inject.Inject
 import org.coursera.naptime.model.KeyFormat
 import org.coursera.naptime.resources.TopLevelCollectionResource
 import org.coursera.naptime.router2.NaptimeRoutes
@@ -20,17 +19,12 @@ import play.api.Application
 import play.api.libs.json.Json
 import play.api.libs.json.OFormat
 
-import scala.concurrent.ExecutionContext
-
 object NaptimeModuleTest {
   case class User(name: String, createdAt: Date)
   object User {
     implicit val oFormat: OFormat[User] = Json.format[User]
   }
-  class MyResource(
-      implicit val executionContext: ExecutionContext,
-      val materializer: Materializer,
-      val application: Application)
+  class MyResource(implicit val application: Application)
       extends TopLevelCollectionResource[String, User] {
     override implicit def resourceFormat: OFormat[User] = User.oFormat
     override def keyFormat: KeyFormat[KeyType] = KeyFormat.stringKeyFormat

--- a/naptime-testing/src/test/scala/org/coursera/naptime/NestedMacroCourierTests.scala
+++ b/naptime-testing/src/test/scala/org/coursera/naptime/NestedMacroCourierTests.scala
@@ -1,13 +1,12 @@
 package org.coursera.naptime
 
-import javax.inject.Inject
-import akka.stream.Materializer
 import com.google.inject.Binder
 import com.google.inject.Guice
 import com.google.inject.Module
 import com.linkedin.data.DataMap
 import com.linkedin.data.schema.DataSchema
 import com.linkedin.data.schema.RecordDataSchema
+import javax.inject.Inject
 import org.coursera.naptime.NestedMacroCourierTests.CoursesResource
 import org.coursera.naptime.ari.FetcherError
 import org.coursera.naptime.ari.Request
@@ -25,8 +24,6 @@ import play.api.Application
 import play.api.libs.json.JsString
 import play.api.test.FakeRequest
 
-import scala.concurrent.ExecutionContext
-
 /**
  * This test suite uses Courier to exercise advanced use cases for Naptime.
  */
@@ -36,10 +33,7 @@ object NestedMacroCourierTests {
     val ID = ResourceName("courses", 1)
   }
 
-  class CoursesResource @Inject()(
-      implicit executionContext: ExecutionContext,
-      materializer: Materializer,
-      val application: Application)
+  class CoursesResource @Inject()(implicit override val application: Application)
       extends CourierCollectionResource[String, Course] {
     override def resourceName: String = CoursesResource.ID.topLevelName
 
@@ -94,10 +88,7 @@ object NestedMacroCourierTests {
     }
   }
 
-  class InstructorsResource @Inject()(
-      implicit ec: ExecutionContext,
-      mat: Materializer,
-      val application: Application)
+  class InstructorsResource @Inject()(implicit override val application: Application)
       extends CourierCollectionResource[String, Instructor]() {
     override def resourceName: String = "instructors"
 
@@ -119,8 +110,6 @@ class NestedMacroCourierTests
 
   val implicitsModule = new Module {
     override def configure(binder: Binder): Unit = {
-      binder.bind(classOf[ExecutionContext]).toInstance(executionContext)
-      binder.bind(classOf[Materializer]).toInstance(materializer)
       binder.bind(classOf[Application]).toInstance(application)
     }
   }

--- a/naptime-testing/src/test/scala/org/coursera/naptime/NestedMacroCourierTests.scala
+++ b/naptime-testing/src/test/scala/org/coursera/naptime/NestedMacroCourierTests.scala
@@ -105,7 +105,7 @@ object NestedMacroCourierTests {
 class NestedMacroCourierTests
     extends AssertionsForJUnit
     with ScalaFutures
-    with ResourceTestImplicits
+    with ImplicitTestApplication
     with IntegrationPatience {
 
   val implicitsModule = new Module {

--- a/naptime-testing/src/test/scala/org/coursera/naptime/NestedMacroCourierTests.scala
+++ b/naptime-testing/src/test/scala/org/coursera/naptime/NestedMacroCourierTests.scala
@@ -1,7 +1,6 @@
 package org.coursera.naptime
 
 import javax.inject.Inject
-
 import akka.stream.Materializer
 import com.google.inject.Binder
 import com.google.inject.Guice
@@ -22,6 +21,7 @@ import org.junit.Test
 import org.scalatest.concurrent.IntegrationPatience
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.junit.AssertionsForJUnit
+import play.api.Application
 import play.api.libs.json.JsString
 import play.api.test.FakeRequest
 
@@ -38,7 +38,8 @@ object NestedMacroCourierTests {
 
   class CoursesResource @Inject()(
       implicit executionContext: ExecutionContext,
-      materializer: Materializer)
+      materializer: Materializer,
+      val application: Application)
       extends CourierCollectionResource[String, Course] {
     override def resourceName: String = CoursesResource.ID.topLevelName
 
@@ -93,7 +94,10 @@ object NestedMacroCourierTests {
     }
   }
 
-  class InstructorsResource @Inject()(implicit ec: ExecutionContext, mat: Materializer)
+  class InstructorsResource @Inject()(
+      implicit ec: ExecutionContext,
+      mat: Materializer,
+      val application: Application)
       extends CourierCollectionResource[String, Instructor]() {
     override def resourceName: String = "instructors"
 
@@ -117,6 +121,7 @@ class NestedMacroCourierTests
     override def configure(binder: Binder): Unit = {
       binder.bind(classOf[ExecutionContext]).toInstance(executionContext)
       binder.bind(classOf[Materializer]).toInstance(materializer)
+      binder.bind(classOf[Application]).toInstance(application)
     }
   }
 

--- a/naptime-testing/src/test/scala/org/coursera/naptime/NestedMacroTests.scala
+++ b/naptime-testing/src/test/scala/org/coursera/naptime/NestedMacroTests.scala
@@ -44,6 +44,7 @@ import org.mockito.Matchers.any
 import org.mockito.Matchers.{eq => e}
 import org.scalatest.junit.AssertionsForJUnit
 import org.scalatest.mockito.MockitoSugar
+import play.api.Application
 import play.api.libs.json.Json
 import play.api.libs.json.OFormat
 import play.api.mvc.AnyContent
@@ -60,7 +61,8 @@ import scala.concurrent.ExecutionContext
  */
 class PersonResource(
     implicit val executionContext: ExecutionContext,
-    val materializer: Materializer)
+    val materializer: Materializer,
+    val application: Application)
     extends TopLevelCollectionResource[String, Person] {
 
   val PATH_KEY: PathKey = ("myPathKeyId" ::: RootParsedPathKey).asInstanceOf[PathKey]
@@ -128,7 +130,8 @@ object FriendshipInfo {
 
 class FriendsResource(val parentResource: PersonResource)(
     implicit val executionContext: ExecutionContext,
-    val materializer: Materializer)
+    val materializer: Materializer,
+    val application: Application)
     extends CollectionResource[PersonResource, String, FriendshipInfo] {
   override def keyFormat: KeyFormat[KeyType] = KeyFormat.stringKeyFormat
 

--- a/naptime-testing/src/test/scala/org/coursera/naptime/NestedMacroTests.scala
+++ b/naptime-testing/src/test/scala/org/coursera/naptime/NestedMacroTests.scala
@@ -166,7 +166,7 @@ object FriendsResource {
   val routerBuilder = Router.build[FriendsResource]
 }
 
-class NestedMacroTests extends AssertionsForJUnit with MockitoSugar with ResourceTestImplicits {
+class NestedMacroTests extends AssertionsForJUnit with MockitoSugar with ImplicitTestApplication {
 
   val peopleInstanceImpl = new PersonResource
   val peopleInstance = mock[PersonResource]

--- a/naptime-testing/src/test/scala/org/coursera/naptime/NestedMacroTests.scala
+++ b/naptime-testing/src/test/scala/org/coursera/naptime/NestedMacroTests.scala
@@ -16,7 +16,6 @@
 
 package org.coursera.naptime
 
-import akka.stream.Materializer
 import com.linkedin.data.DataMap
 import com.linkedin.data.schema.DataSchema
 import com.linkedin.data.schema.RecordDataSchema
@@ -28,8 +27,6 @@ import org.coursera.naptime.model.KeyFormat
 import org.coursera.naptime.model.Keyed
 import org.coursera.naptime.schema.HandlerKind
 import org.coursera.naptime.schema.ResourceKind
-import org.coursera.naptime.actions.RestActionBuilder
-import org.coursera.naptime.access.HeaderAccessControl
 import org.coursera.naptime.path.ParseFailure
 import org.coursera.naptime.path.ParseSuccess
 import org.coursera.naptime.path.RootParsedPathKey
@@ -47,22 +44,16 @@ import org.scalatest.mockito.MockitoSugar
 import play.api.Application
 import play.api.libs.json.Json
 import play.api.libs.json.OFormat
-import play.api.mvc.AnyContent
 import play.api.mvc.AnyContentAsEmpty
-import play.api.mvc.BodyParsers
 import play.api.mvc.RequestHeader
 import play.api.test.FakeRequest
 
 import scala.collection.JavaConversions._
-import scala.concurrent.ExecutionContext
 
 /**
  * The top level resource in our fledgling social network.
  */
-class PersonResource(
-    implicit val executionContext: ExecutionContext,
-    val materializer: Materializer,
-    val application: Application)
+class PersonResource(implicit val application: Application)
     extends TopLevelCollectionResource[String, Person] {
 
   val PATH_KEY: PathKey = ("myPathKeyId" ::: RootParsedPathKey).asInstanceOf[PathKey]
@@ -128,10 +119,7 @@ object FriendshipInfo {
   implicit val jsonFormat: OFormat[FriendshipInfo] = Json.format[FriendshipInfo]
 }
 
-class FriendsResource(val parentResource: PersonResource)(
-    implicit val executionContext: ExecutionContext,
-    val materializer: Materializer,
-    val application: Application)
+class FriendsResource(val parentResource: PersonResource)(implicit val application: Application)
     extends CollectionResource[PersonResource, String, FriendshipInfo] {
   override def keyFormat: KeyFormat[KeyType] = KeyFormat.stringKeyFormat
 

--- a/naptime-testing/src/test/scala/org/coursera/naptime/NestedMacroTests.scala
+++ b/naptime-testing/src/test/scala/org/coursera/naptime/NestedMacroTests.scala
@@ -291,11 +291,11 @@ class NestedMacroTests extends AssertionsForJUnit with MockitoSugar with Resourc
     val result = peopleRouter.routeRequest(request.path.substring("/api".length), request)
     assert(result.isDefined)
     val taggedRequest = result.get.tagRequest(request)
-    assert(taggedRequest.tags.contains(Router.NAPTIME_RESOURCE_NAME))
+    assert(taggedRequest.attrs.contains(Router.NAPTIME_RESOURCE_KEY))
     if (methodName != null && methodName != "") {
-      assert(taggedRequest.tags.get(Router.NAPTIME_METHOD_NAME).contains(methodName))
+      assert(taggedRequest.attrs.get(Router.NAPTIME_METHOD_KEY).contains(methodName))
     } else {
-      assert(taggedRequest.tags.get(Router.NAPTIME_METHOD_NAME).isEmpty)
+      assert(taggedRequest.attrs.get(Router.NAPTIME_METHOD_KEY).isEmpty)
     }
 
     val subResult = friendRouter.routeRequest(request.path.substring("/api".length), request)
@@ -307,8 +307,8 @@ class NestedMacroTests extends AssertionsForJUnit with MockitoSugar with Resourc
     val result = friendRouter.routeRequest(request.path.substring("/api".length), request)
     assert(result.isDefined)
     val taggedRequest = result.get.tagRequest(request)
-    assert(taggedRequest.tags.contains(Router.NAPTIME_RESOURCE_NAME))
-    assert(taggedRequest.tags.get(Router.NAPTIME_METHOD_NAME).contains(methodName))
+    assert(taggedRequest.attrs.contains(Router.NAPTIME_RESOURCE_KEY))
+    assert(taggedRequest.attrs.get(Router.NAPTIME_METHOD_KEY).contains(methodName))
 
     val parentResult = peopleRouter.routeRequest(request.path.substring("/api".length), request)
     assert(parentResult.isEmpty)

--- a/naptime-testing/src/test/scala/org/coursera/naptime/NonNestedMacroTests.scala
+++ b/naptime-testing/src/test/scala/org/coursera/naptime/NonNestedMacroTests.scala
@@ -35,6 +35,7 @@ import play.api.mvc.RequestHeader
 import play.api.test.FakeRequest
 import org.mockito.Mockito._
 import org.mockito.Matchers.any
+import play.api.Application
 
 import scala.concurrent.ExecutionContext
 
@@ -50,7 +51,10 @@ object ComplexEmailType {
     StringKeyFormat.caseClassFormat((ComplexEmailType.apply _).tupled, ComplexEmailType.unapply)
 }
 
-class Resource(implicit val executionContext: ExecutionContext, val materializer: Materializer)
+class Resource(
+    implicit val executionContext: ExecutionContext,
+    val materializer: Materializer,
+    val application: Application)
     extends TopLevelCollectionResource[String, Item] {
 
   override def keyFormat: KeyFormat[String] = KeyFormat.stringKeyFormat

--- a/naptime-testing/src/test/scala/org/coursera/naptime/NonNestedMacroTests.scala
+++ b/naptime-testing/src/test/scala/org/coursera/naptime/NonNestedMacroTests.scala
@@ -16,7 +16,6 @@
 
 package org.coursera.naptime
 
-import akka.stream.Materializer
 import org.coursera.common.stringkey.StringKeyFormat
 import org.coursera.naptime.actions.NaptimeActionSerializer.AnyWrites._
 import org.coursera.naptime.model.KeyFormat
@@ -37,8 +36,6 @@ import org.mockito.Mockito._
 import org.mockito.Matchers.any
 import play.api.Application
 
-import scala.concurrent.ExecutionContext
-
 case class Item(name: String, description: String)
 object Item {
   implicit val jsonFormat: OFormat[Item] = Json.format[Item]
@@ -51,10 +48,7 @@ object ComplexEmailType {
     StringKeyFormat.caseClassFormat((ComplexEmailType.apply _).tupled, ComplexEmailType.unapply)
 }
 
-class Resource(
-    implicit val executionContext: ExecutionContext,
-    val materializer: Materializer,
-    val application: Application)
+class Resource(implicit val application: Application)
     extends TopLevelCollectionResource[String, Item] {
 
   override def keyFormat: KeyFormat[String] = KeyFormat.stringKeyFormat

--- a/naptime-testing/src/test/scala/org/coursera/naptime/NonNestedMacroTests.scala
+++ b/naptime-testing/src/test/scala/org/coursera/naptime/NonNestedMacroTests.scala
@@ -115,7 +115,7 @@ object Resource {
   val routerBuilder = Router.build[Resource]
 }
 
-class NonNestedMacroTests extends AssertionsForJUnit with MockitoSugar with ResourceTestImplicits {
+class NonNestedMacroTests extends AssertionsForJUnit with MockitoSugar with ImplicitTestApplication {
 
   val instance = mock[Resource]
   val instanceImpl = new Resource

--- a/naptime-testing/src/test/scala/org/coursera/naptime/NonNestedMacroTests.scala
+++ b/naptime-testing/src/test/scala/org/coursera/naptime/NonNestedMacroTests.scala
@@ -168,8 +168,8 @@ class NonNestedMacroTests extends AssertionsForJUnit with MockitoSugar with Reso
     val result = router.routeRequest(requestHeader.path.substring("/api".length), requestHeader)
     assert(result.isDefined)
     val taggedRequest = result.get.tagRequest(requestHeader)
-    assert(taggedRequest.tags.contains(Router.NAPTIME_RESOURCE_NAME))
-    assert(taggedRequest.tags.get(Router.NAPTIME_METHOD_NAME).contains(methodName))
+    assert(taggedRequest.attrs.contains(Router.NAPTIME_RESOURCE_KEY))
+    assert(taggedRequest.attrs.get(Router.NAPTIME_METHOD_KEY).contains(methodName))
   }
 
   private[this] def noCustomInputOutputAuthTypes(methodName: String): Unit = {

--- a/naptime-testing/src/test/scala/org/coursera/naptime/router2/PlayNaptimeRouterIntegrationTest.scala
+++ b/naptime-testing/src/test/scala/org/coursera/naptime/router2/PlayNaptimeRouterIntegrationTest.scala
@@ -37,6 +37,7 @@ import org.mockito.Matchers._
 import org.mockito.Mockito._
 import org.scalatest.junit.AssertionsForJUnit
 import org.scalatest.mockito.MockitoSugar
+import play.api.Application
 import play.api.libs.json.Json
 import play.api.libs.json.OFormat
 import play.api.mvc.AnyContentAsEmpty
@@ -58,7 +59,8 @@ object PlayNaptimeRouterIntegrationTest {
    */
   class PersonResource(
       implicit val executionContext: ExecutionContext,
-      val materializer: Materializer)
+      val materializer: Materializer,
+      val application: Application)
       extends TopLevelCollectionResource[String, Person] {
 
     val PATH_KEY: PathKey = ("myPathKeyId" ::: RootParsedPathKey).asInstanceOf[PathKey]
@@ -110,7 +112,8 @@ object PlayNaptimeRouterIntegrationTest {
 
   class FriendsResource(val parentResource: PersonResource)(
       implicit val executionContext: ExecutionContext,
-      val materializer: Materializer)
+      val materializer: Materializer,
+      val application: Application)
       extends CollectionResource[PersonResource, String, FriendshipInfo] {
     override def keyFormat: KeyFormat[KeyType] = KeyFormat.stringKeyFormat
 

--- a/naptime-testing/src/test/scala/org/coursera/naptime/router2/PlayNaptimeRouterIntegrationTest.scala
+++ b/naptime-testing/src/test/scala/org/coursera/naptime/router2/PlayNaptimeRouterIntegrationTest.scala
@@ -16,7 +16,6 @@
 
 package org.coursera.naptime.router2
 
-import akka.stream.Materializer
 import com.google.inject.Guice
 import org.coursera.common.jsonformat.JsonFormats.Implicits.dateTimeFormat
 import org.coursera.naptime.actions.NaptimeActionSerializer.AnyWrites._
@@ -44,8 +43,6 @@ import play.api.mvc.AnyContentAsEmpty
 import play.api.mvc.RequestHeader
 import play.api.test.FakeRequest
 
-import scala.concurrent.ExecutionContext
-
 // TODO(saeta): De-dupe the test resources to share amongst tests.
 object PlayNaptimeRouterIntegrationTest {
   case class Person(name: String, email: String = "a@b.c")
@@ -57,10 +54,7 @@ object PlayNaptimeRouterIntegrationTest {
   /**
    * The top level resource in our fledgling social network.
    */
-  class PersonResource(
-      implicit val executionContext: ExecutionContext,
-      val materializer: Materializer,
-      val application: Application)
+  class PersonResource(implicit val application: Application)
       extends TopLevelCollectionResource[String, Person] {
 
     val PATH_KEY: PathKey = ("myPathKeyId" ::: RootParsedPathKey).asInstanceOf[PathKey]
@@ -110,10 +104,7 @@ object PlayNaptimeRouterIntegrationTest {
     implicit val jsonFormat: OFormat[FriendshipInfo] = Json.format[FriendshipInfo]
   }
 
-  class FriendsResource(val parentResource: PersonResource)(
-      implicit val executionContext: ExecutionContext,
-      val materializer: Materializer,
-      val application: Application)
+  class FriendsResource(val parentResource: PersonResource)(implicit val application: Application)
       extends CollectionResource[PersonResource, String, FriendshipInfo] {
     override def keyFormat: KeyFormat[KeyType] = KeyFormat.stringKeyFormat
 

--- a/naptime-testing/src/test/scala/org/coursera/naptime/router2/PlayNaptimeRouterIntegrationTest.scala
+++ b/naptime-testing/src/test/scala/org/coursera/naptime/router2/PlayNaptimeRouterIntegrationTest.scala
@@ -24,7 +24,7 @@ import org.coursera.naptime.model.Keyed
 import org.coursera.naptime.ComplexEmailType
 import org.coursera.naptime.NaptimeModule
 import org.coursera.naptime.Ok
-import org.coursera.naptime.ResourceTestImplicits
+import org.coursera.naptime.ImplicitTestApplication
 import org.coursera.naptime.path.ParseFailure
 import org.coursera.naptime.path.ParseSuccess
 import org.coursera.naptime.path.RootParsedPathKey
@@ -151,7 +151,7 @@ object PlayNaptimeRouterIntegrationTest {
 class PlayNaptimeRouterIntegrationTest
     extends AssertionsForJUnit
     with MockitoSugar
-    with ResourceTestImplicits {
+    with ImplicitTestApplication {
   import PlayNaptimeRouterIntegrationTest._
 
   val peopleInstanceImpl = new PersonResource

--- a/naptime-testing/src/test/scala/org/coursera/naptime/router2/PlayNaptimeRouterIntegrationTest.scala
+++ b/naptime-testing/src/test/scala/org/coursera/naptime/router2/PlayNaptimeRouterIntegrationTest.scala
@@ -281,8 +281,8 @@ class PlayNaptimeRouterIntegrationTest
     assert(result.isDefined)
     val routeAction = result.get.asInstanceOf[RouteAction]
     val taggedRequest = routeAction.tagRequest(request)
-    assert(taggedRequest.tags.get(Router.NAPTIME_RESOURCE_NAME).contains(resource.getClass.getName))
-    assert(taggedRequest.tags.get(Router.NAPTIME_METHOD_NAME).contains(methodName))
+    assert(taggedRequest.attrs.get(Router.NAPTIME_RESOURCE_KEY).contains(resource.getClass.getName))
+    assert(taggedRequest.attrs.get(Router.NAPTIME_METHOD_KEY).contains(methodName))
   }
 
   @Test

--- a/naptime/src/main/scala/org/coursera/naptime/actions/DefinedBodyTypeRestActionBuilder.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/actions/DefinedBodyTypeRestActionBuilder.scala
@@ -44,8 +44,6 @@ class DefinedBodyTypeRestActionBuilder[
     errorHandler: PartialFunction[Throwable, RestError])(
     implicit keyFormat: KeyFormat[ResourceKeyType],
     resourceFormat: OFormat[ResourceType],
-    ec: ExecutionContext,
-    mat: Materializer,
     application: Application)
     extends RestActionBuilderTerminators[
       RACType,

--- a/naptime/src/main/scala/org/coursera/naptime/actions/DefinedBodyTypeRestActionBuilder.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/actions/DefinedBodyTypeRestActionBuilder.scala
@@ -20,6 +20,7 @@ import akka.stream.Materializer
 import org.coursera.naptime.RestError
 import org.coursera.naptime.access.HeaderAccessControl
 import org.coursera.naptime.model.KeyFormat
+import play.api.Application
 import play.api.libs.json.OFormat
 import play.api.mvc.BodyParser
 
@@ -44,7 +45,8 @@ class DefinedBodyTypeRestActionBuilder[
     implicit keyFormat: KeyFormat[ResourceKeyType],
     resourceFormat: OFormat[ResourceType],
     ec: ExecutionContext,
-    mat: Materializer)
+    mat: Materializer,
+    application: Application)
     extends RestActionBuilderTerminators[
       RACType,
       AuthType,

--- a/naptime/src/main/scala/org/coursera/naptime/actions/RestAction.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/actions/RestAction.scala
@@ -32,15 +32,14 @@ import org.coursera.naptime.RestResponse
 import org.coursera.naptime.ari.Response
 import org.coursera.naptime.model.KeyFormat
 import org.coursera.naptime.router2.RouteAction
+import play.api.Application
 import play.api.Play
 import play.api.libs.json.OFormat
 import play.api.libs.streams.Accumulator
 import play.api.libs.typedmap.TypedKey
 import play.api.mvc.BodyParser
-import play.api.mvc.EssentialAction
 import play.api.mvc.Request
 import play.api.mvc.RequestHeader
-import play.api.mvc.RequestTaggingHandler
 import play.api.mvc.Result
 
 import scala.concurrent.ExecutionContext
@@ -78,6 +77,7 @@ trait RestAction[RACType, AuthType, BodyType, KeyType, ResourceType, ResponseTyp
   protected implicit val resourceFormat: OFormat[ResourceType]
   protected implicit val executionContext: ExecutionContext
   protected implicit val materializer: Materializer
+  protected def maybeApplication: Option[Application]
 
   /**
    * High level API, also used for testing.
@@ -147,7 +147,7 @@ trait RestAction[RACType, AuthType, BodyType, KeyType, ResourceType, ResponseTyp
                 }
 
                 // Implementation below borrowed from Play's Action.scala
-                Play.maybeApplication
+                maybeApplication
                   .map { app =>
                     play.utils.Threads.withContextClassLoader(app.classloader) {
                       run()
@@ -206,7 +206,7 @@ trait RestAction[RACType, AuthType, BodyType, KeyType, ResourceType, ResponseTyp
           }
 
           // Implementation below borrowed from Play's Action.scala
-          Play.maybeApplication
+          maybeApplication
             .map { app =>
               play.utils.Threads.withContextClassLoader(app.classloader) {
                 run()

--- a/naptime/src/main/scala/org/coursera/naptime/actions/RestActionBodyBuilder.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/actions/RestActionBodyBuilder.scala
@@ -24,6 +24,7 @@ import org.coursera.naptime.PaginationConfiguration
 import org.coursera.naptime.RestContext
 import org.coursera.naptime.RestError
 import org.coursera.naptime.RestResponse
+import play.api.Application
 import play.api.libs.json.OFormat
 import play.api.mvc.BodyParser
 
@@ -48,7 +49,8 @@ class RestActionBodyBuilder[
     implicit keyFormat: KeyFormat[ResourceKeyType],
     resourceFormat: OFormat[ResourceType],
     ec: ExecutionContext,
-    mat: Materializer) { self =>
+    mat: Materializer,
+    application: Application) { self =>
 
   type CategoryEngine =
     RestActionCategoryEngine[RACType, ResourceKeyType, ResourceType, ResponseType]
@@ -95,6 +97,7 @@ class RestActionBodyBuilder[
       override val resourceFormat = self.resourceFormat
       override val executionContext = ec
       override val materializer = mat
+      override val maybeApplication = Some(application)
 
       override def apply(
           context: RestContext[AuthType, BodyType]): Future[RestResponse[ResponseType]] =

--- a/naptime/src/main/scala/org/coursera/naptime/actions/RestActionBodyBuilder.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/actions/RestActionBodyBuilder.scala
@@ -99,6 +99,7 @@ class RestActionBodyBuilder[
       override def apply(
           context: RestContext[AuthType, BodyType]): Future[RestResponse[ResponseType]] =
         Futures.safelyCall(fn(context))
+
     }
   }
 }

--- a/naptime/src/main/scala/org/coursera/naptime/actions/RestActionBodyBuilder.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/actions/RestActionBodyBuilder.scala
@@ -48,8 +48,6 @@ class RestActionBodyBuilder[
     errorHandler: PartialFunction[Throwable, RestError])(
     implicit keyFormat: KeyFormat[ResourceKeyType],
     resourceFormat: OFormat[ResourceType],
-    ec: ExecutionContext,
-    mat: Materializer,
     application: Application) { self =>
 
   type CategoryEngine =
@@ -86,6 +84,8 @@ class RestActionBodyBuilder[
       fields: ResourceFields[ResourceType],
       _paginationConfiguration: PaginationConfiguration): BuiltAction = {
 
+    val app = application
+
     new RestAction[RACType, AuthType, BodyType, ResourceKeyType, ResourceType, ResponseType] {
       override def restAuthGenerator = authGeneratorOrAuth
       override def restBodyParser = bodyParser
@@ -95,9 +95,7 @@ class RestActionBodyBuilder[
       override def errorHandler: PartialFunction[Throwable, RestError] = self.errorHandler
       override val keyFormat = self.keyFormat
       override val resourceFormat = self.resourceFormat
-      override val executionContext = ec
-      override val materializer = mat
-      override val maybeApplication = Some(application)
+      override val application = app
 
       override def apply(
           context: RestContext[AuthType, BodyType]): Future[RestResponse[ResponseType]] =

--- a/naptime/src/main/scala/org/coursera/naptime/actions/RestActionBuilder.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/actions/RestActionBuilder.scala
@@ -23,6 +23,7 @@ import org.coursera.naptime.model.KeyFormat
 import org.coursera.naptime.NaptimeActionException
 import org.coursera.naptime.RestError
 import org.coursera.naptime.access.HeaderAccessControl
+import play.api.Application
 import play.api.http.Status
 import play.api.libs.json.JsArray
 import play.api.libs.json.JsError
@@ -51,7 +52,8 @@ class RestActionBuilder[RACType, AuthType, BodyType, ResourceKeyType, ResourceTy
     implicit keyFormat: KeyFormat[ResourceKeyType],
     resourceFormat: OFormat[ResourceType],
     ec: ExecutionContext,
-    mat: Materializer)
+    mat: Materializer,
+    application: Application)
     extends RestActionBuilderTerminators[
       RACType,
       AuthType,

--- a/naptime/src/main/scala/org/coursera/naptime/actions/RestActionBuilder.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/actions/RestActionBuilder.scala
@@ -51,8 +51,6 @@ class RestActionBuilder[RACType, AuthType, BodyType, ResourceKeyType, ResourceTy
     errorHandler: PartialFunction[Throwable, RestError])(
     implicit keyFormat: KeyFormat[ResourceKeyType],
     resourceFormat: OFormat[ResourceType],
-    ec: ExecutionContext,
-    mat: Materializer,
     application: Application)
     extends RestActionBuilderTerminators[
       RACType,
@@ -61,6 +59,8 @@ class RestActionBuilder[RACType, AuthType, BodyType, ResourceKeyType, ResourceTy
       ResourceKeyType,
       ResourceType,
       ResponseType] {
+
+  implicit val ec: ExecutionContext = application.actorSystem.dispatcher
 
   /**
    * Set the body type.

--- a/naptime/src/main/scala/org/coursera/naptime/resources/resources.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/resources/resources.scala
@@ -84,9 +84,9 @@ trait CollectionResource[ParentResource <: Resource[_], K, M] extends Resource[M
 
   def keyFormat: KeyFormat[KeyType]
 
-  implicit protected val executionContext: ExecutionContext
-  implicit protected val materializer: Materializer
   val application: Application
+  implicit protected val executionContext: ExecutionContext = application.actorSystem.dispatcher
+  implicit protected val materializer: Materializer = application.materializer
 
   /**
    * The (Hlist-like) collection of ancestor keys has this type.

--- a/naptime/src/main/scala/org/coursera/naptime/resources/resources.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/resources/resources.scala
@@ -135,7 +135,7 @@ trait CollectionResource[ParentResource <: Resource[_], K, M] extends Resource[M
     new RestActionBuilder[RACType, Unit, AnyContent, K, M, ResponseType](
       HeaderAccessControl.allowAll,
       BodyParsers.parse.default,
-      PartialFunction.empty)(keyFormat, resourceFormat, executionContext, materializer, application)
+      PartialFunction.empty)(keyFormat, resourceFormat, application)
 
   def OkIfPresent[T](a: Option[T]): RestResponse[T] = {
     a.map(Ok(_))
@@ -204,14 +204,10 @@ abstract class NestedCourierCollectionResource[
     M <: ScalaRecordTemplate]()(
     implicit kf: KeyFormat[K],
     classTag: ClassTag[M],
-    ec: ExecutionContext,
-    mat: Materializer)
+    val application: Application)
     extends CollectionResource[ParentResource, K, M] {
 
   final override implicit val keyFormat = kf
-
-  override implicit protected val executionContext: ExecutionContext = ec
-  override implicit protected val materializer: Materializer = mat
 
   // When we use the serializer constructor, the classTag parameter is never initialized, and
   // thus, we get NPEs when working with schemas. Because the OFormat isn't actually needed
@@ -239,9 +235,8 @@ abstract class NestedCourierCollectionResource[
 abstract class CourierCollectionResource[K, M <: ScalaRecordTemplate](
     implicit kf: KeyFormat[K],
     classTag: ClassTag[M],
-    ec: ExecutionContext,
-    mat: Materializer)
-    extends NestedCourierCollectionResource[RootResource, K, M]()(kf, classTag, ec, mat) {
+    application: Application)
+    extends NestedCourierCollectionResource[RootResource, K, M]()(kf, classTag, application) {
 
   final override val parentResource: RootResource = RootResource
 }

--- a/naptime/src/main/scala/org/coursera/naptime/resources/resources.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/resources/resources.scala
@@ -32,6 +32,7 @@ import org.coursera.naptime.path.RootParsedPathKey
 import org.coursera.naptime.path.RootPathParser
 import org.coursera.naptime.path.:::
 import org.coursera.naptime.path.UrlParseResult
+import play.api.Application
 import play.api.libs.json.OFormat
 import play.api.mvc.AnyContent
 import play.api.mvc.BodyParsers
@@ -85,6 +86,7 @@ trait CollectionResource[ParentResource <: Resource[_], K, M] extends Resource[M
 
   implicit protected val executionContext: ExecutionContext
   implicit protected val materializer: Materializer
+  val application: Application
 
   /**
    * The (Hlist-like) collection of ancestor keys has this type.
@@ -133,7 +135,7 @@ trait CollectionResource[ParentResource <: Resource[_], K, M] extends Resource[M
     new RestActionBuilder[RACType, Unit, AnyContent, K, M, ResponseType](
       HeaderAccessControl.allowAll,
       BodyParsers.parse.default,
-      PartialFunction.empty)(keyFormat, resourceFormat, executionContext, materializer)
+      PartialFunction.empty)(keyFormat, resourceFormat, executionContext, materializer, application)
 
   def OkIfPresent[T](a: Option[T]): RestResponse[T] = {
     a.map(Ok(_))

--- a/naptime/src/main/scala/org/coursera/naptime/router2/CollectionResourceRouter.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/router2/CollectionResourceRouter.scala
@@ -22,19 +22,16 @@ import org.coursera.common.stringkey.StringKey
 import org.coursera.common.stringkey.StringKeyFormat
 import play.api.libs.json.Json
 import play.api.libs.streams.Accumulator
-import play.api.mvc.EssentialAction
 import play.api.mvc.RequestHeader
-import play.api.mvc.RequestTaggingHandler
 import play.api.mvc.Result
 import play.api.mvc.Results
-import play.api.mvc.request.RequestAttrKey
 
 import scala.concurrent.Future
 import scala.language.existentials
 
 object CollectionResourceRouter {
   private[naptime] def errorRoute(msg: String, resourceClass: Class[_]): RouteAction =
-    new EssentialAction with RequestTaggingHandler {
+    new RouteAction {
       override def apply(request: RequestHeader): Accumulator[ByteString, Result] = {
         Accumulator(Sink.ignore.mapMaterializedValue { _ =>
           // TODO(saeta): use standardized error response format.
@@ -43,9 +40,7 @@ object CollectionResourceRouter {
       }
 
       override def tagRequest(request: RequestHeader): RequestHeader =
-        request.addAttr(
-          RequestAttrKey.Tags,
-          Map(Router.NAPTIME_RESOURCE_NAME -> resourceClass.getName))
+        request.addAttr(Router.NAPTIME_RESOURCE_KEY, resourceClass.getName)
     }
 
   case class StrictQueryParser[T](

--- a/naptime/src/main/scala/org/coursera/naptime/router2/NaptimePlayRouter.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/router2/NaptimePlayRouter.scala
@@ -108,7 +108,7 @@ case class NaptimePlayRouter(
    * [[apply]], which would result in request routing and URL parsing occuring twice for a single
    * request when it wouldn't need to.
    */
-  override lazy val routes: Routes = Function.unlift(handlerFor)
+  override lazy val routes: Routes = Function.unlift(handlerForImpl)
 
   override def withPrefix(prefix: String): routing.Router = copy(prefix = prefix)
 
@@ -242,7 +242,7 @@ case class NaptimePlayRouter(
    * @param request The request to route.
    * @return If this is a naptime request for one of the routers, return the handler, otherwise None
    */
-  override def handlerFor(request: RequestHeader): Option[Handler] = {
+  def handlerForImpl(request: RequestHeader): Option[Handler] = {
     if (request.path.startsWith(prefix)) {
       val path = request.path.substring(prefix.length)
 

--- a/naptime/src/main/scala/org/coursera/naptime/router2/NestingCollectionResourceRouter.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/router2/NestingCollectionResourceRouter.scala
@@ -27,11 +27,8 @@ import org.coursera.naptime.resources.CollectionResource
 import play.api.http.Status
 import play.api.libs.json.Json
 import play.api.libs.streams.Accumulator
-import play.api.libs.typedmap.TypedEntry
 import play.api.libs.typedmap.TypedKey
-import play.api.mvc.EssentialAction
 import play.api.mvc.RequestHeader
-import play.api.mvc.RequestTaggingHandler
 import play.api.mvc.Result
 import play.api.mvc.Results
 

--- a/naptime/src/main/scala/org/coursera/naptime/router2/Router.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/router2/Router.scala
@@ -17,9 +17,9 @@
 package org.coursera.naptime.router2
 
 import javax.inject.Inject
-
 import com.google.inject.Injector
 import org.coursera.naptime.resources.CollectionResource
+import play.api.libs.typedmap.TypedKey
 import play.api.mvc.RequestHeader
 
 import scala.annotation.tailrec
@@ -32,12 +32,12 @@ object Router {
   /**
    * Key for the [[RequestHeader.tags]] map filled in with the resource's class name
    */
-  val NAPTIME_RESOURCE_NAME = "NAPTIME_RESOURCE_NAME"
+  val NAPTIME_RESOURCE_KEY: TypedKey[String] = TypedKey("NAPTIME_RESOURCE_NAME")
 
   /**
    * Key for the [[RequestHeader.tags]] map filled in with the name of the invoked method.
    */
-  val NAPTIME_METHOD_NAME = "NAPTIME_METHOD_NAME"
+  val NAPTIME_METHOD_KEY: TypedKey[String] = TypedKey("NAPTIME_METHOD_NAME")
 }
 
 /**

--- a/naptime/src/main/scala/org/coursera/naptime/router2/package.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/router2/package.scala
@@ -17,10 +17,15 @@
 package org.coursera.naptime
 
 import play.api.mvc.EssentialAction
-import play.api.mvc.RequestTaggingHandler
+import play.api.mvc.Handler
+import play.api.mvc.RequestHeader
 
 package object router2 {
 
-  type RouteAction = EssentialAction with RequestTaggingHandler
+  trait RouteAction extends EssentialAction with Handler {
+
+    def tagRequest(request: RequestHeader): RequestHeader
+
+  }
 
 }

--- a/naptime/src/test/scala/org/coursera/naptime/ImplicitTestApplication.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/ImplicitTestApplication.scala
@@ -7,7 +7,7 @@ import play.api.Application
 import play.api.Mode
 import play.api.inject.guice.GuiceApplicationBuilder
 
-trait ResourceTestImplicits {
+trait ImplicitTestApplication {
 
   implicit val application: Application = GuiceApplicationBuilder()
     .in(new File("."))
@@ -18,7 +18,8 @@ trait ResourceTestImplicits {
   implicit val materializer = application.materializer
 
   @After
-  def shutDownActorSystem(): Unit = {
+  def shutDownApplication(): Unit = {
+    application.actorSystem.terminate()
     application.stop()
   }
 }

--- a/naptime/src/test/scala/org/coursera/naptime/ResourceTestImplicits.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/ResourceTestImplicits.scala
@@ -2,29 +2,16 @@ package org.coursera.naptime
 
 import java.io.File
 
-import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
-import akka.stream.Materializer
 import org.junit.After
 import play.api.Application
 import play.api.Mode
 import play.api.inject.guice.GuiceApplicationBuilder
 
-import scala.concurrent.ExecutionContext
-
 trait ResourceTestImplicits {
-  private[this] val internalActorSystem: ActorSystem = ActorSystem("test")
-  private[this] val internalExecutionContext: ExecutionContext = actorSystem.dispatcher
-  private[this] val internalMaterializer: Materializer = ActorMaterializer()
-
-  implicit protected def actorSystem: ActorSystem = internalActorSystem
-  implicit protected def executionContext: ExecutionContext = internalExecutionContext
-  implicit protected def materializer: Materializer = internalMaterializer
   implicit protected val application: Application = ResourceTestImplicits.application
-
   @After
   def shutDownActorSystem(): Unit = {
-    actorSystem.terminate()
+    application.stop()
   }
 }
 

--- a/naptime/src/test/scala/org/coursera/naptime/ResourceTestImplicits.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/ResourceTestImplicits.scala
@@ -8,18 +8,19 @@ import play.api.Mode
 import play.api.inject.guice.GuiceApplicationBuilder
 
 trait ResourceTestImplicits {
-  implicit protected val application: Application = ResourceTestImplicits.application
-  @After
-  def shutDownActorSystem(): Unit = {
-    application.stop()
-  }
-}
 
-object ResourceTestImplicits {
-
-  val application: Application = GuiceApplicationBuilder()
+  implicit val application: Application = GuiceApplicationBuilder()
     .in(new File("."))
     .in(Mode.Test)
     .build()
 
+  println(application.actorSystem)
+
+  implicit val ec = application.actorSystem.dispatcher
+  implicit val materializer = application.materializer
+
+  @After
+  def shutDownActorSystem(): Unit = {
+    application.stop()
+  }
 }

--- a/naptime/src/test/scala/org/coursera/naptime/ResourceTestImplicits.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/ResourceTestImplicits.scala
@@ -4,6 +4,9 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.stream.Materializer
 import org.junit.After
+import play.api.Application
+import play.api.routing.Router
+import play.core.server.DefaultAkkaHttpServerComponents
 
 import scala.concurrent.ExecutionContext
 
@@ -15,9 +18,13 @@ trait ResourceTestImplicits {
   implicit protected def actorSystem: ActorSystem = internalActorSystem
   implicit protected def executionContext: ExecutionContext = internalExecutionContext
   implicit protected def materializer: Materializer = internalMaterializer
-
+  implicit protected val application: Application = ResourceTestImplicits.application
   @After
   def shutDownActorSystem(): Unit = {
     actorSystem.terminate()
   }
+}
+
+object ResourceTestImplicits extends DefaultAkkaHttpServerComponents {
+  override def router: Router = ???
 }

--- a/naptime/src/test/scala/org/coursera/naptime/ResourceTestImplicits.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/ResourceTestImplicits.scala
@@ -14,8 +14,6 @@ trait ResourceTestImplicits {
     .in(Mode.Test)
     .build()
 
-  println(application.actorSystem)
-
   implicit val ec = application.actorSystem.dispatcher
   implicit val materializer = application.materializer
 

--- a/naptime/src/test/scala/org/coursera/naptime/ResourceTestImplicits.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/ResourceTestImplicits.scala
@@ -1,12 +1,14 @@
 package org.coursera.naptime
 
+import java.io.File
+
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.stream.Materializer
 import org.junit.After
 import play.api.Application
-import play.api.routing.Router
-import play.core.server.DefaultAkkaHttpServerComponents
+import play.api.Mode
+import play.api.inject.guice.GuiceApplicationBuilder
 
 import scala.concurrent.ExecutionContext
 
@@ -19,12 +21,18 @@ trait ResourceTestImplicits {
   implicit protected def executionContext: ExecutionContext = internalExecutionContext
   implicit protected def materializer: Materializer = internalMaterializer
   implicit protected val application: Application = ResourceTestImplicits.application
+
   @After
   def shutDownActorSystem(): Unit = {
     actorSystem.terminate()
   }
 }
 
-object ResourceTestImplicits extends DefaultAkkaHttpServerComponents {
-  override def router: Router = ???
+object ResourceTestImplicits {
+
+  val application: Application = GuiceApplicationBuilder()
+    .in(new File("."))
+    .in(Mode.Test)
+    .build()
+
 }

--- a/naptime/src/test/scala/org/coursera/naptime/access/HeaderAccessControlCombinersTest.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/access/HeaderAccessControlCombinersTest.scala
@@ -17,7 +17,7 @@
 package org.coursera.naptime.access
 
 import org.coursera.naptime.NaptimeActionException
-import org.coursera.naptime.ResourceTestImplicits
+import org.coursera.naptime.ImplicitTestApplication
 import org.coursera.naptime.access.authenticator.Authenticator
 import org.coursera.naptime.access.authenticator.Decorator
 import org.coursera.naptime.access.authenticator.HeaderAuthenticationParser
@@ -34,7 +34,7 @@ import play.api.test.FakeRequest
 class HeaderAccessControlCombinersTest
     extends AssertionsForJUnit
     with ScalaFutures
-    with ResourceTestImplicits {
+    with ImplicitTestApplication {
 
   import HeaderAccessControlCombinersTest._
 

--- a/naptime/src/test/scala/org/coursera/naptime/access/authenticator/DecoratorTest.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/access/authenticator/DecoratorTest.scala
@@ -16,14 +16,14 @@
 
 package org.coursera.naptime.access.authenticator
 
-import org.coursera.naptime.ResourceTestImplicits
+import org.coursera.naptime.ImplicitTestApplication
 import org.junit.Test
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.junit.AssertionsForJUnit
 
 import scala.concurrent.Future
 
-class DecoratorTest extends AssertionsForJUnit with ScalaFutures with ResourceTestImplicits {
+class DecoratorTest extends AssertionsForJUnit with ScalaFutures with ImplicitTestApplication {
 
   @Test
   def identity(): Unit = {

--- a/naptime/src/test/scala/org/coursera/naptime/actionCategoriesTests.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/actionCategoriesTests.scala
@@ -118,7 +118,7 @@ object RestActionCategoryEngineTest {
 class RestActionCategoryEngineTest
     extends AssertionsForJUnit
     with ScalaFutures
-    with ResourceTestImplicits {
+    with ImplicitTestApplication {
   import RestActionCategoryEngineTest._
 
   override def spanScaleFactor: Double = 10

--- a/naptime/src/test/scala/org/coursera/naptime/actionCategoriesTests.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/actionCategoriesTests.scala
@@ -12,6 +12,7 @@ import org.coursera.naptime.resources.TopLevelCollectionResource
 import org.junit.Test
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.junit.AssertionsForJUnit
+import play.api.Application
 import play.api.http.HeaderNames
 import play.api.http.HttpEntity
 import play.api.http.Status
@@ -46,7 +47,10 @@ object RestActionCategoryEngineTest {
    * Note: because we're not using routing, we can get away with having multiple get's / etc.
    * In general, it is a very bad idea to have multiple gets / etc. in a single resource.
    */
-  class SampleResource(implicit ec: ExecutionContext, mat: Materializer)
+  class SampleResource(
+      implicit ec: ExecutionContext,
+      mat: Materializer,
+      val application: Application)
       extends TopLevelCollectionResource[Int, EngineTestResource] {
     override val keyFormat: KeyFormat[Int] = KeyFormat.intKeyFormat
     override val resourceName: String = "tests"

--- a/naptime/src/test/scala/org/coursera/naptime/actions/RestActionCategoryEngine2Test.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/actions/RestActionCategoryEngine2Test.scala
@@ -16,7 +16,6 @@
 
 package org.coursera.naptime.actions
 
-import akka.stream.Materializer
 import com.linkedin.data.DataList
 import org.coursera.common.stringkey.StringKey
 import org.coursera.courier.templates.DataTemplates.DataConversion
@@ -58,7 +57,6 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers
 import play.api.test.Helpers.defaultAwaitTimeout
 
-import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
 object RestActionCategoryEngine2Test {
@@ -77,10 +75,7 @@ object RestActionCategoryEngine2Test {
    *
    * In general, it is a very bad idea to have multiple gets, creates, etc, in a single resource.
    */
-  class PlayJsonTestResource(
-      implicit val executionContext: ExecutionContext,
-      val materializer: Materializer,
-      val application: Application)
+  class PlayJsonTestResource(implicit val application: Application)
     extends TopLevelCollectionResource[Int, Person] {
     import RestActionCategoryEngine2._
 
@@ -134,10 +129,7 @@ object RestActionCategoryEngine2Test {
    *
    * In general, it is a very bad idea to have multiple gets, creates, etc, in a single resource.
    */
-  class CourierTestResource(
-      implicit val executionContext: ExecutionContext,
-      val materializer: Materializer,
-      val application: Application)
+  class CourierTestResource(implicit val application: Application)
     extends TopLevelCollectionResource[String, Course] {
     import RestActionCategoryEngine2._
 
@@ -187,10 +179,7 @@ object RestActionCategoryEngine2Test {
     }
   }
 
-  class courierKeyedTestResource(
-      implicit val executionContext: ExecutionContext,
-      val materializer: Materializer,
-      val application: Application)
+  class courierKeyedTestResource(implicit val application: Application)
     extends TopLevelCollectionResource[EnrollmentId, Course] {
     import RestActionCategoryEngine2._
 

--- a/naptime/src/test/scala/org/coursera/naptime/actions/RestActionCategoryEngine2Test.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/actions/RestActionCategoryEngine2Test.scala
@@ -134,7 +134,10 @@ object RestActionCategoryEngine2Test {
    *
    * In general, it is a very bad idea to have multiple gets, creates, etc, in a single resource.
    */
-  class CourierTestResource(implicit val executionContext: ExecutionContext, val materializer: Materializer)
+  class CourierTestResource(
+      implicit val executionContext: ExecutionContext,
+      val materializer: Materializer,
+      val application: Application)
     extends TopLevelCollectionResource[String, Course] {
     import RestActionCategoryEngine2._
 
@@ -184,7 +187,10 @@ object RestActionCategoryEngine2Test {
     }
   }
 
-  class courierKeyedTestResource(implicit val executionContext: ExecutionContext, val materializer: Materializer)
+  class courierKeyedTestResource(
+      implicit val executionContext: ExecutionContext,
+      val materializer: Materializer,
+      val application: Application)
     extends TopLevelCollectionResource[EnrollmentId, Course] {
     import RestActionCategoryEngine2._
 

--- a/naptime/src/test/scala/org/coursera/naptime/actions/RestActionCategoryEngine2Test.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/actions/RestActionCategoryEngine2Test.scala
@@ -33,7 +33,7 @@ import org.coursera.naptime.QueryFields
 import org.coursera.naptime.QueryIncludes
 import org.coursera.naptime.RequestPagination
 import org.coursera.naptime.ResourceName
-import org.coursera.naptime.ResourceTestImplicits
+import org.coursera.naptime.ImplicitTestApplication
 import org.coursera.naptime.actions.util.Validators
 import org.coursera.naptime.resources.TopLevelCollectionResource
 import org.junit.Test
@@ -304,7 +304,7 @@ object RestActionCategoryEngine2Test {
   }
 }
 
-class RestActionCategoryEngine2Test extends AssertionsForJUnit with ScalaFutures with ResourceTestImplicits {
+class RestActionCategoryEngine2Test extends AssertionsForJUnit with ScalaFutures with ImplicitTestApplication {
   import RestActionCategoryEngine2Test._
   // Increase timeout a bit.
   override def spanScaleFactor: Double = 10

--- a/naptime/src/test/scala/org/coursera/naptime/actions/RestActionCategoryEngine2Test.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/actions/RestActionCategoryEngine2Test.scala
@@ -40,6 +40,7 @@ import org.coursera.naptime.resources.TopLevelCollectionResource
 import org.junit.Test
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.junit.AssertionsForJUnit
+import play.api.Application
 import play.api.http.HeaderNames
 import play.api.http.HttpEntity
 import play.api.http.Status
@@ -76,7 +77,10 @@ object RestActionCategoryEngine2Test {
    *
    * In general, it is a very bad idea to have multiple gets, creates, etc, in a single resource.
    */
-  class PlayJsonTestResource(implicit val executionContext: ExecutionContext, val materializer: Materializer)
+  class PlayJsonTestResource(
+      implicit val executionContext: ExecutionContext,
+      val materializer: Materializer,
+      val application: Application)
     extends TopLevelCollectionResource[Int, Person] {
     import RestActionCategoryEngine2._
 

--- a/naptime/src/test/scala/org/coursera/naptime/resources/NestingTests.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/resources/NestingTests.scala
@@ -17,7 +17,7 @@
 package org.coursera.naptime.resources
 
 import org.coursera.common.jsonformat.JsonFormats.Implicits.dateTimeFormat
-import org.coursera.naptime.ResourceTestImplicits
+import org.coursera.naptime.ImplicitTestApplication
 import org.coursera.naptime.model.KeyFormat
 import org.coursera.naptime.path.ParseFailure
 import org.coursera.naptime.path.ParseSuccess
@@ -60,7 +60,7 @@ object NestingTests {
   }
 }
 
-class NestingTests extends AssertionsForJUnit with ResourceTestImplicits {
+class NestingTests extends AssertionsForJUnit with ImplicitTestApplication {
 
   @Test
   def topLevelRouting(): Unit = {

--- a/naptime/src/test/scala/org/coursera/naptime/resources/NestingTests.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/resources/NestingTests.scala
@@ -16,7 +16,6 @@
 
 package org.coursera.naptime.resources
 
-import akka.stream.Materializer
 import org.coursera.common.jsonformat.JsonFormats.Implicits.dateTimeFormat
 import org.coursera.naptime.ResourceTestImplicits
 import org.coursera.naptime.model.KeyFormat
@@ -32,18 +31,13 @@ import play.api.Application
 import play.api.libs.json.Json
 import play.api.libs.json.OFormat
 
-import scala.concurrent.ExecutionContext
-
 object NestingTests {
   case class Person(name: String)
   object Person {
     implicit val jsonFormat: OFormat[Person] = Json.format[Person]
   }
 
-  class PeopleResource(
-      implicit val executionContext: ExecutionContext,
-      val materializer: Materializer,
-      val application: Application)
+  class PeopleResource(implicit val application: Application)
       extends TopLevelCollectionResource[String, Person] {
 
     override def keyFormat = KeyFormat.stringKeyFormat
@@ -56,10 +50,7 @@ object NestingTests {
     implicit val jsonFormat: OFormat[FriendInfo] = Json.format[FriendInfo]
   }
 
-  class FriendInfoResource(peopleResource: PeopleResource)(
-      implicit val executionContext: ExecutionContext,
-      val materializer: Materializer,
-      val application: Application)
+  class FriendInfoResource(peopleResource: PeopleResource)(implicit val application: Application)
       extends CollectionResource[PeopleResource, String, FriendInfo] {
 
     override def keyFormat = KeyFormat.stringKeyFormat

--- a/naptime/src/test/scala/org/coursera/naptime/resources/NestingTests.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/resources/NestingTests.scala
@@ -28,6 +28,7 @@ import org.coursera.naptime.resources.NestingTests.PeopleResource
 import org.joda.time.DateTime
 import org.junit.Test
 import org.scalatest.junit.AssertionsForJUnit
+import play.api.Application
 import play.api.libs.json.Json
 import play.api.libs.json.OFormat
 
@@ -41,7 +42,8 @@ object NestingTests {
 
   class PeopleResource(
       implicit val executionContext: ExecutionContext,
-      val materializer: Materializer)
+      val materializer: Materializer,
+      val application: Application)
       extends TopLevelCollectionResource[String, Person] {
 
     override def keyFormat = KeyFormat.stringKeyFormat
@@ -56,7 +58,8 @@ object NestingTests {
 
   class FriendInfoResource(peopleResource: PeopleResource)(
       implicit val executionContext: ExecutionContext,
-      val materializer: Materializer)
+      val materializer: Materializer,
+      val application: Application)
       extends CollectionResource[PeopleResource, String, FriendInfo] {
 
     override def keyFormat = KeyFormat.stringKeyFormat

--- a/naptime/src/test/scala/org/coursera/naptime/router2/NaptimePlayRouterTest.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/router2/NaptimePlayRouterTest.scala
@@ -37,9 +37,8 @@ import play.api.mvc.Result
 import play.api.test.FakeRequest
 
 class NaptimePlayRouterTest extends AssertionsForJUnit with MockitoSugar {
-  object FakeHandler extends /* RouteAction */ EssentialAction with RequestTaggingHandler {
+  object FakeHandler extends RouteAction {
     override def tagRequest(request: RequestHeader): RequestHeader = request
-
     override def apply(v1: RequestHeader): Accumulator[ByteString, Result] = ???
   }
 

--- a/naptime/src/test/scala/org/coursera/naptime/router2/NaptimePlayRouterTest.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/router2/NaptimePlayRouterTest.scala
@@ -30,9 +30,7 @@ import org.mockito.Matchers.any
 import org.scalatest.junit.AssertionsForJUnit
 import org.scalatest.mockito.MockitoSugar
 import play.api.libs.streams.Accumulator
-import play.api.mvc.EssentialAction
 import play.api.mvc.RequestHeader
-import play.api.mvc.RequestTaggingHandler
 import play.api.mvc.Result
 import play.api.test.FakeRequest
 

--- a/naptime/src/test/scala/org/coursera/naptime/router2/NestingCollectionResourceRouterTest.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/router2/NestingCollectionResourceRouterTest.scala
@@ -418,11 +418,11 @@ class NestingCollectionResourceRouterTest
     assert(result.isDefined, s"Router did not correctly route $request")
     val taggedRequest = result.get.tagRequest(request)
     assert(
-      taggedRequest.tags.contains(Router.NAPTIME_RESOURCE_NAME),
+      taggedRequest.attrs.contains(Router.NAPTIME_RESOURCE_KEY),
       "Router result (typically a RestAction) did not tag the request properly.")
     Option(expectedMethodName).foreach { methodName =>
       assert(
-        taggedRequest.tags.get(Router.NAPTIME_METHOD_NAME).contains(methodName),
+        taggedRequest.attrs.get(Router.NAPTIME_METHOD_KEY).contains(methodName),
         "method names did not match.")
     }
   }
@@ -438,11 +438,11 @@ class NestingCollectionResourceRouterTest
     assert(result.isDefined, s"Router did not correctly route $request")
     val taggedRequest = result.get.tagRequest(request)
     assert(
-      taggedRequest.tags.contains(Router.NAPTIME_RESOURCE_NAME),
+      taggedRequest.attrs.contains(Router.NAPTIME_RESOURCE_KEY),
       "Router result (typically a RestAction) did not tag the request properly.")
     Option(expectedMethodName).foreach { methodName =>
       assert(
-        taggedRequest.tags.get(Router.NAPTIME_METHOD_NAME).contains(methodName),
+        taggedRequest.attrs.get(Router.NAPTIME_METHOD_KEY).contains(methodName),
         "method names did not match.")
     }
   }

--- a/naptime/src/test/scala/org/coursera/naptime/router2/NestingCollectionResourceRouterTest.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/router2/NestingCollectionResourceRouterTest.scala
@@ -173,10 +173,7 @@ object NestingCollectionResourceRouterTest {
    * A nested resource that has more sophisticated parameters to its Naptime operations to test the
    * capabilities of the routing system.
    */
-  class MyNestedResource(val parentResource: MyResource)(
-      implicit val executionContext: ExecutionContext,
-      val materializer: Materializer,
-      val application: Application)
+  class MyNestedResource(val parentResource: MyResource)(val application: Application)
       extends CollectionResource[MyResource, String, Person] {
 
     override def keyFormat: KeyFormat[KeyType] = KeyFormat.stringKeyFormat

--- a/naptime/src/test/scala/org/coursera/naptime/router2/NestingCollectionResourceRouterTest.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/router2/NestingCollectionResourceRouterTest.scala
@@ -33,6 +33,7 @@ import org.mockito.Mockito.when
 import org.mockito.Mockito.verify
 import org.scalatest.junit.AssertionsForJUnit
 import org.scalatest.mockito.MockitoSugar
+import play.api.Application
 import play.api.libs.json.Json
 import play.api.libs.json.OFormat
 import play.api.mvc.RequestHeader
@@ -49,7 +50,10 @@ object NestingCollectionResourceRouterTest {
   /**
    * A sample top-level resource, with very standard / normal Naptime operations.
    */
-  class MyResource(implicit val executionContext: ExecutionContext, val materializer: Materializer)
+  class MyResource(
+      implicit val executionContext: ExecutionContext,
+      val materializer: Materializer,
+      val application: Application)
       extends TopLevelCollectionResource[String, Person] {
     override def keyFormat: KeyFormat[KeyType] = KeyFormat.stringKeyFormat
     override implicit def resourceFormat: OFormat[Person] = Person.jsonFormat
@@ -171,7 +175,8 @@ object NestingCollectionResourceRouterTest {
    */
   class MyNestedResource(val parentResource: MyResource)(
       implicit val executionContext: ExecutionContext,
-      val materializer: Materializer)
+      val materializer: Materializer,
+      val application: Application)
       extends CollectionResource[MyResource, String, Person] {
 
     override def keyFormat: KeyFormat[KeyType] = KeyFormat.stringKeyFormat

--- a/naptime/src/test/scala/org/coursera/naptime/router2/NestingCollectionResourceRouterTest.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/router2/NestingCollectionResourceRouterTest.scala
@@ -16,7 +16,6 @@
 
 package org.coursera.naptime.router2
 
-import akka.stream.Materializer
 import org.coursera.common.stringkey.StringKeyFormat
 import org.coursera.naptime.ResourceTestImplicits
 import org.coursera.naptime.actions.NaptimeActionSerializer.AnyWrites._
@@ -39,8 +38,6 @@ import play.api.libs.json.OFormat
 import play.api.mvc.RequestHeader
 import play.api.test.FakeRequest
 
-import scala.concurrent.ExecutionContext
-
 object NestingCollectionResourceRouterTest {
   case class Person(name: String)
   object Person {
@@ -50,10 +47,7 @@ object NestingCollectionResourceRouterTest {
   /**
    * A sample top-level resource, with very standard / normal Naptime operations.
    */
-  class MyResource(
-      implicit val executionContext: ExecutionContext,
-      val materializer: Materializer,
-      val application: Application)
+  class MyResource(implicit val application: Application)
       extends TopLevelCollectionResource[String, Person] {
     override def keyFormat: KeyFormat[KeyType] = KeyFormat.stringKeyFormat
     override implicit def resourceFormat: OFormat[Person] = Person.jsonFormat
@@ -173,7 +167,7 @@ object NestingCollectionResourceRouterTest {
    * A nested resource that has more sophisticated parameters to its Naptime operations to test the
    * capabilities of the routing system.
    */
-  class MyNestedResource(val parentResource: MyResource)(val application: Application)
+  class MyNestedResource(val parentResource: MyResource)(implicit val application: Application)
       extends CollectionResource[MyResource, String, Person] {
 
     override def keyFormat: KeyFormat[KeyType] = KeyFormat.stringKeyFormat

--- a/naptime/src/test/scala/org/coursera/naptime/router2/NestingCollectionResourceRouterTest.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/router2/NestingCollectionResourceRouterTest.scala
@@ -17,7 +17,7 @@
 package org.coursera.naptime.router2
 
 import org.coursera.common.stringkey.StringKeyFormat
-import org.coursera.naptime.ResourceTestImplicits
+import org.coursera.naptime.ImplicitTestApplication
 import org.coursera.naptime.actions.NaptimeActionSerializer.AnyWrites._
 import org.coursera.naptime.model.KeyFormat
 import org.coursera.naptime.path.:::
@@ -291,7 +291,7 @@ object NestingCollectionResourceRouterTest {
 class NestingCollectionResourceRouterTest
     extends AssertionsForJUnit
     with MockitoSugar
-    with ResourceTestImplicits {
+    with ImplicitTestApplication {
   import NestingCollectionResourceRouterTest._
 
   val resourceInstance = new MyResource

--- a/project/NaptimeBuild.scala
+++ b/project/NaptimeBuild.scala
@@ -25,8 +25,8 @@ import play.sbt.PlayScala
 
 object NaptimeBuild extends Build with NamedDependencies with PluginVersionProvider {
 
-  override def playVersion = "2.6.7" // Play version is defined here, and in project/plugins.sbt
-  override def playJsonVersion = "2.6.7"
+  override def playVersion = "2.7.2" // Play version is defined here, and in project/plugins.sbt
+  override def playJsonVersion = "2.7.2"
   override def courierVersion = "2.1.4"
 
   lazy val root = project

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.7")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.2")
 
 // Courier binding generator plugin
 addSbtPlugin("org.coursera.courier" % "courier-sbt-plugin" % "2.1.4")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.9.2-alpha28"
+version in ThisBuild := "0.9.3-alpha29"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.9.3-alpha29"
+version in ThisBuild := "0.10.0-alpha"


### PR DESCRIPTION
This PR upgrades Naptime to use Play 2.7. Changes in this revision address two incompatibilities, which in turn introduce mild breaking changes in Naptime, motivating a version bump to 0.10.0:

- Play 2.7 has fully deprecated request tags, and instead guides developers to use typed request attributes. This revision shifts all tagging to Play's preferred attribute representation.
- From version 2.5, Play has strongly discouraged static references to the running application via the `Play.maybeApplication` accessor, and instead recommends that the application be injected as a dependency. While applications can be configured to allow static application references by setting `play.allowGlobalApplication=true` in configuration, I think the Play team's advice is good here, and have chosen to follow it. Injecting the application reduces the implicit constructor signature of resources and handlers, and ensures consistent execution contexts.

We'll need to take care in rolling this out. Switching to Application injection rather than materializer + execution context in Coursera apps should be pretty straightforward, but an incautious shift from tags to attrs could break things libraries aren't in sync. 