### PR TITLE
bump version to 0.11.7

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.11.6"
+version in ThisBuild := "0.11.7"


### PR DESCRIPTION
Release 0.11.6 was accidentally compiled with Java 17 instead Java 8. Bumping version to create a new release with the right Java version.