### PR TITLE
Quiet noisy logs when deserializing a NULL as we appear to be handling that case explicitly

### DIFF
--- a/naptime-models/src/main/scala/org/coursera/naptime/courier/CourierFormats.scala
+++ b/naptime-models/src/main/scala/org/coursera/naptime/courier/CourierFormats.scala
@@ -462,7 +462,8 @@ object CourierFormats extends StrictLogging {
       schema: DataSchema): AnyRef = {
     (schema, jsValue) match {
       case (_, JsNull) =>
-        checkSchema[NullDataSchema](schemaPath, "deserializing a NULL", schema)
+        // We don't check the schema when deserializing a NULL, since we can encode any optional schema into NULL.
+        // See `jsObjectToRecord` for where we set com.linkedin.data.Null to `None`...
         Null.getInstance
       case (arraySchema: ArrayDataSchema, jsArray: JsArray) =>
         jsArrayToDataList(schemaPath, jsArray, arraySchema)

--- a/naptime-models/src/main/scala/org/coursera/naptime/courier/CourierFormats.scala
+++ b/naptime-models/src/main/scala/org/coursera/naptime/courier/CourierFormats.scala
@@ -464,6 +464,7 @@ object CourierFormats extends StrictLogging {
       case (_, JsNull) =>
         // We don't check the schema when deserializing a NULL, since we can encode any optional schema into NULL.
         // See `jsObjectToRecord` for where we set com.linkedin.data.Null to `None`...
+        // This implies that we treat JSON null the same as the absence of a value.
         Null.getInstance
       case (arraySchema: ArrayDataSchema, jsArray: JsArray) =>
         jsArrayToDataList(schemaPath, jsArray, arraySchema)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.11.0"
+version in ThisBuild := "0.11.1"


### PR DESCRIPTION
See added comment. It appears we handle this case explicitly (`jsObjectToRecord` is what is calling `jsValueToData`) so maybe this check is somewhat over-eager. 

Specifically, L544-550 of this file.
```
 if (field != null) {
          val result = jsValueToData(newSchemaPath, value, field.getType)
          if (result != Null.getInstance) {
            Some(field.getName -> result)
          } else {
            None
          }
```

Also, note that the check is only a log and not a throw, if something terrible happens downstream, we'd still get the same error behaviors.

