### PR TITLE
Add includes relations to dataSchema

### DIFF
--- a/naptime/src/main/pegasus/org/coursera/naptime/schema/IncludedRelationAnnotation.courier
+++ b/naptime/src/main/pegasus/org/coursera/naptime/schema/IncludedRelationAnnotation.courier
@@ -3,7 +3,7 @@ namespace org.coursera.naptime.schema
 /**
  * The schema for a linked relation annotation.
  */
-record LinkedRelationAnnotation {
+record IncludedRelationAnnotation {
 
   /**
    * The name of the resource.

--- a/naptime/src/main/pegasus/org/coursera/naptime/schema/LinkedRelationAnnotation.courier
+++ b/naptime/src/main/pegasus/org/coursera/naptime/schema/LinkedRelationAnnotation.courier
@@ -1,0 +1,13 @@
+namespace org.coursera.naptime.schema
+
+/**
+ * The schema for a linked relation annotation.
+ */
+record LinkedRelationAnnotation {
+
+  /**
+   * The name of the resource.
+   */
+  resourceName: string
+
+}

--- a/naptime/src/main/scala/org/coursera/naptime/Types.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/Types.scala
@@ -95,7 +95,7 @@ object Types extends StrictLogging {
     val relationKeys = fields.relations.keys ++ fields.graphQLRelations.keys
     for (name <- relationKeys) {
       val relationOption = fields.relations.get(name)
-      var graphQLRelationOption = fields.graphQLRelations.get(name)
+      val graphQLRelationOption = fields.graphQLRelations.get(name)
       if (mergedSchema.contains(name)) {
         logger.warn(
           s"Fields for resource $typeName tries to add Include/GraphQL relation on field " +

--- a/naptime/src/main/scala/org/coursera/naptime/Types.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/Types.scala
@@ -40,7 +40,7 @@ object Types extends StrictLogging {
 
   object Relations {
     val RELATION_PROPERTY_NAME = "relatedOn"
-    val INCLUDES_PROPERTY_NAME = "included"
+    val includedPropertyName = "included"
   }
 
   @deprecated("Please use the one with fields included", "0.2.4")
@@ -119,7 +119,7 @@ object Types extends StrictLogging {
         val graphQLProperty =
           graphQLRelationOption.map(Relations.RELATION_PROPERTY_NAME -> _.toAnnotation.data)
         val includeProperty =
-          relationOption.map(Relations.INCLUDES_PROPERTY_NAME -> _.toAnnotation.data)
+          relationOption.map(Relations.includedPropertyName -> _.toAnnotation.data)
         newField.setProperties(
           List(graphQLProperty, includeProperty).flatten.toMap[String, AnyRef].asJava)
         graphQLRelationOption.map(_.description).foreach(newField.setDoc)

--- a/naptime/src/main/scala/org/coursera/naptime/Types.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/Types.scala
@@ -29,7 +29,6 @@ import com.linkedin.data.schema.StringDataSchema
 import com.linkedin.data.schema.TyperefDataSchema
 import com.linkedin.data.schema.UnionDataSchema
 import com.typesafe.scalalogging.StrictLogging
-import org.coursera.naptime.schema.LinkedRelationAnnotation
 import org.coursera.naptime.schema.RelationType.FINDER
 import org.coursera.naptime.schema.RelationType.GET
 import org.coursera.naptime.schema.RelationType.MULTI_GET
@@ -41,7 +40,7 @@ object Types extends StrictLogging {
 
   object Relations {
     val RELATION_PROPERTY_NAME = "relatedOn"
-    val INCLUDES_PROPERTY_NAME = "includes"
+    val INCLUDES_PROPERTY_NAME = "included"
   }
 
   @deprecated("Please use the one with fields included", "0.2.4")

--- a/naptime/src/main/scala/org/coursera/naptime/models.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/models.scala
@@ -22,7 +22,7 @@ import org.coursera.naptime.schema.AuthOverride
 import org.coursera.naptime.schema.RelationType
 import org.coursera.naptime.schema.Resource
 import org.coursera.naptime.schema.GraphQLRelationAnnotation
-import org.coursera.naptime.schema.LinkedRelationAnnotation
+import org.coursera.naptime.schema.IncludedRelationAnnotation
 import play.api.http.Status
 import play.api.i18n.Lang
 import play.api.libs.json.JsObject
@@ -443,7 +443,7 @@ case class ResourceName(
     val suffix = if (resourcePath.isEmpty) "" else resourcePath.mkString("/", "/", "")
     s"$topLevelName.v$version$suffix"
   }
-  def toAnnotation: LinkedRelationAnnotation = LinkedRelationAnnotation(identifier)
+  def toAnnotation: IncludedRelationAnnotation = IncludedRelationAnnotation(identifier)
 }
 
 object ResourceName {

--- a/naptime/src/main/scala/org/coursera/naptime/models.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/models.scala
@@ -22,6 +22,7 @@ import org.coursera.naptime.schema.AuthOverride
 import org.coursera.naptime.schema.RelationType
 import org.coursera.naptime.schema.Resource
 import org.coursera.naptime.schema.GraphQLRelationAnnotation
+import org.coursera.naptime.schema.LinkedRelationAnnotation
 import play.api.http.Status
 import play.api.i18n.Lang
 import play.api.libs.json.JsObject
@@ -442,6 +443,7 @@ case class ResourceName(
     val suffix = if (resourcePath.isEmpty) "" else resourcePath.mkString("/", "/", "")
     s"$topLevelName.v$version$suffix"
   }
+  def toAnnotation: LinkedRelationAnnotation = LinkedRelationAnnotation(identifier)
 }
 
 object ResourceName {

--- a/naptime/src/test/pegasus/org/coursera/naptime/Empty.courier
+++ b/naptime/src/test/pegasus/org/coursera/naptime/Empty.courier
@@ -1,0 +1,3 @@
+namespace org.coursera.naptime
+
+record Empty {}

--- a/naptime/src/test/scala/org/coursera/naptime/TypesTest.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/TypesTest.scala
@@ -126,9 +126,9 @@ class TypesTest extends AssertionsForJUnit {
       ResourceFields(Set.empty, FieldsFunction.default, includeRelations, graphQLRelations)(null))
 
     val fieldsExpectedNames = List("id", "includeOnly", "shared", "graphQLOnly")
-    val includeOnlyExpectedProperties = Map("includes" -> includeOnlyResourceName.toAnnotation.data)
+    val includeOnlyExpectedProperties = Map("included" -> includeOnlyResourceName.toAnnotation.data)
     val sharedExpectedProperties = Map(
-      "includes" -> includeSharedResourceName.toAnnotation.data,
+      "included" -> includeSharedResourceName.toAnnotation.data,
       "relatedOn" -> graphQLShared.toAnnotation.data
     )
     val graphQLOnlyExpectedProperties = Map("relatedOn" -> graphQLOnly.toAnnotation.data)

--- a/naptime/src/test/scala/org/coursera/naptime/TypesTest.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/TypesTest.scala
@@ -16,18 +16,20 @@
 
 package org.coursera.naptime
 
-import com.linkedin.data.schema.ArrayDataSchema
-import com.linkedin.data.schema.IntegerDataSchema
-import com.linkedin.data.schema.StringDataSchema
+import com.linkedin.data.schema.{ArrayDataSchema, IntegerDataSchema, StringDataSchema}
 import org.coursera.naptime.actions.Course
 import org.coursera.naptime.actions.EnrollmentId
 import org.coursera.naptime.actions.SessionId
+import org.coursera.naptime.courier.CourierFormats
 import org.junit.Test
 import org.scalatest.junit.AssertionsForJUnit
+import play.api.libs.json.OFormat
 
 import scala.collection.JavaConverters._
 
 class TypesTest extends AssertionsForJUnit {
+
+  implicit val emptyFormat: OFormat[Empty] = CourierFormats.recordTemplateFormats[Empty]
 
   @Test
   def primitiveSchema(): Unit = {
@@ -102,28 +104,28 @@ class TypesTest extends AssertionsForJUnit {
     val includeRelations =
       Map("includeOnly" -> includeOnlyResourceName, "shared" -> includeSharedResourceName)
     val graphQLOnlyResourceName = ResourceName("graphQLOnly", 1)
-    val graphQLOnly =
-      FinderGraphQLRelation(
-        graphQLOnlyResourceName,
-        "find",
-        Map("foo" -> "bar"),
-        "greetings from graphql")
+    val graphQLOnly = FinderGraphQLRelation(
+      graphQLOnlyResourceName,
+      "find",
+      Map("foo" -> "bar"),
+      "greetings from graphql")
     val graphQLSharedResourceName = ResourceName("shared", 2)
-    val graphQLShared =
-      GetGraphQLRelation(
-        graphQLSharedResourceName,
-        "get",
-        Map("foo" -> "bar"),
-        "greetings from graphql")
+    val graphQLShared = GetGraphQLRelation(
+      graphQLSharedResourceName,
+      "get",
+      Map("foo" -> "bar"),
+      "greetings from graphql")
     val graphQLRelations = Map(
       "graphQLOnly" -> graphQLOnly,
       "shared" -> graphQLShared
     )
+    val resourceFields =
+      ResourceFields(Set.empty, FieldsFunction.default, includeRelations, graphQLRelations)
     val resultingType = Types.computeAsymType(
       "org.coursera.naptime.Relations.Model",
       Empty.SCHEMA,
       Empty.SCHEMA,
-      ResourceFields(Set.empty, FieldsFunction.default, includeRelations, graphQLRelations)(null))
+      resourceFields)
 
     val fieldsExpectedNames = List("id", "includeOnly", "shared", "graphQLOnly")
     val includeOnlyExpectedProperties = Map("included" -> includeOnlyResourceName.toAnnotation.data)

--- a/naptime/src/test/scala/org/coursera/naptime/TypesTest.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/TypesTest.scala
@@ -16,6 +16,7 @@
 
 package org.coursera.naptime
 
+import com.linkedin.data.schema.ArrayDataSchema
 import com.linkedin.data.schema.IntegerDataSchema
 import com.linkedin.data.schema.StringDataSchema
 import org.coursera.naptime.actions.Course
@@ -23,6 +24,8 @@ import org.coursera.naptime.actions.EnrollmentId
 import org.coursera.naptime.actions.SessionId
 import org.junit.Test
 import org.scalatest.junit.AssertionsForJUnit
+
+import scala.collection.JavaConverters._
 
 class TypesTest extends AssertionsForJUnit {
 
@@ -90,5 +93,62 @@ class TypesTest extends AssertionsForJUnit {
     assert(resultingType.getField("name").getRecord == Course.SCHEMA)
     assert(resultingType.getField("description") != null)
     assert(resultingType.getField("description").getRecord == Course.SCHEMA)
+  }
+
+  @Test
+  def relations(): Unit = {
+    val includeOnlyResourceName = ResourceName("includeOnly", 1)
+    val includeSharedResourceName = ResourceName("shared", 2)
+    val includeRelations =
+      Map("includeOnly" -> includeOnlyResourceName, "shared" -> includeSharedResourceName)
+    val graphQLOnlyResourceName = ResourceName("graphQLOnly", 1)
+    val graphQLOnly =
+      FinderGraphQLRelation(
+        graphQLOnlyResourceName,
+        "find",
+        Map("foo" -> "bar"),
+        "greetings from graphql")
+    val graphQLSharedResourceName = ResourceName("shared", 2)
+    val graphQLShared =
+      GetGraphQLRelation(
+        graphQLSharedResourceName,
+        "get",
+        Map("foo" -> "bar"),
+        "greetings from graphql")
+    val graphQLRelations = Map(
+      "graphQLOnly" -> graphQLOnly,
+      "shared" -> graphQLShared
+    )
+    val resultingType = Types.computeAsymType(
+      "org.coursera.naptime.Relations.Model",
+      Empty.SCHEMA,
+      Empty.SCHEMA,
+      ResourceFields(Set.empty, FieldsFunction.default, includeRelations, graphQLRelations)(null))
+
+    val fieldsExpectedNames = List("id", "includeOnly", "shared", "graphQLOnly")
+    val includeOnlyExpectedProperties = Map("includes" -> includeOnlyResourceName.toAnnotation.data)
+    val sharedExpectedProperties = Map(
+      "includes" -> includeSharedResourceName.toAnnotation.data,
+      "relatedOn" -> graphQLShared.toAnnotation.data
+    )
+    val graphQLOnlyExpectedProperties = Map("relatedOn" -> graphQLOnly.toAnnotation.data)
+
+    assert(!resultingType.isErrorRecord)
+    assert(resultingType.getFields.asScala.map(_.getName) === fieldsExpectedNames)
+    val includeOnlyField = resultingType.getField("includeOnly")
+    assert(includeOnlyField != null)
+    assert(!includeOnlyField.getOptional)
+    assert(includeOnlyField.getType == new ArrayDataSchema(new StringDataSchema))
+    assert(includeOnlyField.getProperties.asScala === includeOnlyExpectedProperties)
+    val sharedField = resultingType.getField("shared")
+    assert(sharedField != null)
+    assert(sharedField.getOptional)
+    assert(sharedField.getType == new StringDataSchema)
+    assert(sharedField.getProperties.asScala === sharedExpectedProperties)
+    val graphQLOnlyField = resultingType.getField("graphQLOnly")
+    assert(graphQLOnlyField != null)
+    assert(!graphQLOnlyField.getOptional)
+    assert(graphQLOnlyField.getType == new ArrayDataSchema(new StringDataSchema))
+    assert(graphQLOnlyField.getProperties.asScala === graphQLOnlyExpectedProperties)
   }
 }

--- a/naptime/src/test/scala/org/coursera/naptime/TypesTest.scala
+++ b/naptime/src/test/scala/org/coursera/naptime/TypesTest.scala
@@ -16,7 +16,12 @@
 
 package org.coursera.naptime
 
-import com.linkedin.data.schema.{ArrayDataSchema, IntegerDataSchema, StringDataSchema}
+import com.linkedin.data.schema.{
+  ArrayDataSchema,
+  IntegerDataSchema,
+  NullDataSchema,
+  StringDataSchema
+}
 import org.coursera.naptime.actions.Course
 import org.coursera.naptime.actions.EnrollmentId
 import org.coursera.naptime.actions.SessionId
@@ -116,24 +121,24 @@ class TypesTest extends AssertionsForJUnit {
     val includeOnlyExpectedProperties = Map(
       "included" -> ResourceName("includeOnly", 1).toAnnotation.data)
     assert(includeOnlyField != null)
-    assert(!includeOnlyField.getOptional)
-    assert(includeOnlyField.getType == new ArrayDataSchema(new StringDataSchema))
+    assert(includeOnlyField.getOptional)
+    assert(includeOnlyField.getType == new NullDataSchema())
     assert(includeOnlyField.getProperties.asScala === includeOnlyExpectedProperties)
-    val sharedField = resultingType.getField("shared")
+    val sharedScalarField = resultingType.getField("shared")
     val sharedExpectedProperties = Map(
       "included" -> ResourceName("shared", 2).toAnnotation.data,
       "relatedOn" -> GetGraphQLRelation(ResourceName("shared", 2), "get").toAnnotation.data
     )
-    assert(sharedField != null)
-    assert(sharedField.getOptional)
-    assert(sharedField.getType == new StringDataSchema)
-    assert(sharedField.getProperties.asScala === sharedExpectedProperties)
-    val gqlOnlyField = resultingType.getField("gqlOnly")
+    assert(sharedScalarField != null)
+    assert(sharedScalarField.getOptional)
+    assert(sharedScalarField.getType == new StringDataSchema)
+    assert(sharedScalarField.getProperties.asScala === sharedExpectedProperties)
+    val graphQLOnlyArrayField = resultingType.getField("gqlOnly")
     val gqlOnlyExpectedProperties = Map(
       "relatedOn" -> FinderGraphQLRelation(ResourceName("gqlOnly", 1), "find").toAnnotation.data)
-    assert(gqlOnlyField != null)
-    assert(!gqlOnlyField.getOptional)
-    assert(gqlOnlyField.getType == new ArrayDataSchema(new StringDataSchema))
-    assert(gqlOnlyField.getProperties.asScala === gqlOnlyExpectedProperties)
+    assert(graphQLOnlyArrayField != null)
+    assert(!graphQLOnlyArrayField.getOptional)
+    assert(graphQLOnlyArrayField.getType == new ArrayDataSchema(new StringDataSchema))
+    assert(graphQLOnlyArrayField.getProperties.asScala === gqlOnlyExpectedProperties)
   }
 }


### PR DESCRIPTION
This PR adds Naptime include relations to the dataSchema, similar to how we stuff the GraphQL relations in as pseudo-fields. In particular, we add a new field property `"included"` with is an object with a `"resourceName"` property. When we have both a GraphQL and Naptime relation, both the `"relatedOn"` and `"included"` properties are present, otherwise only the relation that applies for that pseudo-field is present. Consider the resource with fields:

```
ResourceFields
  .withRelated(
    "legacyRelation" -> ResourceName("first", 1),
    "modernRelation" -> ResourceName("second", 2))
  .withGraphQLRelations(
    "modernRelation" -> GetGraphQLRelation(ResourceName("second", 2), "relatedId"))
```

It produces a fields array on the model for this resource like this:

```
{
  "fields": [
    {
      "name": "legacyRelation",
      "included": {
        "resourceName": "first.v1"
      },
      "optional": false,
      "type": {
        "type": "array",
        "items": "string"
      }
    },
    {
      "name": "modernRelation",
      "included": {
        "resourceName": "second.v2"
      },
      "relatedOn": {
        "resourceName": "second.v2",
        "id": "relatedId"
      },
      "optional": true,
      "type": "string"
    }
  ]
}
```