### PR TITLE
Bump Play to version 2.6.24

### DIFF
--- a/project/NaptimeBuild.scala
+++ b/project/NaptimeBuild.scala
@@ -25,8 +25,8 @@ import play.sbt.PlayScala
 
 object NaptimeBuild extends Build with NamedDependencies with PluginVersionProvider {
 
-  override def playVersion = "2.6.7" // Play version is defined here, and in project/plugins.sbt
-  override def playJsonVersion = "2.6.7"
+  override def playVersion = "2.6.24" // Play version is defined here, and in project/plugins.sbt
+  override def playJsonVersion = "2.6.13"
   override def courierVersion = "2.1.4"
 
   lazy val root = project

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.7")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.24")
 
 // Courier binding generator plugin
 addSbtPlugin("org.coursera.courier" % "courier-sbt-plugin" % "2.1.4")
@@ -17,3 +17,10 @@ libraryDependencies += { "org.scala-sbt" % "scripted-plugin" % sbtVersion.value 
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "1.5.1-2-g8b57b53")
 
 addSbtPlugin("com.lucidchart" % "sbt-scalafmt" % "1.15")
+
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
+
+addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.2.7")
+
+addSbtPlugin("com.codacy" % "sbt-codacy-coverage" % "2.112")
+

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.9.2-alpha30"
+version in ThisBuild := "0.10.0"


### PR DESCRIPTION
Pulls in this diff along with some other library version upgrades thats needed to avoid classpath hell in our main repo: https://github.com/playframework/playframework/issues/9612