### PR TITLE
omit invalid naptime resource schemas in graphql schema builder

### DIFF
--- a/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/SangriaGraphQlSchemaBuilder.scala
+++ b/naptime-graphql/src/main/scala/org/coursera/naptime/ari/graphql/SangriaGraphQlSchemaBuilder.scala
@@ -30,6 +30,8 @@ import sangria.schema.Value
 import sangria.schema.Field
 import sangria.schema.ObjectType
 
+import scala.util.Try
+
 class SangriaGraphQlSchemaBuilder(resources: Set[Resource], schemas: Map[String, RecordDataSchema])
     extends StrictLogging {
 
@@ -62,10 +64,11 @@ class SangriaGraphQlSchemaBuilder(resources: Set[Resource], schemas: Map[String,
       lookupTypeAndErrors.copy(data = fields)
     }
 
-    val topLevelResourceObjects = topLevelResourceObjectsAndErrors.flatMap(_.data)
+    val topLevelResourceObjects = topLevelResourceObjectsAndErrors.filter(_.errors.errors.isEmpty).flatMap(_.data)
     val schemaErrors = topLevelResourceObjectsAndErrors.foldLeft(SchemaErrors.empty)(_ ++ _.errors)
 
     val dedupedResources = topLevelResourceObjects.groupBy(_.name).map(_._2.head).toList
+
     val rootObject = ObjectType[SangriaGraphQlContext, DataMap](
       name = "root",
       description = "Top-level accessor for Naptime resources",

--- a/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/SangriaGraphQlSchemaBuilderTest.scala
+++ b/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/SangriaGraphQlSchemaBuilderTest.scala
@@ -25,7 +25,7 @@ import org.scalatest.mockito.MockitoSugar
 
 class SangriaGraphQlSchemaBuilderTest extends AssertionsForJUnit {
   @Test
-  def badResourceSchema_omitFromGraphqlSchema(): Unit = {
+  def badResourceSchemaOmitFromGraphqlSchema(): Unit = {
     val schemaTypes = Map(
       "org.coursera.naptime.ari.graphql.models.MergedCourse" -> MergedCourse.SCHEMA,
       "org.coursera.naptime.ari.graphql.models.FakeModel" -> RecordWithUnionTypes.SCHEMA,

--- a/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/SangriaGraphQlSchemaBuilderTest.scala
+++ b/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/SangriaGraphQlSchemaBuilderTest.scala
@@ -25,7 +25,7 @@ import org.scalatest.mockito.MockitoSugar
 
 class SangriaGraphQlSchemaBuilderTest extends AssertionsForJUnit {
   @Test
-  def checkEmptySchema(): Unit = {
+  def badResourceSchema_omitFromGraphqlSchema(): Unit = {
     val schemaTypes = Map(
       "org.coursera.naptime.ari.graphql.models.MergedCourse" -> MergedCourse.SCHEMA,
       "org.coursera.naptime.ari.graphql.models.FakeModel" -> RecordWithUnionTypes.SCHEMA,

--- a/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/SangriaGraphQlSchemaBuilderTest.scala
+++ b/naptime-graphql/src/test/scala/org/coursera/naptime/ari/graphql/SangriaGraphQlSchemaBuilderTest.scala
@@ -1,0 +1,56 @@
+package org.coursera.naptime.ari.graphql
+
+import com.google.inject.Injector
+import com.linkedin.data.schema.RecordDataSchema
+import org.coursera.naptime.ResourceName
+import org.coursera.naptime.ari.FullSchema
+import org.coursera.naptime.ari.LocalSchemaProvider
+import org.coursera.naptime.ari.SchemaProvider
+import org.coursera.naptime.ari.graphql.models.MergedCourse
+import org.coursera.naptime.ari.graphql.models.MergedInstructor
+import org.coursera.naptime.ari.graphql.models.MergedPartner
+import org.coursera.naptime.ari.graphql.models.RecordWithUnionTypes
+import org.coursera.naptime.model.Keyed
+import org.coursera.naptime.router2.NaptimeRoutes
+import org.coursera.naptime.router2.ResourceRouterBuilder
+import org.coursera.naptime.schema.Handler
+import org.coursera.naptime.schema.HandlerKind
+import org.coursera.naptime.schema.Parameter
+import org.coursera.naptime.schema.Resource
+import org.coursera.naptime.schema.ResourceKind
+import org.junit.Test
+import org.mockito.Mockito._
+import org.scalatest.junit.AssertionsForJUnit
+import org.scalatest.mockito.MockitoSugar
+
+class SangriaGraphQlSchemaBuilderTest extends AssertionsForJUnit {
+  @Test
+  def checkEmptySchema(): Unit = {
+    val schemaTypes = Map(
+      "org.coursera.naptime.ari.graphql.models.MergedCourse" -> MergedCourse.SCHEMA,
+      "org.coursera.naptime.ari.graphql.models.FakeModel" -> RecordWithUnionTypes.SCHEMA,
+      "org.coursera.naptime.ari.graphql.models.MergedPartner" -> MergedPartner.SCHEMA,
+      "org.coursera.naptime.ari.graphql.models.MergedInstructor" -> MergedInstructor.SCHEMA
+    )
+    val resourcesWithInvalidResource =
+      Set(
+        Models.courseResource.copy(version = Some(-1)),
+        Models.instructorResource,
+        Models.partnersResource,
+        Models.fakeModelResource
+      )
+    val builder = new SangriaGraphQlSchemaBuilder(resourcesWithInvalidResource, schemaTypes)
+    val schema = builder.generateSchema().data
+
+    val allResources2 =
+      Set(
+        Models.instructorResource,
+        Models.partnersResource,
+        Models.fakeModelResource
+      )
+    val builder2 = new SangriaGraphQlSchemaBuilder(allResources2, schemaTypes)
+    val schema2 = builder2.generateSchema().data
+
+    assertResult(schema2.renderPretty)(schema.renderPretty)
+  }
+}

--- a/naptime/src/main/scala/org/coursera/naptime/router2/NaptimePlayRouter.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/router2/NaptimePlayRouter.scala
@@ -35,7 +35,7 @@ import scala.annotation.tailrec
 import scala.collection.immutable
 
 @Singleton
-private[naptime] case class NaptimeRoutes @Inject()(
+case class NaptimeRoutes @Inject()(
     injector: Injector,
     routerBuilders: immutable.Set[ResourceRouterBuilder]) {
 

--- a/naptime/src/main/scala/org/coursera/naptime/router2/NaptimePlayRouter.scala
+++ b/naptime/src/main/scala/org/coursera/naptime/router2/NaptimePlayRouter.scala
@@ -35,7 +35,7 @@ import scala.annotation.tailrec
 import scala.collection.immutable
 
 @Singleton
-case class NaptimeRoutes @Inject()(
+private[naptime] case class NaptimeRoutes @Inject()(
     injector: Injector,
     routerBuilders: immutable.Set[ResourceRouterBuilder]) {
 


### PR DESCRIPTION
This PR changes `SangriaGraphQlSchemaBuilder` so that it is able to compose a schema for multiple resources, even if one or more of them do not pass validation, by excluding resources with invalid schemas before composing.