### PR TITLE
Minor fixes for test compatibility

### DIFF
--- a/naptime-testing/src/main/scala/org/coursera/naptime/actions/RestActionTester.scala
+++ b/naptime-testing/src/main/scala/org/coursera/naptime/actions/RestActionTester.scala
@@ -18,8 +18,6 @@ package org.coursera.naptime.actions
 
 import java.io.File
 
-import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
 import akka.stream.Materializer
 import org.coursera.naptime.NaptimeActionException
 import org.coursera.naptime.QueryFields
@@ -37,6 +35,7 @@ import play.api.Mode
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.FakeRequest
 
+import scala.concurrent.ExecutionContext
 import scala.util.Try
 
 /**
@@ -48,8 +47,8 @@ trait RestActionTester { this: ScalaFutures =>
     .in(Mode.Test)
     .build()
 
-  implicit val ec = application.actorSystem.dispatcher
-  implicit val materializer = application.materializer
+  implicit val ec: ExecutionContext = application.actorSystem.dispatcher
+  implicit val materializer: Materializer = application.materializer
 
   @After
   def shutDownApplication(): Unit = {

--- a/naptime-testing/src/test/scala/org/coursera/naptime/NonNestedMacroTests.scala
+++ b/naptime-testing/src/test/scala/org/coursera/naptime/NonNestedMacroTests.scala
@@ -115,7 +115,10 @@ object Resource {
   val routerBuilder = Router.build[Resource]
 }
 
-class NonNestedMacroTests extends AssertionsForJUnit with MockitoSugar with ImplicitTestApplication {
+class NonNestedMacroTests
+    extends AssertionsForJUnit
+    with MockitoSugar
+    with ImplicitTestApplication {
 
   val instance = mock[Resource]
   val instanceImpl = new Resource

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.10.0-alpha"
+version in ThisBuild := "0.10.0-alpha1"


### PR DESCRIPTION
See contents for details. Missing type annotation caused a name conflict in existing tests. 