### PR TITLE
Use Matcher.quoteReplacement to escape ids with special characters

### DIFF
--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/NaptimeResourceUtils.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/schema/NaptimeResourceUtils.scala
@@ -16,6 +16,8 @@
 
 package org.coursera.naptime.ari.graphql.schema
 
+import java.util.regex.Matcher
+
 import com.typesafe.scalalogging.StrictLogging
 import org.coursera.naptime.ResourceName
 import org.coursera.naptime.ari.engine.Utilities
@@ -222,7 +224,9 @@ object NaptimeResourceUtils extends StrictLogging {
         val variableName = withoutBraces.orElse(withBraces).getOrElse("")
         Try {
           val interpolatedIds = variableNameToInterpolatedIds(variableName)
-          interpolatedIds(i % interpolatedIds.size)
+          // REMARK: `quoteReplacement` properly escapes `$`  and `\`, which is necessary
+          // when the ID has these special characters.
+          Matcher.quoteReplacement(interpolatedIds(i % interpolatedIds.size))
         } match {
           case Success(v) => v
           case Failure(f) =>

--- a/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/schema/NaptimeResourceUtilsTest.scala
+++ b/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/schema/NaptimeResourceUtilsTest.scala
@@ -149,4 +149,23 @@ class NaptimeResourceUtilsTest extends AssertionsForJUnit with MockitoSugar {
         JsString(s"OLD_COURSE~${Models.oldCourseIdB}")))
     assert(interpolatedArguments("ids") === expectedCourseIds)
   }
+
+  @Test
+  def interpolateArgumentsWithDollarSignsEscaped(): Unit = {
+    val courseWithDollarSignInId = Models.COURSE_A.copy(id = "course$A")
+
+    val testCourse = DataMapWithParent(
+      courseWithDollarSignInId.data(),
+      ParentModel(ResourceName("courses", 1), courseWithDollarSignInId.data(), MergedCourse.SCHEMA))
+
+    val finderRelation = GraphQLRelationAnnotation(
+      resourceName = "courses.v1",
+      arguments = StringMap(Map("id" -> "COURSE~$id", "q" -> "byId")),
+      relationType = RelationType.FINDER)
+
+    val interpolatedArguments =
+      NaptimeResourceUtils.interpolateArguments(testCourse, finderRelation).toMap
+    assert(interpolatedArguments("id") === JsString(s"COURSE~${courseWithDollarSignInId.id}"))
+    assert(interpolatedArguments("q") === JsString("byId"))
+  }
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.11.1"
+version in ThisBuild := "0.11.2"


### PR DESCRIPTION
Should fix the issue described in https://coursera.slack.com/archives/C025SQ0GH/p1594832573018600 which comes from ids with `$` embedded. Looks like the root cause is the replacement text for the `regex. replaceAllIn` method needs to escape special characters. They provide an API for this.

Existing unit tests should cover regressions, and added a new unit test for this case.

This is only deployed through assembler so fairly safe to deploy with traffic shifting + E2E tests as well.